### PR TITLE
feat: Add checksum command to CLI (v0.2.7)

### DIFF
--- a/cli/bin/dossier
+++ b/cli/bin/dossier
@@ -1187,17 +1187,134 @@ program
   });
 
 // ============================================================================
-// COMMAND: checksum (TBD)
+// COMMAND: checksum (IMPLEMENTED)
 // ============================================================================
 program
   .command('checksum')
-  .description('Calculate and update dossier checksum [TBD]')
+  .description('Calculate, verify, or update dossier checksum')
   .argument('<file>', 'Dossier file')
-  .option('--update', 'Update checksum in file')
-  .option('--verify', 'Just verify, don\'t update')
+  .option('--update', 'Update checksum in frontmatter')
+  .option('--verify', 'Verify existing checksum (exit 0 if valid, 1 if invalid)')
+  .option('--quiet', 'Only output the hash (for scripting)')
   .action((file, options) => {
-    console.log('⚠️  checksum tbd - follow docs/planning/cli-evolution.md');
-    process.exit(1);
+    const fs = require('fs');
+    const path = require('path');
+    const crypto = require('crypto');
+
+    // Resolve file path
+    const dossierFile = path.resolve(file);
+
+    if (!fs.existsSync(dossierFile)) {
+      console.log(`❌ File not found: ${dossierFile}`);
+      process.exit(1);
+    }
+
+    // Read and parse dossier
+    const content = fs.readFileSync(dossierFile, 'utf8');
+
+    // Parse frontmatter
+    const jsonMatch = content.match(/^---dossier\s*\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+    if (!jsonMatch) {
+      console.log('❌ Invalid dossier format: missing ---dossier frontmatter');
+      process.exit(1);
+    }
+
+    let frontmatter;
+    try {
+      frontmatter = JSON.parse(jsonMatch[1]);
+    } catch (err) {
+      console.log(`❌ Invalid JSON in frontmatter: ${err.message}`);
+      process.exit(1);
+    }
+
+    const body = jsonMatch[2];
+
+    // Calculate checksum of body only
+    const calculatedHash = crypto.createHash('sha256').update(body, 'utf8').digest('hex');
+
+    // Get existing checksum if present
+    const existingHash = frontmatter.checksum?.hash;
+
+    // Quiet mode - just output the hash
+    if (options.quiet && !options.verify && !options.update) {
+      console.log(calculatedHash);
+      process.exit(0);
+    }
+
+    // Verify mode
+    if (options.verify) {
+      if (!existingHash) {
+        if (!options.quiet) {
+          console.log('❌ No checksum found in frontmatter');
+        }
+        process.exit(1);
+      }
+
+      if (existingHash === calculatedHash) {
+        if (!options.quiet) {
+          console.log('✅ Checksum valid');
+          console.log(`   SHA256: ${calculatedHash}`);
+        }
+        process.exit(0);
+      } else {
+        if (!options.quiet) {
+          console.log('❌ Checksum mismatch - content has been modified');
+          console.log(`   Expected: ${existingHash}`);
+          console.log(`   Actual:   ${calculatedHash}`);
+        }
+        process.exit(1);
+      }
+    }
+
+    // Update mode
+    if (options.update) {
+      // Update frontmatter
+      frontmatter.checksum = {
+        algorithm: 'sha256',
+        hash: calculatedHash
+      };
+
+      // Write back
+      const updatedContent = `---dossier\n${JSON.stringify(frontmatter, null, 2)}\n---\n${body}`;
+      fs.writeFileSync(dossierFile, updatedContent, 'utf8');
+
+      if (!options.quiet) {
+        if (existingHash === calculatedHash) {
+          console.log('✅ Checksum unchanged');
+        } else if (existingHash) {
+          console.log('✅ Checksum updated');
+          console.log(`   Old: ${existingHash}`);
+          console.log(`   New: ${calculatedHash}`);
+        } else {
+          console.log('✅ Checksum added');
+        }
+        console.log(`   SHA256: ${calculatedHash}`);
+      } else {
+        console.log(calculatedHash);
+      }
+      process.exit(0);
+    }
+
+    // Default: just show the checksum
+    console.log(`\n📊 Dossier Checksum\n`);
+    console.log(`   File: ${path.basename(dossierFile)}`);
+    console.log(`   SHA256: ${calculatedHash}`);
+
+    if (existingHash) {
+      if (existingHash === calculatedHash) {
+        console.log(`\n   ✅ Matches frontmatter checksum`);
+      } else {
+        console.log(`\n   ⚠️  Does NOT match frontmatter checksum`);
+        console.log(`   Frontmatter: ${existingHash}`);
+        console.log(`\n   Run 'dossier checksum ${file} --update' to fix`);
+      }
+    } else {
+      console.log(`\n   ⚠️  No checksum in frontmatter`);
+      console.log(`\n   Run 'dossier checksum ${file} --update' to add`);
+    }
+
+    console.log('');
+    process.exit(0);
   });
 
 // ============================================================================

--- a/docs/planning/cli-evolution.md
+++ b/docs/planning/cli-evolution.md
@@ -4,16 +4,16 @@ Planning document for redesigning the Dossier CLI from single-purpose `dossier-v
 
 ## Status Overview
 
-**Current Version**: v0.2.6
+**Current Version**: v0.2.7
 **Released**: 2025-11-28
-**Status**: ✅ Phase 1 Complete + Phase 2 In Progress - Sign Command Added
+**Status**: ✅ Phase 1 Complete + Phase 2 In Progress - Checksum Command Added
 
 ### Implementation Progress
 
 | Phase | Status | Completion |
 |-------|--------|------------|
 | Phase 1: MVP | ✅ Complete | 100% |
-| Phase 2: Enhanced Authoring | 🚧 In Progress | 40% |
+| Phase 2: Enhanced Authoring | 🚧 In Progress | 50% |
 | Phase 3: Advanced Features | 📋 Planned | 0% |
 
 ### Command Status
@@ -26,8 +26,8 @@ Planning document for redesigning the Dossier CLI from single-purpose `dossier-v
 | `create` | ✅ Done | v0.2.4 | P1 |
 | `list` | ✅ Done | v0.2.5 | P1 |
 | `sign` | ✅ Done | v0.2.6 | P2 |
+| `checksum` | ✅ Done | v0.2.7 | P2 |
 | `publish` | 📋 Planned | - | P2 |
-| `checksum` | 📋 Planned | - | P2 |
 | `validate` | 📋 Planned | - | P2 |
 | `init` | 📋 Planned | - | P3 |
 | `info` | 📋 Planned | - | P3 |
@@ -35,6 +35,40 @@ Planning document for redesigning the Dossier CLI from single-purpose `dossier-v
 ---
 
 ## Evolution History
+
+### v0.2.7 - Checksum Command Implementation ✅ (2025-11-28)
+
+**What Changed**:
+- ✅ Implemented `dossier checksum` command for integrity management
+- ✅ Calculate SHA256 checksum of dossier body
+- ✅ Verify existing checksum against content
+- ✅ Update checksum in frontmatter
+- ✅ Quiet mode for scripting (`--quiet`)
+
+**Command Syntax**:
+```bash
+dossier checksum <file> [options]
+
+Options:
+  --update    Update checksum in frontmatter
+  --verify    Verify existing checksum (exit 0 if valid, 1 if invalid)
+  --quiet     Only output the hash (for scripting)
+```
+
+**Examples**:
+```bash
+# Show checksum and compare with frontmatter
+dossier checksum file.ds.md
+
+# Verify checksum (useful in CI/CD)
+dossier checksum file.ds.md --verify
+
+# Update checksum after editing
+dossier checksum file.ds.md --update
+
+# Get just the hash for scripting
+dossier checksum file.ds.md --quiet
+```
 
 ### v0.2.6 - Sign Command Implementation ✅ (2025-11-28)
 
@@ -1106,7 +1140,7 @@ Exit code: 1
 - [ ] Test coverage (deferred to Phase 2)
 - [ ] `list` command implementation (moved to Phase 2)
 
-### Phase 2: Enhanced Authoring 🚧 40% Complete
+### Phase 2: Enhanced Authoring 🚧 50% Complete
 
 **Timeline**: 2-3 weeks
 **Status**: In Progress
@@ -1114,10 +1148,10 @@ Exit code: 1
 **Commands**:
 5. ✅ `dossier list` - List and discover dossiers (v0.2.5)
 6. ✅ `dossier sign` - Sign dossiers with KMS or Ed25519 (v0.2.6)
-7. 📋 `dossier publish` - Share to registry (MVP: print GUID only)
-8. 📋 `dossier init` - Scaffold projects
-9. 📋 `dossier checksum` - Checksum utilities
-10. 📋 `dossier validate` - Schema validation
+7. ✅ `dossier checksum` - Checksum utilities (v0.2.7)
+8. 📋 `dossier publish` - Share to registry (MVP: print GUID only)
+9. 📋 `dossier validate` - Schema validation
+10. 📋 `dossier init` - Scaffold projects
 
 **Features**:
 - [ ] Templates for common use cases
@@ -1553,6 +1587,6 @@ dossier verify file.ds.md
 
 ---
 
-**Current Status**: ✅ v0.2.6 Released - Phase 2 40% Complete: List + Sign commands
+**Current Status**: ✅ v0.2.7 Released - Phase 2 50% Complete: List + Sign + Checksum commands
 
-**Last Updated**: 2025-11-28 (v0.2.6 release - sign command implemented as wrapper around existing tools)
+**Last Updated**: 2025-11-28 (v0.2.7 release - checksum command implemented for integrity management)


### PR DESCRIPTION
## Summary

Phase 2 CLI evolution progress - now 50% complete with the checksum command:

### `dossier checksum` (v0.2.7)
- **Calculate** SHA256 checksum of dossier body
- **Verify** existing checksum against content (`--verify`)
- **Update** checksum in frontmatter (`--update`)
- **Quiet mode** for scripting (`--quiet`)

```bash
# Show checksum and compare with frontmatter
dossier checksum file.ds.md

# Verify checksum (useful in CI/CD)
dossier checksum file.ds.md --verify
# Exit code: 0 = valid, 1 = invalid/missing

# Update checksum after editing
dossier checksum file.ds.md --update

# Get just the hash for scripting
HASH=$(dossier checksum file.ds.md --quiet)
```

## Test plan
- [x] `dossier checksum` shows hash and compares with frontmatter
- [x] `dossier checksum --verify` returns correct exit code
- [x] `dossier checksum --update` writes to frontmatter
- [x] `dossier checksum --quiet` outputs only the hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)