### PR TITLE
Decouple project from MI6 dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ Dossiers can be created for any automation workflow. Here are common categories:
 
 The dossier standard is designed to be implementation-agnostic. Projects can adopt dossiers in various ways:
 
-- **[MI6](https://github.com/imboard-ai/mi6)** - AI-native project automation framework (reference implementation)
+- **[Sample Implementation](./examples/sample-implementation/)** - Example showing how to organize and document your dossiers
+- **[MI6](https://github.com/imboard-ai/mi6)** - An AI-native project automation framework (early adopter)
 - **Your project** - Create your own dossier collection for your specific workflows
 
 Want to create an implementation? See [SPECIFICATION.md](./SPECIFICATION.md) for the formal standard.
@@ -342,6 +343,65 @@ Share useful dossiers! Contribute to dossier implementations or create your own 
 
 ---
 
+## Organizing Multiple Dossiers
+
+As your dossier collection grows, organization becomes important. A **dossier registry** helps document relationships, workflows, and navigation paths.
+
+### Why Use a Registry?
+
+When you have multiple dossiers, a registry provides:
+- **Quick reference** - Summary table of all dossiers
+- **Journey mapping** - Common workflow paths (e.g., greenfield vs brownfield)
+- **Relationship documentation** - Which dossiers depend on or complement each other
+- **Navigation guidance** - Help users find the right dossier for their needs
+- **Output tracking** - What each dossier produces and what consumes it
+
+### Registry Pattern
+
+A dossier registry typically includes:
+
+1. **Quick Reference Table**
+   - List all dossiers with version, purpose, and coupling level
+   - Helps users scan available automation
+
+2. **Journey Maps**
+   - Group dossiers into common workflows
+   - Show sequential paths (e.g., "New Project: init → setup → deploy")
+   - Visualize with mermaid diagrams
+
+3. **Relationship Matrix**
+   - Document dependencies between dossiers
+   - Identify sequential, suggested, or conflicting relationships
+   - Note coupling levels (loose, medium, tight)
+
+4. **Output Matrix**
+   - Track what files/artifacts each dossier creates
+   - Document which other dossiers consume those outputs
+   - Helps understand data flow
+
+5. **Navigation Guide**
+   - User-centric paths ("I want to..." → recommended dossiers)
+   - Makes discovery easier for both humans and LLMs
+
+### Example Registry
+
+See **[examples/sample-implementation/dossiers-registry.md](./examples/sample-implementation/dossiers-registry.md)** for a complete example showing:
+- Categorization (Setup, Development, Maintenance)
+- Journey mapping (Greenfield vs Brownfield paths)
+- Relationship and output matrices
+- Coupling level classification
+- User-centric navigation
+
+### When to Create a Registry
+
+- **3+ dossiers**: Consider a simple list
+- **5+ dossiers**: Add categorization and basic relationships
+- **10+ dossiers**: Full registry with journeys and matrices
+
+A well-organized registry makes your dossier collection more discoverable and helps LLMs understand how to chain multiple dossiers together intelligently.
+
+---
+
 ## Best Practices
 
 ### ✅ Do:
@@ -476,7 +536,8 @@ If you don't have an LLM agent:
 - [PROTOCOL.md](./PROTOCOL.md) - Dossier execution protocol
 - [SPECIFICATION.md](./SPECIFICATION.md) - Formal dossier specification
 - [examples/](./examples/) - Example dossier implementations
-- [MI6](https://github.com/imboard-ai/mi6) - Reference implementation
+- [Sample Implementation](./examples/sample-implementation/) - Example of organizing dossiers
+- [MI6](https://github.com/imboard-ai/mi6) - Community implementation example
 
 ---
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -538,7 +538,7 @@ See [examples/devops/deploy-to-aws.md](./examples/devops/deploy-to-aws.md) for a
 Implementations **MAY** add custom sections prefixed with `X-`:
 
 ```markdown
-## X-MI6-Specific-Feature
+## X-MyProject-Custom-Section
 
 [Implementation-specific content]
 ```

--- a/examples/sample-implementation/dossiers-registry.md
+++ b/examples/sample-implementation/dossiers-registry.md
@@ -1,8 +1,8 @@
-# MI6 Dossier Registry
+# Sample Dossier Registry
 
-> **Note**: This is an example implementation from the [MI6 project](https://github.com/imboard-ai/mi6), showing how a specific dossier implementation organizes and documents its dossiers. Your implementation may use a different structure.
+> **Note**: This is an example of how a dossier implementation might organize and document its dossiers. This shows organizational patterns, relationship mapping, and navigation structures. Your implementation may use a different structure based on your needs.
 
-Complete catalog of all MI6 dossiers with relationships, outputs, and navigation maps.
+Complete catalog of all project dossiers with relationships, outputs, and navigation maps.
 
 ---
 
@@ -11,14 +11,14 @@ Complete catalog of all MI6 dossiers with relationships, outputs, and navigation
 | Dossier | Version | Purpose | Journey | Coupling |
 |---------|---------|---------|---------|----------|
 | [greenfield-start](./greenfield-start.md) | 1.0.0 | Start new project from zero | Greenfield | Loose |
-| [project-init](./project-init.md) | 1.0.0 | Initialize MI6 structure | Both | Medium |
-| [brownfield-adoption](./brownfield-adoption.md) | 1.0.0 | Add MI6 to existing project | Brownfield | Medium |
+| [project-init](./project-init.md) | 1.0.0 | Initialize project structure | Both | Medium |
+| [brownfield-adoption](./brownfield-adoption.md) | 1.0.0 | Add dossiers to existing project | Brownfield | Medium |
 | [dependency-install](./dependency-install.md) | 1.0.0 | Install all dependencies | Both | Loose |
 | [first-dev-session](./first-dev-session.md) | 1.0.0 | First productive session | Both | Loose |
 | [worktree-multi-repo](./worktree-multi-repo.md) | 1.0.0 | Create multi-repo worktrees | Feature | Medium |
 | [worktree-cleanup](./worktree-cleanup.md) | 1.0.0 | Remove worktrees | Feature | Medium |
 | [task-create](./task-create.md) | 1.0.0 | Generate task documents | Feature | Loose |
-| [project-uninstall](./project-uninstall.md) | 1.0.0 | Remove MI6 safely | Maintenance | Medium |
+| [project-uninstall](./project-uninstall.md) | 1.0.0 | Remove dossier system safely | Maintenance | Medium |
 
 ---
 
@@ -30,7 +30,7 @@ Complete catalog of all MI6 dossiers with relationships, outputs, and navigation
 
 ```mermaid
 graph LR
-    A[greenfield-start<br/>Create directory] --> B[project-init<br/>MI6 setup]
+    A[greenfield-start<br/>Create directory] --> B[project-init<br/>Project setup]
     B --> C[dependency-install<br/>Install deps]
     C --> D[first-dev-session<br/>Start coding]
 
@@ -42,7 +42,7 @@ graph LR
 
 **Steps**:
 1. **greenfield-start**: Create project directory, init git
-2. **project-init**: Add MI6 templates, customize for project
+2. **project-init**: Add dossier templates, customize for project
 3. **dependency-install**: Install npm/pip/cargo dependencies
 4. **first-dev-session**: Create first task, start developing
 
@@ -52,7 +52,7 @@ graph LR
 
 ### Brownfield Journey (Existing Projects)
 
-**Path**: Existing → MI6-Enhanced in 2-3 steps
+**Path**: Existing → Dossier-Enhanced in 2-3 steps
 
 ```mermaid
 graph LR
@@ -66,7 +66,7 @@ graph LR
 
 **Steps**:
 1. **brownfield-adoption**: Backup, plan integration, merge strategy
-2. **project-init**: Add MI6 files (merge with existing)
+2. **project-init**: Add dossier files (merge with existing)
 3. **dependency-install**: Optional if deps already installed
 
 **Time to enhanced**: < 20 minutes
@@ -131,7 +131,7 @@ graph LR
 | dependency-install | node_modules/, lock files | first-dev-session |
 | worktree-multi-repo | .worktrees/[feature]/ | worktree-cleanup |
 | task-create | Task .md file | task manager scripts |
-| project-uninstall | Removed MI6 files, archives | N/A (terminal) |
+| project-uninstall | Removed dossier files, archives | N/A (terminal) |
 
 ###Configuration Flow
 
@@ -151,11 +151,11 @@ graph TD
 
 ### Setup & Initialization
 - **greenfield-start** - Brand new projects
-- **project-init** - Core MI6 setup
+- **project-init** - Core dossier setup
 - **brownfield-adoption** - Existing projects
 - **dependency-install** - Package installation
 
-**Purpose**: Get projects MI6-ready
+**Purpose**: Get projects dossier-ready
 
 ### Development Workflows
 - **first-dev-session** - Onboarding walkthrough
@@ -166,7 +166,7 @@ graph TD
 **Purpose**: Day-to-day development operations
 
 ### Maintenance & Utilities
-- **project-uninstall** - Remove MI6
+- **project-uninstall** - Remove dossier system
 
 **Purpose**: Lifecycle management
 
@@ -194,7 +194,7 @@ graph TD
 ### Tight Coupling (Interdependent)
 - None currently
 
-**Note**: MI6 deliberately avoids tight coupling for flexibility
+**Note**: This implementation deliberately avoids tight coupling for flexibility
 
 ---
 
@@ -206,7 +206,7 @@ graph TD
 
 ### Terminal Nodes (Nothing follows)
 - first-dev-session (user continues development)
-- project-uninstall (MI6 removed)
+- project-uninstall (dossier system removed)
 - worktree-cleanup (worktree removed)
 
 ### Middleware (Part of chains)
@@ -229,7 +229,7 @@ graph TD
 ### I want to create a task
 **Path**: task-create → task:start (script)
 
-### MI6 didn't work for me
+### The dossier system didn't work for me
 **Path**: project-uninstall
 
 ---
@@ -238,9 +238,9 @@ graph TD
 
 - [Dossiers README](./README.md) - How to use dossiers
 - [Protocol](./PROTOCOL.md) - Execution guidelines
-- [Main README](../README.md) - MI6 overview
+- [Main README](../README.md) - Project overview
 
 ---
 
-**🕵️ MI6 Dossier Registry v1.0**
-*Complete catalog of intelligent automation workflows*
+**📋 Sample Dossier Registry v1.0**
+*Example of organizing and documenting dossier workflows*


### PR DESCRIPTION
This commit completes the decoupling of the dossier project from MI6, making it a truly universal and implementation-agnostic standard.

Changes:
- Renamed examples/mi6/ → examples/sample-implementation/
- Rewrote dossiers-registry.md to be generic and implementation-agnostic
- Updated SPECIFICATION.md: X-MI6-Specific → X-MyProject-Custom example
- Updated README.md: Reframed MI6 as one community implementation (not coupled)
- Added new "Organizing Multiple Dossiers" section documenting registry pattern

The project now stands as an independent standard with MI6 acknowledged as an early adopter rather than the source project. The sample implementation provides valuable organizational patterns while remaining generic.