### PR TITLE
feat: Add validate command to CLI (v0.2.8)

### DIFF
--- a/cli/bin/dossier
+++ b/cli/bin/dossier
@@ -1318,17 +1318,184 @@ program
   });
 
 // ============================================================================
-// COMMAND: validate (TBD)
+// COMMAND: validate (IMPLEMENTED)
 // ============================================================================
+
+// Required fields per schema spec
+const REQUIRED_FIELDS = ['dossier_schema_version', 'title', 'version'];
+
+// Recommended fields (warn if missing)
+const RECOMMENDED_FIELDS = ['objective', 'risk_level', 'status'];
+
+// Valid values for certain fields
+const VALID_RISK_LEVELS = ['low', 'medium', 'high', 'critical'];
+const VALID_STATUSES = ['Draft', 'Stable', 'Deprecated', 'Experimental'];
+
 program
   .command('validate')
-  .description('Validate dossier against schema [TBD]')
+  .description('Validate dossier frontmatter structure')
   .argument('<file>', 'Dossier file to validate')
-  .option('--schema <file>', 'Custom schema file')
-  .option('--fix', 'Auto-fix issues')
+  .option('--strict', 'Treat warnings as errors')
+  .option('--quiet', 'Only output errors (no warnings)')
+  .option('--json', 'Output results as JSON')
   .action((file, options) => {
-    console.log('⚠️  validate tbd - follow docs/planning/cli-evolution.md');
-    process.exit(1);
+    const fs = require('fs');
+    const path = require('path');
+
+    // Resolve file path
+    const dossierFile = path.resolve(file);
+
+    if (!fs.existsSync(dossierFile)) {
+      if (options.json) {
+        console.log(JSON.stringify({ valid: false, errors: [`File not found: ${dossierFile}`], warnings: [] }));
+      } else {
+        console.log(`❌ File not found: ${dossierFile}`);
+      }
+      process.exit(1);
+    }
+
+    const content = fs.readFileSync(dossierFile, 'utf8');
+    const errors = [];
+    const warnings = [];
+    let frontmatter = null;
+
+    // Try to parse frontmatter
+    // Format 1: ---dossier\n{JSON}\n---
+    const jsonMatch = content.match(/^---dossier\s*\n([\s\S]*?)\n---/);
+
+    // Format 2: ---\nYAML\n--- (future support)
+    const yamlMatch = !jsonMatch && content.match(/^---\s*\n([\s\S]*?)\n---/);
+
+    if (jsonMatch) {
+      try {
+        frontmatter = JSON.parse(jsonMatch[1]);
+      } catch (err) {
+        errors.push(`Invalid JSON in frontmatter: ${err.message}`);
+      }
+    } else if (yamlMatch) {
+      // Basic YAML support (simple key: value parsing)
+      // TODO: Add full YAML parser when format is finalized
+      warnings.push('YAML frontmatter detected - basic validation only');
+      frontmatter = {};
+      const lines = yamlMatch[1].split('\n');
+      for (const line of lines) {
+        const match = line.match(/^(\w+):\s*(.*)$/);
+        if (match) {
+          let value = match[2].trim();
+          if ((value.startsWith('"') && value.endsWith('"')) ||
+              (value.startsWith("'") && value.endsWith("'"))) {
+            value = value.slice(1, -1);
+          }
+          frontmatter[match[1]] = value;
+        }
+      }
+    } else {
+      errors.push('No frontmatter found. Expected ---dossier or --- at start of file.');
+    }
+
+    // Validate frontmatter if parsed successfully
+    if (frontmatter && errors.length === 0) {
+      // Check required fields
+      for (const field of REQUIRED_FIELDS) {
+        if (!frontmatter[field]) {
+          errors.push(`Missing required field: ${field}`);
+        }
+      }
+
+      // Check recommended fields
+      if (!options.quiet) {
+        for (const field of RECOMMENDED_FIELDS) {
+          if (!frontmatter[field]) {
+            warnings.push(`Missing recommended field: ${field}`);
+          }
+        }
+      }
+
+      // Validate field values
+      if (frontmatter.risk_level && !VALID_RISK_LEVELS.includes(frontmatter.risk_level.toLowerCase())) {
+        warnings.push(`Unknown risk_level: "${frontmatter.risk_level}" (expected: ${VALID_RISK_LEVELS.join(', ')})`);
+      }
+
+      if (frontmatter.status && !VALID_STATUSES.includes(frontmatter.status)) {
+        warnings.push(`Unknown status: "${frontmatter.status}" (expected: ${VALID_STATUSES.join(', ')})`);
+      }
+
+      // Check version format (semver-like)
+      if (frontmatter.version && !/^\d+\.\d+(\.\d+)?(-[\w.]+)?$/.test(frontmatter.version)) {
+        warnings.push(`Version "${frontmatter.version}" doesn't follow semver format (e.g., 1.0.0)`);
+      }
+
+      // Check schema version
+      if (frontmatter.dossier_schema_version && frontmatter.dossier_schema_version !== '1.0.0') {
+        warnings.push(`Unknown schema version: ${frontmatter.dossier_schema_version} (current: 1.0.0)`);
+      }
+
+      // Check for checksum (recommended for signed dossiers)
+      if (frontmatter.signature && !frontmatter.checksum) {
+        warnings.push('Dossier is signed but has no checksum');
+      }
+
+      // High-risk dossiers should be signed
+      if (!options.quiet && frontmatter.risk_level) {
+        const risk = frontmatter.risk_level.toLowerCase();
+        if ((risk === 'high' || risk === 'critical') && !frontmatter.signature) {
+          warnings.push(`${risk}-risk dossier is not signed`);
+        }
+      }
+    }
+
+    // Determine validity
+    const hasErrors = errors.length > 0;
+    const hasWarnings = warnings.length > 0;
+    const valid = options.strict ? (!hasErrors && !hasWarnings) : !hasErrors;
+
+    // Output results
+    if (options.json) {
+      console.log(JSON.stringify({
+        valid,
+        file: dossierFile,
+        errors,
+        warnings,
+        frontmatter: frontmatter ? {
+          title: frontmatter.title,
+          version: frontmatter.version,
+          schema_version: frontmatter.dossier_schema_version
+        } : null
+      }, null, 2));
+    } else {
+      console.log(`\n📋 Dossier Validation\n`);
+      console.log(`   File: ${path.basename(dossierFile)}`);
+
+      if (frontmatter?.title) {
+        console.log(`   Title: ${frontmatter.title}`);
+      }
+      if (frontmatter?.version) {
+        console.log(`   Version: ${frontmatter.version}`);
+      }
+
+      if (errors.length > 0) {
+        console.log(`\n❌ Errors (${errors.length}):`);
+        for (const err of errors) {
+          console.log(`   • ${err}`);
+        }
+      }
+
+      if (warnings.length > 0 && !options.quiet) {
+        console.log(`\n⚠️  Warnings (${warnings.length}):`);
+        for (const warn of warnings) {
+          console.log(`   • ${warn}`);
+        }
+      }
+
+      if (valid) {
+        console.log(`\n✅ Valid${hasWarnings ? ' (with warnings)' : ''}`);
+      } else {
+        console.log(`\n❌ Invalid`);
+      }
+      console.log('');
+    }
+
+    process.exit(valid ? 0 : 1);
   });
 
 // ============================================================================

--- a/docs/planning/cli-evolution.md
+++ b/docs/planning/cli-evolution.md
@@ -4,16 +4,16 @@ Planning document for redesigning the Dossier CLI from single-purpose `dossier-v
 
 ## Status Overview
 
-**Current Version**: v0.2.7
+**Current Version**: v0.2.8
 **Released**: 2025-11-28
-**Status**: ✅ Phase 1 Complete + Phase 2 In Progress - Checksum Command Added
+**Status**: ✅ Phase 1 Complete + Phase 2 In Progress - Validate Command Added
 
 ### Implementation Progress
 
 | Phase | Status | Completion |
 |-------|--------|------------|
 | Phase 1: MVP | ✅ Complete | 100% |
-| Phase 2: Enhanced Authoring | 🚧 In Progress | 50% |
+| Phase 2: Enhanced Authoring | 🚧 In Progress | 66% |
 | Phase 3: Advanced Features | 📋 Planned | 0% |
 
 ### Command Status
@@ -27,14 +27,53 @@ Planning document for redesigning the Dossier CLI from single-purpose `dossier-v
 | `list` | ✅ Done | v0.2.5 | P1 |
 | `sign` | ✅ Done | v0.2.6 | P2 |
 | `checksum` | ✅ Done | v0.2.7 | P2 |
+| `validate` | ✅ Done | v0.2.8 | P2 |
 | `publish` | 📋 Planned | - | P2 |
-| `validate` | 📋 Planned | - | P2 |
 | `init` | 📋 Planned | - | P3 |
 | `info` | 📋 Planned | - | P3 |
 
 ---
 
 ## Evolution History
+
+### v0.2.8 - Validate Command Implementation ✅ (2025-11-28)
+
+**What Changed**:
+- ✅ Implemented `dossier validate` command for frontmatter validation
+- ✅ Validates required fields: `dossier_schema_version`, `title`, `version`
+- ✅ Warns on missing recommended fields: `objective`, `risk_level`, `status`
+- ✅ Validates field values (risk levels, statuses, semver format)
+- ✅ Supports both JSON and basic YAML frontmatter
+- ✅ JSON output for CI/CD integration
+- ✅ Strict mode treats warnings as errors
+
+**Command Syntax**:
+```bash
+dossier validate <file> [options]
+
+Options:
+  --strict    Treat warnings as errors
+  --quiet     Only output errors (no warnings)
+  --json      Output results as JSON
+```
+
+**Examples**:
+```bash
+# Validate a dossier
+dossier validate file.ds.md
+
+# Strict mode for CI/CD
+dossier validate file.ds.md --strict
+
+# JSON output for automation
+dossier validate file.ds.md --json
+```
+
+**Validation Rules**:
+- Required: `dossier_schema_version`, `title`, `version`
+- Recommended: `objective`, `risk_level`, `status`
+- Warns on invalid risk levels, statuses, version format
+- Warns if high-risk dossier is unsigned
 
 ### v0.2.7 - Checksum Command Implementation ✅ (2025-11-28)
 
@@ -1140,7 +1179,7 @@ Exit code: 1
 - [ ] Test coverage (deferred to Phase 2)
 - [ ] `list` command implementation (moved to Phase 2)
 
-### Phase 2: Enhanced Authoring 🚧 50% Complete
+### Phase 2: Enhanced Authoring 🚧 66% Complete
 
 **Timeline**: 2-3 weeks
 **Status**: In Progress
@@ -1149,8 +1188,8 @@ Exit code: 1
 5. ✅ `dossier list` - List and discover dossiers (v0.2.5)
 6. ✅ `dossier sign` - Sign dossiers with KMS or Ed25519 (v0.2.6)
 7. ✅ `dossier checksum` - Checksum utilities (v0.2.7)
-8. 📋 `dossier publish` - Share to registry (MVP: print GUID only)
-9. 📋 `dossier validate` - Schema validation
+8. ✅ `dossier validate` - Schema validation (v0.2.8)
+9. 📋 `dossier publish` - Share to registry (MVP: print GUID only)
 10. 📋 `dossier init` - Scaffold projects
 
 **Features**:
@@ -1587,6 +1626,6 @@ dossier verify file.ds.md
 
 ---
 
-**Current Status**: ✅ v0.2.7 Released - Phase 2 50% Complete: List + Sign + Checksum commands
+**Current Status**: ✅ v0.2.8 Released - Phase 2 66% Complete: List + Sign + Checksum + Validate commands
 
-**Last Updated**: 2025-11-28 (v0.2.7 release - checksum command implemented for integrity management)
+**Last Updated**: 2025-11-28 (v0.2.8 release - validate command implemented for frontmatter validation)


### PR DESCRIPTION
## Summary

Phase 2 CLI evolution progress - now 66% complete with the validate command:

### `dossier validate` (v0.2.8)
- **Required fields**: `dossier_schema_version`, `title`, `version`
- **Recommended fields**: `objective`, `risk_level`, `status` (warns if missing)
- **Value validation**: risk levels, statuses, semver format
- **Frontmatter support**: JSON (`---dossier`) and basic YAML (`---`)
- **CI/CD integration**: `--json` for machine-readable output, `--strict` to fail on warnings

```bash
# Standard validation
dossier validate file.ds.md

# Strict mode (fail on warnings)
dossier validate file.ds.md --strict

# JSON output for automation
dossier validate file.ds.md --json

# Quiet mode (errors only)
dossier validate file.ds.md --quiet
```

### Design decisions (per user request):
- Frontmatter format is flexible (JSON now, YAML in future)
- Only 3 truly required fields - rest are recommendations
- Warnings don't affect exit code unless `--strict`

## Test plan
- [x] Valid dossier returns exit code 0
- [x] Missing required fields returns exit code 1
- [x] Missing recommended fields shows warnings but passes
- [x] `--strict` mode fails on warnings
- [x] `--quiet` mode hides warnings
- [x] `--json` outputs machine-readable format

🤖 Generated with [Claude Code](https://claude.com/claude-code)