### PR TITLE
feat: Migrate remaining JavaScript to TypeScript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help:
 	@echo "Build order:"
 	@echo "  1. packages/core (TypeScript → dist/)"
 	@echo "  2. mcp-server (TypeScript → dist/, depends on core)"
-	@echo "  3. cli (JavaScript, no build needed)"
+	@echo "  3. cli (TypeScript → dist/)"
 
 ## install: Install all npm dependencies
 install:
@@ -40,14 +40,16 @@ build-mcp: build-core
 
 ## build-cli: Build CLI (depends on core)
 build-cli: build-core
-	@echo "Checking CLI..."
-	@echo "✓ CLI is JavaScript - no build needed"
+	@echo "Building CLI..."
+	cd cli && npm run build
+	@echo "✓ cli built"
 
 ## clean: Remove all build artifacts
 clean:
 	@echo "Cleaning build artifacts..."
 	rm -rf packages/core/dist
 	rm -rf mcp-server/dist
+	rm -rf cli/dist
 	@echo "✓ Build artifacts cleaned"
 
 ## rebuild: Clean and rebuild all packages

--- a/cli/bin/dossier
+++ b/cli/bin/dossier
@@ -8,8 +8,8 @@
 const { program } = require('commander');
 const { execSync } = require('child_process');
 const path = require('path');
-const config = require('../lib/config');
-const { convertGitHubBlobToRaw } = require('../lib/github-url');
+const config = require('../dist/config');
+const { convertGitHubBlobToRaw } = require('../dist/github-url');
 
 // Package info
 const pkg = require('../package.json');
@@ -1193,9 +1193,9 @@ program
   .command('login')
   .description('Authenticate with the dossier registry via GitHub')
   .action(async () => {
-    const { runOAuthFlow } = require('../lib/oauth');
-    const { saveCredentials } = require('../lib/credentials');
-    const { getRegistryUrl } = require('../lib/registry-client');
+    const { runOAuthFlow } = require('../dist/oauth');
+    const { saveCredentials } = require('../dist/credentials');
+    const { getRegistryUrl } = require('../dist/registry-client');
 
     try {
       const registryUrl = getRegistryUrl();
@@ -1225,7 +1225,7 @@ program
   .command('logout')
   .description('Remove stored registry credentials')
   .action(() => {
-    const { deleteCredentials } = require('../lib/credentials');
+    const { deleteCredentials } = require('../dist/credentials');
 
     const deleted = deleteCredentials();
     if (deleted) {
@@ -1242,7 +1242,7 @@ program
   .command('whoami')
   .description('Show current registry user')
   .action(() => {
-    const { loadCredentials, isExpired } = require('../lib/credentials');
+    const { loadCredentials, isExpired } = require('../dist/credentials');
 
     const credentials = loadCredentials();
     if (!credentials) {

--- a/cli/bin/dossier-verify
+++ b/cli/bin/dossier-verify
@@ -24,7 +24,7 @@ const {
   loadTrustedKeys,
   verifySignature
 } = require('@imboard-ai/dossier-core');
-const { convertGitHubBlobToRaw } = require('../lib/github-url');
+const { convertGitHubBlobToRaw } = require('../dist/github-url');
 
 // Colors for terminal output
 const colors = {

--- a/cli/package.json
+++ b/cli/package.json
@@ -8,10 +8,11 @@
   },
   "files": [
     "bin/",
-    "lib/",
+    "dist/",
     "README.md"
   ],
   "scripts": {
+    "build": "tsc",
     "test": "./test-verify.sh"
   },
   "keywords": [
@@ -45,5 +46,9 @@
   "dependencies": {
     "@imboard-ai/dossier-core": "^1.0.1",
     "commander": "^12.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "@types/node": "^24.10.0"
   }
 }

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -3,17 +3,21 @@
  * Handles reading and writing user preferences to ~/.dossier/config.json
  */
 
-const fs = require('node:fs');
-const path = require('node:path');
-const os = require('node:os');
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export interface DossierConfig {
+  defaultLlm: string;
+  theme: string;
+  auditLog: boolean;
+  [key: string]: unknown;
+}
 
 const CONFIG_DIR = path.join(os.homedir(), '.dossier');
 const CONFIG_FILE = path.join(CONFIG_DIR, 'config.json');
 
-/**
- * Default configuration
- */
-const DEFAULT_CONFIG = {
+const DEFAULT_CONFIG: DossierConfig = {
   defaultLlm: 'auto',
   theme: 'auto',
   auditLog: true,
@@ -22,7 +26,7 @@ const DEFAULT_CONFIG = {
 /**
  * Ensure config directory exists
  */
-function ensureConfigDir() {
+function ensureConfigDir(): void {
   if (!fs.existsSync(CONFIG_DIR)) {
     fs.mkdirSync(CONFIG_DIR, { recursive: true });
   }
@@ -30,9 +34,8 @@ function ensureConfigDir() {
 
 /**
  * Load configuration from file
- * @returns {Object} Configuration object
  */
-function loadConfig() {
+function loadConfig(): DossierConfig {
   try {
     if (!fs.existsSync(CONFIG_FILE)) {
       return { ...DEFAULT_CONFIG };
@@ -51,47 +54,33 @@ function loadConfig() {
 
 /**
  * Save configuration to file
- * @param {Object} config - Configuration object to save
  */
-function saveConfig(config) {
+function saveConfig(config: DossierConfig): boolean {
   try {
     ensureConfigDir();
     fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2), 'utf8');
     return true;
   } catch (error) {
-    console.error('❌ Error: Could not save config file:', error.message);
+    console.error('❌ Error: Could not save config file:', (error as Error).message);
     return false;
   }
 }
 
 /**
  * Get a specific config value
- * @param {string} key - Config key to retrieve
- * @returns {*} Config value
  */
-function getConfig(key) {
+function getConfig(key: string): unknown {
   const config = loadConfig();
   return config[key];
 }
 
 /**
  * Set a specific config value
- * @param {string} key - Config key to set
- * @param {*} value - Value to set
- * @returns {boolean} Success status
  */
-function setConfig(key, value) {
+function setConfig(key: string, value: unknown): boolean {
   const config = loadConfig();
   config[key] = value;
   return saveConfig(config);
 }
 
-module.exports = {
-  loadConfig,
-  saveConfig,
-  getConfig,
-  setConfig,
-  CONFIG_DIR,
-  CONFIG_FILE,
-  DEFAULT_CONFIG,
-};
+export { loadConfig, saveConfig, getConfig, setConfig, CONFIG_DIR, CONFIG_FILE, DEFAULT_CONFIG };

--- a/cli/src/credentials.ts
+++ b/cli/src/credentials.ts
@@ -3,16 +3,23 @@
  * Stores credentials at ~/.dossier/credentials.json with secure file permissions.
  */
 
-const fs = require('node:fs');
-const path = require('node:path');
-const { CONFIG_DIR } = require('./config');
+import fs from 'node:fs';
+import path from 'node:path';
+import { CONFIG_DIR } from './config';
+
+export interface Credentials {
+  token: string;
+  username: string;
+  orgs: string[];
+  expiresAt: string | null;
+}
 
 const CREDENTIALS_FILE = path.join(CONFIG_DIR, 'credentials.json');
 
 /**
  * Ensure the config directory exists.
  */
-function ensureConfigDir() {
+function ensureConfigDir(): void {
   if (!fs.existsSync(CONFIG_DIR)) {
     fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
   }
@@ -20,9 +27,8 @@ function ensureConfigDir() {
 
 /**
  * Save credentials to file with secure permissions (0600).
- * @param {{ token: string, username: string, orgs: string[], expiresAt?: string }} credentials
  */
-function saveCredentials(credentials) {
+function saveCredentials(credentials: Credentials): void {
   ensureConfigDir();
   const data = {
     token: credentials.token,
@@ -35,9 +41,8 @@ function saveCredentials(credentials) {
 
 /**
  * Load credentials from file.
- * @returns {{ token: string, username: string, orgs: string[], expiresAt: string|null } | null}
  */
-function loadCredentials() {
+function loadCredentials(): Credentials | null {
   if (!fs.existsSync(CREDENTIALS_FILE)) {
     return null;
   }
@@ -60,9 +65,8 @@ function loadCredentials() {
 
 /**
  * Delete the credentials file.
- * @returns {boolean} True if deleted, false if it didn't exist.
  */
-function deleteCredentials() {
+function deleteCredentials(): boolean {
   if (fs.existsSync(CREDENTIALS_FILE)) {
     fs.unlinkSync(CREDENTIALS_FILE);
     return true;
@@ -72,10 +76,8 @@ function deleteCredentials() {
 
 /**
  * Check if credentials are expired.
- * @param {{ expiresAt: string|null }} credentials
- * @returns {boolean}
  */
-function isExpired(credentials) {
+function isExpired(credentials: Pick<Credentials, 'expiresAt'>): boolean {
   if (!credentials.expiresAt) {
     return false;
   }
@@ -87,10 +89,4 @@ function isExpired(credentials) {
   }
 }
 
-module.exports = {
-  CREDENTIALS_FILE,
-  saveCredentials,
-  loadCredentials,
-  deleteCredentials,
-  isExpired,
-};
+export { CREDENTIALS_FILE, saveCredentials, loadCredentials, deleteCredentials, isExpired };

--- a/cli/src/github-url.ts
+++ b/cli/src/github-url.ts
@@ -8,9 +8,6 @@
  * GitHub blob URLs return HTML pages, not raw file content.
  * This function converts them to raw.githubusercontent.com URLs.
  *
- * @param {string} url - The URL to convert
- * @returns {string} - The converted URL (or original if not a GitHub blob URL)
- *
  * @example
  * // Converts blob URLs to raw URLs
  * convertGitHubBlobToRaw('https://github.com/owner/repo/blob/main/path/file.md')
@@ -21,10 +18,10 @@
  * convertGitHubBlobToRaw('https://example.com/file.md')
  * // => 'https://example.com/file.md'
  */
-function convertGitHubBlobToRaw(url) {
+function convertGitHubBlobToRaw(url: string): string {
   // https://github.com/OWNER/REPO/blob/BRANCH/PATH
   // -> https://raw.githubusercontent.com/OWNER/REPO/BRANCH/PATH
-  const githubBlobRegex = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/(.+)$/;
+  const githubBlobRegex = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/(.+)$/;
   const match = url.match(githubBlobRegex);
   if (match) {
     const [, owner, repo, rest] = match;
@@ -33,6 +30,4 @@ function convertGitHubBlobToRaw(url) {
   return url;
 }
 
-module.exports = {
-  convertGitHubBlobToRaw,
-};
+export { convertGitHubBlobToRaw };

--- a/cli/src/oauth.ts
+++ b/cli/src/oauth.ts
@@ -4,11 +4,24 @@
  * decodes JWT token to extract user info.
  */
 
-const { exec } = require('node:child_process');
-const readline = require('node:readline');
+import { exec } from 'node:child_process';
+import readline from 'node:readline';
+
+export interface OAuthResult {
+  token: string;
+  username: string;
+  orgs: string[];
+  email: string | null;
+}
+
+interface JwtPayload {
+  sub: string;
+  orgs?: string[];
+  email?: string;
+}
 
 class OAuthError extends Error {
-  constructor(message) {
+  constructor(message: string) {
     super(message);
     this.name = 'OAuthError';
   }
@@ -16,10 +29,8 @@ class OAuthError extends Error {
 
 /**
  * Decode a base64url-encoded string, adding padding if needed.
- * @param {string} data - Base64url-encoded string
- * @returns {string} Decoded UTF-8 string
  */
-function decodeBase64Url(data) {
+function decodeBase64Url(data: string): string {
   // Replace URL-safe chars with standard base64 chars
   let base64 = data.replace(/-/g, '+').replace(/_/g, '/');
   // Add padding
@@ -32,11 +43,10 @@ function decodeBase64Url(data) {
 
 /**
  * Open a URL in the user's default browser (platform-aware).
- * @param {string} url
  */
-function openBrowser(url) {
+function openBrowser(url: string): void {
   const platform = process.platform;
-  let command;
+  let command: string;
   if (platform === 'darwin') {
     command = `open "${url}"`;
   } else if (platform === 'win32') {
@@ -45,19 +55,15 @@ function openBrowser(url) {
     command = `xdg-open "${url}"`;
   }
 
-  exec(command, (err) => {
-    if (err) {
-      // Browser failed to open — URL is already printed for the user
-    }
+  exec(command, (_err) => {
+    // Browser failed to open — URL is already printed for the user
   });
 }
 
 /**
  * Prompt the user for input via stdin.
- * @param {string} question - The prompt message
- * @returns {Promise<string>} User's input
  */
-function prompt(question) {
+function prompt(question: string): Promise<string> {
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stderr,
@@ -74,11 +80,8 @@ function prompt(question) {
  * Run the OAuth flow using copy/paste method.
  * Opens a browser for GitHub authentication. The registry displays a code
  * that the user copies and pastes back into the CLI.
- *
- * @param {string} registryUrl - Base URL of the registry
- * @returns {Promise<{ token: string, username: string, orgs: string[], email: string|null }>}
  */
-async function runOAuthFlow(registryUrl) {
+async function runOAuthFlow(registryUrl: string): Promise<OAuthResult> {
   const authUrl = `${registryUrl}/auth/login`;
 
   console.log(`\n🔐 Opening browser for GitHub authentication...`);
@@ -93,11 +96,11 @@ async function runOAuthFlow(registryUrl) {
   }
 
   // The code is a base64url-encoded JWT
-  let token;
+  let token: string;
   try {
     token = decodeBase64Url(code);
   } catch (err) {
-    throw new OAuthError(`Invalid code format: ${err.message}`);
+    throw new OAuthError(`Invalid code format: ${(err as Error).message}`);
   }
 
   // Decode JWT payload (middle part) to get user info
@@ -106,11 +109,11 @@ async function runOAuthFlow(registryUrl) {
     throw new OAuthError('Invalid token format');
   }
 
-  let payload;
+  let payload: JwtPayload;
   try {
     payload = JSON.parse(decodeBase64Url(parts[1]));
   } catch (err) {
-    throw new OAuthError(`Invalid token: ${err.message}`);
+    throw new OAuthError(`Invalid token: ${(err as Error).message}`);
   }
 
   const username = payload.sub;
@@ -126,7 +129,4 @@ async function runOAuthFlow(registryUrl) {
   };
 }
 
-module.exports = {
-  OAuthError,
-  runOAuthFlow,
-};
+export { OAuthError, runOAuthFlow };

--- a/cli/src/registry-client.ts
+++ b/cli/src/registry-client.ts
@@ -6,12 +6,10 @@
 const DEFAULT_REGISTRY_URL = 'https://dossier-registry-mvp-ten.vercel.app';
 
 class RegistryError extends Error {
-  /**
-   * @param {string} message
-   * @param {number|null} statusCode
-   * @param {string|null} code
-   */
-  constructor(message, statusCode = null, code = null) {
+  statusCode: number | null;
+  code: string | null;
+
+  constructor(message: string, statusCode: number | null = null, code: string | null = null) {
     super(message);
     this.name = 'RegistryError';
     this.statusCode = statusCode;
@@ -19,22 +17,36 @@ class RegistryError extends Error {
   }
 }
 
+interface ListDossiersOptions {
+  category?: string;
+  page?: number;
+  perPage?: number;
+}
+
+interface SearchOptions {
+  page?: number;
+  perPage?: number;
+}
+
+interface DossierContentResult {
+  content: string;
+  digest: string | null;
+}
+
 class RegistryClient {
-  /**
-   * @param {string} baseUrl - Registry base URL
-   * @param {string|null} token - Optional Bearer token for authenticated requests
-   */
-  constructor(baseUrl, token = null) {
+  private baseUrl: string;
+  private token: string | null;
+
+  constructor(baseUrl: string, token: string | null = null) {
     this.baseUrl = `${baseUrl.replace(/\/+$/, '')}/api/v1`;
     this.token = token;
   }
 
   /**
    * Build request headers.
-   * @returns {Record<string, string>}
    */
-  _buildHeaders(contentType = null) {
-    const headers = { Accept: 'application/json' };
+  private _buildHeaders(contentType: string | null = null): Record<string, string> {
+    const headers: Record<string, string> = { Accept: 'application/json' };
     if (this.token) {
       headers.Authorization = `Bearer ${this.token}`;
     }
@@ -46,16 +58,14 @@ class RegistryClient {
 
   /**
    * Handle API response, throwing on errors.
-   * @param {Response} response
-   * @returns {Promise<any>}
    */
-  async _handleResponse(response) {
+  private async _handleResponse(response: Response): Promise<unknown> {
     if (!response.ok) {
       let message = `Registry request failed: ${response.status} ${response.statusText}`;
-      let code = null;
+      let code: string | null = null;
 
       try {
-        const body = await response.json();
+        const body = (await response.json()) as { error?: { message?: string; code?: string } };
         const errorData = body.error || {};
         if (errorData.message) {
           message = errorData.message;
@@ -73,11 +83,8 @@ class RegistryClient {
 
   /**
    * Build URL with query parameters.
-   * @param {string} path
-   * @param {Record<string, any>} params
-   * @returns {string}
    */
-  _buildUrl(path, params = {}) {
+  private _buildUrl(path: string, params: Record<string, unknown> = {}): string {
     const url = new URL(`${this.baseUrl}${path}`);
     for (const [key, value] of Object.entries(params)) {
       if (value != null) {
@@ -89,11 +96,9 @@ class RegistryClient {
 
   /**
    * List dossiers from the registry.
-   * @param {{ category?: string, page?: number, perPage?: number }} options
-   * @returns {Promise<{ dossiers: any[], pagination: any }>}
    */
-  async listDossiers(options = {}) {
-    const params = {
+  async listDossiers(options: ListDossiersOptions = {}): Promise<unknown> {
+    const params: Record<string, unknown> = {
       page: options.page || 1,
       per_page: options.perPage || 20,
     };
@@ -109,12 +114,9 @@ class RegistryClient {
 
   /**
    * Get metadata for a dossier.
-   * @param {string} name - Dossier name (e.g., 'myorg/deploy')
-   * @param {string|null} version - Optional version (default: latest)
-   * @returns {Promise<any>}
    */
-  async getDossier(name, version = null) {
-    const params = {};
+  async getDossier(name: string, version: string | null = null): Promise<unknown> {
+    const params: Record<string, unknown> = {};
     if (version) {
       params.version = version;
     }
@@ -127,12 +129,12 @@ class RegistryClient {
 
   /**
    * Download dossier content.
-   * @param {string} name - Dossier name
-   * @param {string|null} version - Optional version
-   * @returns {Promise<{ content: string, digest: string|null }>}
    */
-  async getDossierContent(name, version = null) {
-    const params = {};
+  async getDossierContent(
+    name: string,
+    version: string | null = null
+  ): Promise<DossierContentResult> {
+    const params: Record<string, unknown> = {};
     if (version) {
       params.version = version;
     }
@@ -143,10 +145,10 @@ class RegistryClient {
 
     if (!response.ok) {
       let message = `Failed to download dossier '${name}': ${response.status} ${response.statusText}`;
-      let code = null;
+      let code: string | null = null;
 
       try {
-        const body = await response.json();
+        const body = (await response.json()) as { error?: { message?: string; code?: string } };
         const errorData = body.error || {};
         if (errorData.message) {
           message = errorData.message;
@@ -167,12 +169,9 @@ class RegistryClient {
 
   /**
    * Search dossiers.
-   * @param {string} query - Search query
-   * @param {{ page?: number, perPage?: number }} options
-   * @returns {Promise<any>}
    */
-  async searchDossiers(query, options = {}) {
-    const params = {
+  async searchDossiers(query: string, options: SearchOptions = {}): Promise<unknown> {
+    const params: Record<string, unknown> = {
       q: query,
       page: options.page || 1,
       per_page: options.perPage || 20,
@@ -186,13 +185,13 @@ class RegistryClient {
 
   /**
    * Publish a dossier to the registry.
-   * @param {string} namespace - Target namespace (e.g., 'myorg/tools')
-   * @param {string} content - Full .ds.md file content
-   * @param {string|null} changelog - Optional changelog message
-   * @returns {Promise<any>}
    */
-  async publishDossier(namespace, content, changelog = null) {
-    const data = { namespace, content };
+  async publishDossier(
+    namespace: string,
+    content: string,
+    changelog: string | null = null
+  ): Promise<unknown> {
+    const data: Record<string, string> = { namespace, content };
     if (changelog) {
       data.changelog = changelog;
     }
@@ -207,12 +206,9 @@ class RegistryClient {
 
   /**
    * Delete a dossier from the registry.
-   * @param {string} name - Dossier name
-   * @param {string|null} version - Optional specific version to delete
-   * @returns {Promise<any>}
    */
-  async removeDossier(name, version = null) {
-    const params = {};
+  async removeDossier(name: string, version: string | null = null): Promise<unknown> {
+    const params: Record<string, unknown> = {};
     if (version) {
       params.version = version;
     }
@@ -226,9 +222,8 @@ class RegistryClient {
 
   /**
    * Get current user info.
-   * @returns {Promise<any>}
    */
-  async getMe() {
+  async getMe(): Promise<unknown> {
     const response = await fetch(this._buildUrl('/me'), {
       headers: this._buildHeaders(),
     });
@@ -237,11 +232,8 @@ class RegistryClient {
 
   /**
    * Exchange OAuth code for access token.
-   * @param {string} code - Authorization code
-   * @param {string} redirectUri - Redirect URI used in the auth request
-   * @returns {Promise<any>}
    */
-  async exchangeCode(code, redirectUri) {
+  async exchangeCode(code: string, redirectUri: string): Promise<unknown> {
     const response = await fetch(this._buildUrl('/auth/token'), {
       method: 'POST',
       headers: this._buildHeaders('application/json'),
@@ -253,27 +245,22 @@ class RegistryClient {
 
 /**
  * Get registry URL from environment or use default.
- * @returns {string}
  */
-function getRegistryUrl() {
+function getRegistryUrl(): string {
   return process.env.DOSSIER_REGISTRY_URL || DEFAULT_REGISTRY_URL;
 }
 
 /**
  * Create a registry client from environment configuration.
- * @param {string|null} token - Optional auth token
- * @returns {RegistryClient}
  */
-function getClient(token = null) {
+function getClient(token: string | null = null): RegistryClient {
   return new RegistryClient(getRegistryUrl(), token);
 }
 
 /**
  * Parse a name@version string.
- * @param {string} name - Dossier name, optionally with @version suffix
- * @returns {[string, string|null]} Tuple of [name, version]
  */
-function parseNameVersion(name) {
+function parseNameVersion(name: string): [string, string | null] {
   if (name.includes('@')) {
     const idx = name.lastIndexOf('@');
     return [name.slice(0, idx), name.slice(idx + 1)];
@@ -281,7 +268,7 @@ function parseNameVersion(name) {
   return [name, null];
 }
 
-module.exports = {
+export {
   RegistryClient,
   RegistryError,
   getRegistryUrl,

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/validation/validate-dossier.ts
+++ b/examples/validation/validate-dossier.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env npx tsx
 
 /**
  * Dossier Schema Validator (Node.js)
@@ -7,13 +7,13 @@
  *
  * Usage:
  *   npm install ajv ajv-formats
- *   node validate-dossier.js /path/to/dossier.md
+ *   npx tsx validate-dossier.ts /path/to/dossier.md
  */
 
-const fs = require('node:fs');
-const path = require('node:path');
-const Ajv = require('ajv');
-const addFormats = require('ajv-formats');
+import fs from 'node:fs';
+import path from 'node:path';
+import Ajv, { type ErrorObject } from 'ajv';
+import addFormats from 'ajv-formats';
 
 // Load schema
 const schemaPath = path.join(__dirname, '../../dossier-schema.json');
@@ -27,7 +27,7 @@ const validate = ajv.compile(schema);
 /**
  * Extract JSON frontmatter from a Dossier markdown file
  */
-function extractFrontmatter(filePath) {
+function extractFrontmatter(filePath: string): Record<string, unknown> {
   const content = fs.readFileSync(filePath, 'utf8');
 
   // Match ---dossier\n{...}\n---
@@ -43,19 +43,23 @@ function extractFrontmatter(filePath) {
   try {
     return JSON.parse(jsonString);
   } catch (err) {
-    throw new Error(`Failed to parse frontmatter JSON: ${err.message}`);
+    throw new Error(`Failed to parse frontmatter JSON: ${(err as Error).message}`);
   }
 }
 
 /**
  * Validate a Dossier file
  */
-function validateDossier(filePath) {
+function validateDossier(filePath: string): boolean {
   console.log(`\n🔍 Validating: ${filePath}\n`);
 
   try {
     // Extract frontmatter
-    const frontmatter = extractFrontmatter(filePath);
+    const frontmatter = extractFrontmatter(filePath) as {
+      title?: string;
+      version?: string;
+      status?: string;
+    };
     console.log('✓ Frontmatter extracted successfully');
     console.log(`  Title: ${frontmatter.title}`);
     console.log(`  Version: ${frontmatter.version}`);
@@ -70,7 +74,7 @@ function validateDossier(filePath) {
       return true;
     } else {
       console.log('❌ INVALID - Schema validation failed:\n');
-      validate.errors.forEach((err, i) => {
+      (validate.errors as ErrorObject[]).forEach((err, i) => {
         console.log(`  Error ${i + 1}:`);
         console.log(`    Path: ${err.instancePath || '(root)'}`);
         console.log(`    Message: ${err.message}`);
@@ -82,7 +86,7 @@ function validateDossier(filePath) {
       return false;
     }
   } catch (err) {
-    console.log(`❌ ERROR: ${err.message}\n`);
+    console.log(`❌ ERROR: ${(err as Error).message}\n`);
     return false;
   }
 }
@@ -90,12 +94,12 @@ function validateDossier(filePath) {
 /**
  * Main
  */
-function main() {
+function main(): void {
   const args = process.argv.slice(2);
 
   if (args.length === 0) {
-    console.log('Usage: node validate-dossier.js <dossier-file.md>');
-    console.log('Example: node validate-dossier.js ../../examples/devops/deploy-to-aws.md');
+    console.log('Usage: npx tsx validate-dossier.ts <dossier-file.md>');
+    console.log('Example: npx tsx validate-dossier.ts ../../examples/devops/deploy-to-aws.md');
     process.exit(1);
   }
 
@@ -111,8 +115,6 @@ function main() {
 }
 
 // Run if called directly
-if (require.main === module) {
-  main();
-}
+main();
 
-module.exports = { extractFrontmatter, validateDossier };
+export { extractFrontmatter, validateDossier };

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -6,6 +6,7 @@
  * Enables LLMs to discover, verify, and execute dossiers securely
  */
 
+import { getErrorMessage, getErrorStack } from '@imboard-ai/dossier-core';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
@@ -16,7 +17,6 @@ import {
   ListToolsRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { getErrorMessage, getErrorStack } from '@imboard-ai/dossier-core';
 import { getConceptResource } from './resources/concept.js';
 import { getProtocolResource } from './resources/protocol.js';
 import { getSecurityResource } from './resources/security.js';
@@ -135,10 +135,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       stack: getErrorStack(error),
     });
 
-    return createToolResponse(
-      { error: { message: getErrorMessage(error), tool: name } },
-      true
-    );
+    return createToolResponse({ error: { message: getErrorMessage(error), tool: name } }, true);
   }
 });
 

--- a/mcp-server/src/utils/resourceLoader.ts
+++ b/mcp-server/src/utils/resourceLoader.ts
@@ -40,7 +40,7 @@ export function loadMarkdownResource(relativePath: string, resourceName: string)
  * @param resourceName - Human-readable name for logging
  * @returns A function that loads the resource when called
  */
-export const createResourceLoader = (
-  relativePath: string,
-  resourceName: string
-): (() => string) => (): string => loadMarkdownResource(relativePath, resourceName);
+export const createResourceLoader =
+  (relativePath: string, resourceName: string): (() => string) =>
+  (): string =>
+    loadMarkdownResource(relativePath, resourceName);

--- a/mcp-server/test-list.ts
+++ b/mcp-server/test-list.ts
@@ -1,11 +1,11 @@
-#!/usr/bin/env node
+#!/usr/bin/env npx tsx
 
 /**
  * Test script for list_dossiers functionality
  */
 
-const { listDossiers } = require('./dist/tools/listDossiers.js');
-const path = require('node:path');
+import path from 'node:path';
+import { listDossiers } from './dist/tools/listDossiers.js';
 
 // Test with the examples directory
 const examplesPath = path.join(__dirname, '../examples');
@@ -21,7 +21,7 @@ try {
   console.log('Test completed successfully!');
   process.exit(0);
 } catch (error) {
-  console.error('Test failed:', error.message);
-  console.error(error.stack);
+  console.error('Test failed:', (error as Error).message);
+  console.error((error as Error).stack);
   process.exit(1);
 }

--- a/mcp-server/test-verify.ts
+++ b/mcp-server/test-verify.ts
@@ -1,11 +1,11 @@
-#!/usr/bin/env node
+#!/usr/bin/env npx tsx
 
 /**
  * Test script for verify_dossier functionality
  */
 
-const { verifyDossier } = require('./dist/tools/verifyDossier.js');
-const path = require('node:path');
+import path from 'node:path';
+import { verifyDossier } from './dist/tools/verifyDossier.js';
 
 // Test with the git worktree dossier
 const dossierPath = path.join(__dirname, '../examples/development/add-git-worktree-support.ds.md');
@@ -20,7 +20,7 @@ try {
   console.log('Test completed successfully!');
   process.exit(0);
 } catch (error) {
-  console.error('Test failed:', error.message);
-  console.error(error.stack);
+  console.error('Test failed:', (error as Error).message);
+  console.error((error as Error).stack);
   process.exit(1);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
       ],
       "devDependencies": {
         "@aws-sdk/client-kms": "^3.932.0",
-        "@biomejs/biome": "^2.3.6"
+        "@biomejs/biome": "^2.3.6",
+        "tsx": "^4.20.6"
       }
     },
     "cli": {
@@ -28,6 +29,10 @@
       },
       "bin": {
         "dossier": "bin/dossier"
+      },
+      "devDependencies": {
+        "@types/node": "^24.10.0",
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -208,6 +213,7 @@
     "mcp-server/node_modules/express": {
       "version": "5.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -303,17 +309,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "mcp-server/node_modules/get-tsconfig": {
-      "version": "4.13.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "mcp-server/node_modules/http-errors": {
@@ -441,14 +436,6 @@
         "node": ">=0.10.0"
       }
     },
-    "mcp-server/node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "mcp-server/node_modules/router": {
       "version": "2.2.0",
       "license": "MIT",
@@ -531,24 +518,6 @@
         "node": ">=8"
       }
     },
-    "mcp-server/node_modules/tsx": {
-      "version": "4.20.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "~0.25.0",
-        "get-tsconfig": "^4.7.5"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      }
-    },
     "mcp-server/node_modules/vary": {
       "version": "1.1.2",
       "license": "MIT",
@@ -576,6 +545,7 @@
     "mcp-server/node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2996,6 +2966,7 @@
       "integrity": "sha512-6HV2HHl9aRJ09TlYj/WAQxaa797Ezb5u0LpgabthlASAUAWKgw/W1DSPX7t848mMZmIUvzZgnUHGIylAoYHP0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.9",
         "fflate": "^0.8.2",
@@ -3400,6 +3371,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3716,6 +3700,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3780,6 +3765,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/rollup": {
@@ -4067,6 +4062,510 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
@@ -4123,6 +4622,7 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -4198,6 +4698,7 @@
       "integrity": "sha512-E0Ja2AX4th+CG33yAFRC+d1wFx2pzU5r6HtG6LiPSE04flaE0qB6YyjSw9ZcpJAtVPfsvZGtJlKWZpuW7EHRxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.9",
         "@vitest/mocker": "4.0.9",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "format": "biome format --write .",
     "check": "biome check --write .",
     "publish:core": "cd packages/core && npm run build && npm publish",
-    "publish:cli": "cd cli && npm publish",
+    "publish:cli": "cd cli && npm run build && npm publish",
     "publish:all": "npm run publish:core && npm run publish:cli"
   },
   "author": "Yuval Dimnik <yuval.dimnik@gmail.com>",
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-kms": "^3.932.0",
-    "@biomejs/biome": "^2.3.6"
+    "@biomejs/biome": "^2.3.6",
+    "tsx": "^4.20.6"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,11 +29,11 @@ export {
 } from './signers';
 // Type exports
 export * from './types';
-// Error utilities
-export { getErrorMessage, getErrorStack } from './utils/errors';
-// Verification utilities
-export { createDefaultVerificationResult } from './utils/verification';
 // Crypto utilities
 export { sha256Hash, sha256Hex } from './utils/crypto';
+// Error utilities
+export { getErrorMessage, getErrorStack } from './utils/errors';
 // File system utilities
 export { readFileIfExists } from './utils/fs';
+// Verification utilities
+export { createDefaultVerificationResult } from './utils/verification';

--- a/packages/core/src/signature.ts
+++ b/packages/core/src/signature.ts
@@ -7,12 +7,12 @@
 
 import { createPublicKey, verify } from 'node:crypto';
 import { homedir } from 'node:os';
-import { sha256Hash } from './utils/crypto';
-import { readFileIfExists } from './utils/fs';
 import { join } from 'node:path';
 import { KMSClient, SigningAlgorithmSpec, VerifyCommand } from '@aws-sdk/client-kms';
 import type { SignatureResult } from './signers';
 import { getVerifierRegistry } from './signers';
+import { sha256Hash } from './utils/crypto';
+import { readFileIfExists } from './utils/fs';
 
 /**
  * Load trusted keys from file

--- a/packages/core/src/signers/kms.ts
+++ b/packages/core/src/signers/kms.ts
@@ -9,8 +9,8 @@ import {
   SigningAlgorithmSpec,
   VerifyCommand,
 } from '@aws-sdk/client-kms';
-import type { SignatureResult, Signer, Verifier } from './index';
 import { sha256Hash } from '../utils/crypto';
+import type { SignatureResult, Signer, Verifier } from './index';
 
 export class KmsSigner implements Signer {
   readonly algorithm = 'ECDSA-SHA-256';

--- a/tools/lib/cli-parser.ts
+++ b/tools/lib/cli-parser.ts
@@ -3,32 +3,28 @@
  * Provides a declarative way to define CLI options
  */
 
-/**
- * @typedef {Object} OptionConfig
- * @property {string} name - Option name (used as key in result)
- * @property {string} flag - Flag without -- prefix (e.g., 'key-id')
- * @property {string} description - Description for help text
- * @property {boolean} [required] - Whether option is required
- * @property {*} [defaultValue] - Default value if not provided
- * @property {boolean} [isBoolean] - If true, option is a flag (no value)
- * @property {Function} [defaultFn] - Function to compute default value
- */
+export interface OptionConfig {
+  name: string;
+  flag: string;
+  description: string;
+  required?: boolean;
+  defaultValue?: string;
+  isBoolean?: boolean;
+  defaultFn?: () => string;
+}
 
-/**
- * @typedef {Object} ParserConfig
- * @property {string} name - Tool name for help text
- * @property {string} description - Tool description
- * @property {string} usage - Usage line
- * @property {OptionConfig[]} options - Available options
- * @property {string} [extraHelp] - Additional help text (examples, notes)
- */
+export interface ParserConfig {
+  name: string;
+  description: string;
+  usage: string;
+  options: OptionConfig[];
+  extraHelp?: string;
+}
 
 /**
  * Print help message and exit
- * @param {ParserConfig} config - Parser configuration
- * @param {number} exitCode - Exit code (0 for help, 1 for error)
  */
-function printHelp(config, exitCode) {
+function printHelp(config: ParserConfig, exitCode: number): never {
   console.log(`
 ${config.name}
 
@@ -56,11 +52,9 @@ Options:`);
 
 /**
  * Create a CLI argument parser
- * @param {ParserConfig} config - Parser configuration
- * @returns {Function} Parser function that returns parsed options
  */
-function createCliParser(config) {
-  return function parseArgs() {
+function createCliParser(config: ParserConfig): () => Record<string, string | boolean | null> {
+  return function parseArgs(): Record<string, string | boolean | null> {
     const args = process.argv.slice(2);
 
     // Help check
@@ -69,7 +63,7 @@ function createCliParser(config) {
     }
 
     // First positional argument is the dossier file
-    const result = {
+    const result: Record<string, string | boolean | null> = {
       dossierFile: args[0],
     };
 
@@ -111,7 +105,4 @@ function createCliParser(config) {
   };
 }
 
-module.exports = {
-  createCliParser,
-  printHelp,
-};
+export { createCliParser, printHelp };

--- a/tools/lib/signing-common.ts
+++ b/tools/lib/signing-common.ts
@@ -1,28 +1,35 @@
 /**
  * Common utilities for dossier signing tools
- * Shared by sign-dossier.js and sign-dossier-kms.js
+ * Shared by sign-dossier.ts and sign-dossier-kms.ts
  */
 
-const fs = require('node:fs');
-const { parseDossierContent, calculateChecksum, readFileIfExists } = require('@imboard-ai/dossier-core');
+import fs from 'node:fs';
+import {
+  calculateChecksum,
+  type DossierFrontmatter,
+  type ParsedDossier,
+  parseDossierContent,
+  readFileIfExists,
+} from '@imboard-ai/dossier-core';
 
 /**
  * Read and parse a dossier file
- * @param {string} dossierFile - Path to dossier file
- * @returns {{ frontmatter: object, body: string }} Parsed dossier
  */
-function readAndParseDossier(dossierFile) {
+function readAndParseDossier(dossierFile: string): {
+  frontmatter: DossierFrontmatter;
+  body: string;
+} {
   const content = readFileIfExists(dossierFile);
   if (!content) {
     console.error(`Error: File not found: ${dossierFile}`);
     process.exit(1);
   }
 
-  let parsed;
+  let parsed: ParsedDossier;
   try {
     parsed = parseDossierContent(content);
   } catch (err) {
-    console.error(`Error: ${err.message}`);
+    console.error(`Error: ${(err as Error).message}`);
     process.exit(1);
   }
 
@@ -31,11 +38,8 @@ function readAndParseDossier(dossierFile) {
 
 /**
  * Calculate and add checksum to frontmatter
- * @param {object} frontmatter - Frontmatter object to update
- * @param {string} body - Dossier body content
- * @returns {string} The calculated checksum hash
  */
-function addChecksum(frontmatter, body) {
+function addChecksum(frontmatter: DossierFrontmatter, body: string): string {
   console.log('\n📊 Calculating checksum...');
   const checksum = calculateChecksum(body);
   console.log(`   SHA256: ${checksum}`);
@@ -43,16 +47,15 @@ function addChecksum(frontmatter, body) {
   frontmatter.checksum = {
     algorithm: 'sha256',
     hash: checksum,
-  };
+  } as DossierFrontmatter['checksum'];
 
   return checksum;
 }
 
 /**
  * Handle dry run - print checksum without signing
- * @param {object} frontmatter - Frontmatter with checksum added
  */
-function handleDryRun(frontmatter) {
+function handleDryRun(frontmatter: DossierFrontmatter): void {
   console.log('\n✅ Dry run complete (checksum calculated, no signature)');
   console.log('\nUpdated frontmatter:');
   console.log(JSON.stringify(frontmatter, null, 2));
@@ -60,11 +63,8 @@ function handleDryRun(frontmatter) {
 
 /**
  * Write updated dossier file with new frontmatter
- * @param {string} dossierFile - Path to dossier file
- * @param {object} frontmatter - Updated frontmatter
- * @param {string} body - Dossier body content
  */
-function writeDossier(dossierFile, frontmatter, body) {
+function writeDossier(dossierFile: string, frontmatter: DossierFrontmatter, body: string): void {
   console.log('\n💾 Updating dossier file...');
 
   const updatedContent = `---dossier\n${JSON.stringify(frontmatter, null, 2)}\n---\n${body}`;
@@ -73,9 +73,4 @@ function writeDossier(dossierFile, frontmatter, body) {
   console.log('   ✓ File updated');
 }
 
-module.exports = {
-  readAndParseDossier,
-  addChecksum,
-  handleDryRun,
-  writeDossier,
-};
+export { readAndParseDossier, addChecksum, handleDryRun, writeDossier };

--- a/tools/sign-dossier-kms.ts
+++ b/tools/sign-dossier-kms.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env npx tsx
 
 /**
  * Dossier AWS KMS Signing Tool
@@ -6,7 +6,7 @@
  * Signs a dossier with AWS KMS and embeds the checksum and signature in the frontmatter.
  *
  * Usage:
- *   node tools/sign-dossier-kms.js <dossier-file> [options]
+ *   npx tsx tools/sign-dossier-kms.ts <dossier-file> [options]
  *
  * Prerequisites:
  *   - AWS SDK must be installed (npm install @aws-sdk/client-kms)
@@ -14,25 +14,21 @@
  *   - Permission to use the KMS key
  *
  * Example:
- *   node tools/sign-dossier-kms.js examples/devops/deploy-to-aws.ds.md \\
- *     --key-id alias/dossier-official-prod \\
+ *   npx tsx tools/sign-dossier-kms.ts examples/devops/deploy-to-aws.ds.md \
+ *     --key-id alias/dossier-official-prod \
  *     --signed-by "Dossier Team <team@dossier.ai>"
  */
 
-const { KmsSigner } = require('@imboard-ai/dossier-core');
-const {
-  readAndParseDossier,
-  addChecksum,
-  handleDryRun,
-  writeDossier,
-} = require('./lib/signing-common');
-const { createCliParser } = require('./lib/cli-parser');
+import { KmsSigner, type SignatureResult } from '@imboard-ai/dossier-core';
+import { createCliParser } from './lib/cli-parser';
+import { addChecksum, handleDryRun, readAndParseDossier, writeDossier } from './lib/signing-common';
 
 // Configure CLI parser
 const parseArgs = createCliParser({
   name: 'Dossier AWS KMS Signing Tool',
-  description: 'Signs a dossier with AWS KMS and embeds the checksum and signature in the frontmatter.',
-  usage: 'node tools/sign-dossier-kms.js <dossier-file> [options]',
+  description:
+    'Signs a dossier with AWS KMS and embeds the checksum and signature in the frontmatter.',
+  usage: 'npx tsx tools/sign-dossier-kms.ts <dossier-file> [options]',
   options: [
     {
       name: 'keyId',
@@ -65,13 +61,13 @@ Environment Variables:
   AWS_SECRET_ACCESS_KEY AWS secret key
 
 Example:
-  node tools/sign-dossier-kms.js examples/devops/deploy-to-aws.ds.md \\
+  npx tsx tools/sign-dossier-kms.ts examples/devops/deploy-to-aws.ds.md \\
     --key-id alias/dossier-official-prod \\
     --signed-by "Dossier Team <team@dossier.ai>"`,
 });
 
 // Main function
-async function main() {
+async function main(): Promise<void> {
   const options = parseArgs();
 
   console.log('🔐 Dossier AWS KMS Signing Tool\n');
@@ -80,7 +76,7 @@ async function main() {
   console.log(`Region: ${options.region}`);
 
   // Read and parse dossier
-  const { frontmatter, body } = readAndParseDossier(options.dossierFile);
+  const { frontmatter, body } = readAndParseDossier(options.dossierFile as string);
 
   // Calculate and add checksum
   addChecksum(frontmatter, body);
@@ -93,12 +89,12 @@ async function main() {
   // Sign with AWS KMS
   console.log('\n✍️  Signing with AWS KMS...');
 
-  let signatureResult;
+  let signatureResult: SignatureResult;
   try {
-    const signer = new KmsSigner(options.keyId, options.region);
+    const signer = new KmsSigner(options.keyId as string, options.region as string);
     signatureResult = await signer.sign(body);
   } catch (err) {
-    console.error(`\nError: ${err.message}`);
+    console.error(`\nError: ${(err as Error).message}`);
     process.exit(1);
   }
 
@@ -110,11 +106,11 @@ async function main() {
 
   // Add optional metadata
   if (options.signedBy) {
-    frontmatter.signature.signed_by = options.signedBy;
+    frontmatter.signature.signed_by = options.signedBy as string;
   }
 
   // Write updated dossier
-  writeDossier(options.dossierFile, frontmatter, body);
+  writeDossier(options.dossierFile as string, frontmatter, body);
   console.log('\n✅ Dossier signed successfully!');
   console.log(`\nSignature details:`);
   console.log(`  Algorithm: ECDSA-SHA-256`);
@@ -125,9 +121,7 @@ async function main() {
 }
 
 // Run
-if (require.main === module) {
-  main().catch((err) => {
-    console.error(`\nFatal error: ${err.message}`);
-    process.exit(1);
-  });
-}
+main().catch((err: unknown) => {
+  console.error(`\nFatal error: ${(err as Error).message}`);
+  process.exit(1);
+});

--- a/tools/sign-dossier.ts
+++ b/tools/sign-dossier.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env npx tsx
 
 /**
  * Dossier Signing Tool
@@ -6,7 +6,7 @@
  * Signs a dossier with Ed25519 and embeds the checksum and signature in the frontmatter.
  *
  * Usage:
- *   node tools/sign-dossier.js <dossier-file> --key <ed25519-private-key.pem> [--key-id <id>]
+ *   npx tsx tools/sign-dossier.ts <dossier-file> --key <ed25519-private-key.pem> [--key-id <id>]
  *
  * Prerequisites:
  *   - Ed25519 private key in PEM format
@@ -16,23 +16,19 @@
  *   openssl pkey -in private-key.pem -pubout -out public-key.pem
  *
  * Example:
- *   node tools/sign-dossier.js examples/devops/deploy-to-aws.md --key ~/.dossier/private-key.pem --key-id imboard-ai-2024
+ *   npx tsx tools/sign-dossier.ts examples/devops/deploy-to-aws.md --key ~/.dossier/private-key.pem --key-id imboard-ai-2024
  */
 
-const { Ed25519Signer } = require('@imboard-ai/dossier-core');
-const {
-  readAndParseDossier,
-  addChecksum,
-  handleDryRun,
-  writeDossier,
-} = require('./lib/signing-common');
-const { createCliParser } = require('./lib/cli-parser');
+import { Ed25519Signer, type SignatureResult } from '@imboard-ai/dossier-core';
+import { createCliParser } from './lib/cli-parser';
+import { addChecksum, handleDryRun, readAndParseDossier, writeDossier } from './lib/signing-common';
 
 // Configure CLI parser
 const parseArgs = createCliParser({
   name: 'Dossier Signing Tool',
-  description: 'Signs a dossier with Ed25519 and embeds the checksum and signature in the frontmatter.',
-  usage: 'node tools/sign-dossier.js <dossier-file> --key <ed25519-private-key.pem> [options]',
+  description:
+    'Signs a dossier with Ed25519 and embeds the checksum and signature in the frontmatter.',
+  usage: 'npx tsx tools/sign-dossier.ts <dossier-file> --key <ed25519-private-key.pem> [options]',
   options: [
     {
       name: 'keyFile',
@@ -63,21 +59,21 @@ Generate keypair:
   openssl pkey -in private-key.pem -pubout -out public-key.pem
 
 Example:
-  node tools/sign-dossier.js examples/devops/deploy-to-aws.md \\
+  npx tsx tools/sign-dossier.ts examples/devops/deploy-to-aws.md \\
     --key ~/.dossier/private-key.pem \\
     --key-id imboard-ai-2024 \\
     --signed-by "Imboard AI <security@imboard.ai>"`,
 });
 
 // Main function
-async function main() {
+async function main(): Promise<void> {
   const options = parseArgs();
 
   console.log('🔐 Dossier Signing Tool\n');
   console.log(`Dossier: ${options.dossierFile}`);
 
   // Read and parse dossier
-  const { frontmatter, body } = readAndParseDossier(options.dossierFile);
+  const { frontmatter, body } = readAndParseDossier(options.dossierFile as string);
 
   // Calculate and add checksum
   addChecksum(frontmatter, body);
@@ -91,12 +87,12 @@ async function main() {
   console.log('\n✍️  Signing with Ed25519...');
   console.log(`   Key file: ${options.keyFile}`);
 
-  let signatureResult;
+  let signatureResult: SignatureResult;
   try {
-    const signer = new Ed25519Signer(options.keyFile);
+    const signer = new Ed25519Signer(options.keyFile as string);
     signatureResult = await signer.sign(body);
   } catch (err) {
-    console.error(`\nError: ${err.message}`);
+    console.error(`\nError: ${(err as Error).message}`);
     process.exit(1);
   }
 
@@ -107,15 +103,15 @@ async function main() {
 
   // Add optional metadata
   if (options.keyId) {
-    frontmatter.signature.key_id = options.keyId;
+    frontmatter.signature.key_id = options.keyId as string;
   }
 
   if (options.signedBy) {
-    frontmatter.signature.signed_by = options.signedBy;
+    frontmatter.signature.signed_by = options.signedBy as string;
   }
 
   // Write updated dossier
-  writeDossier(options.dossierFile, frontmatter, body);
+  writeDossier(options.dossierFile as string, frontmatter, body);
   console.log('\n✅ Dossier signed successfully!');
   console.log(`\nSignature details:`);
   console.log(`  Algorithm: ed25519`);
@@ -125,9 +121,7 @@ async function main() {
 }
 
 // Run
-if (require.main === module) {
-  main().catch((err) => {
-    console.error(`\nFatal error: ${err.message}`);
-    process.exit(1);
-  });
-}
+main().catch((err: unknown) => {
+  console.error(`\nFatal error: ${(err as Error).message}`);
+  process.exit(1);
+});

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tools/verify-dossier.ts
+++ b/tools/verify-dossier.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env npx tsx
 
 /**
  * Dossier Verification Tool
@@ -6,29 +6,57 @@
  * Verifies the integrity (checksum) and authenticity (signature) of a dossier.
  *
  * Usage:
- *   node tools/verify-dossier.js <dossier-file> [--trusted-keys <file>]
+ *   npx tsx tools/verify-dossier.ts <dossier-file> [--trusted-keys <file>]
  *
  * Example:
- *   node tools/verify-dossier.js examples/devops/deploy-to-aws.ds.md
- *   node tools/verify-dossier.js examples/devops/deploy-to-aws.ds.md --trusted-keys ~/.dossier/trusted-keys.txt
+ *   npx tsx tools/verify-dossier.ts examples/devops/deploy-to-aws.ds.md
+ *   npx tsx tools/verify-dossier.ts examples/devops/deploy-to-aws.ds.md --trusted-keys ~/.dossier/trusted-keys.txt
  */
 
-const path = require('node:path');
-const os = require('node:os');
-const {
-  parseDossierContent,
-  verifyIntegrity,
+import os from 'node:os';
+import path from 'node:path';
+import {
+  type DossierFrontmatter,
   loadTrustedKeys,
-  verifySignature,
+  type ParsedDossier,
+  parseDossierContent,
   readFileIfExists,
-} = require('@imboard-ai/dossier-core');
-const { createCliParser } = require('./lib/cli-parser');
+  verifyIntegrity,
+  verifySignature,
+} from '@imboard-ai/dossier-core';
+import { createCliParser } from './lib/cli-parser';
+
+interface VerifyResult {
+  dossierFile: string;
+  integrity: {
+    status: string;
+    message: string;
+    expectedHash?: string;
+    actualHash?: string;
+  };
+  authenticity: {
+    status: string;
+    message: string;
+    signer: string | null;
+    keyId: string | null;
+    isTrusted: boolean;
+    trustedAs?: string;
+  };
+  riskAssessment: {
+    riskLevel: string | null;
+    riskFactors: string[];
+    destructiveOperations: string[];
+    requiresApproval: boolean | null;
+  };
+  recommendation: string;
+  errors: string[];
+}
 
 // Configure CLI parser
 const parseArgs = createCliParser({
   name: 'Dossier Verification Tool',
   description: 'Verifies the integrity (checksum) and authenticity (signature) of a dossier.',
-  usage: 'node tools/verify-dossier.js <dossier-file> [options]',
+  usage: 'npx tsx tools/verify-dossier.ts <dossier-file> [options]',
   options: [
     {
       name: 'trustedKeysFile',
@@ -45,13 +73,13 @@ const parseArgs = createCliParser({
   ],
   extraHelp: `
 Example:
-  node tools/verify-dossier.js examples/devops/deploy-to-aws.ds.md
-  node tools/verify-dossier.js examples/devops/deploy-to-aws.ds.md --trusted-keys ./my-keys.txt`,
+  npx tsx tools/verify-dossier.ts examples/devops/deploy-to-aws.ds.md
+  npx tsx tools/verify-dossier.ts examples/devops/deploy-to-aws.ds.md --trusted-keys ./my-keys.txt`,
 });
 
 // Main verification function
-async function verifyDossier(dossierFile, trustedKeysFile) {
-  const result = {
+async function verifyDossier(dossierFile: string, trustedKeysFile: string): Promise<VerifyResult> {
+  const result: VerifyResult = {
     dossierFile,
     integrity: {
       status: 'unknown',
@@ -83,11 +111,11 @@ async function verifyDossier(dossierFile, trustedKeysFile) {
   }
 
   // Parse dossier
-  let parsed;
+  let parsed: ParsedDossier;
   try {
     parsed = parseDossierContent(content);
   } catch (err) {
-    result.errors.push(`Parse error: ${err.message}`);
+    result.errors.push(`Parse error: ${(err as Error).message}`);
     result.recommendation = 'BLOCK';
     return result;
   }
@@ -144,16 +172,18 @@ async function verifyDossier(dossierFile, trustedKeysFile) {
       }
     } catch (err) {
       result.authenticity.status = 'error';
-      result.authenticity.message = `Verification error: ${err.message}`;
-      result.errors.push(`Signature verification error: ${err.message}`);
+      result.authenticity.message = `Verification error: ${(err as Error).message}`;
+      result.errors.push(`Signature verification error: ${(err as Error).message}`);
     }
   }
 
   // 3. RISK ASSESSMENT
-  result.riskAssessment.riskLevel = frontmatter.risk_level || 'unknown';
-  result.riskAssessment.riskFactors = frontmatter.risk_factors || [];
-  result.riskAssessment.destructiveOperations = frontmatter.destructive_operations || [];
-  result.riskAssessment.requiresApproval = frontmatter.requires_approval !== false; // default true
+  result.riskAssessment.riskLevel = (frontmatter as DossierFrontmatter).risk_level || 'unknown';
+  result.riskAssessment.riskFactors = (frontmatter as DossierFrontmatter).risk_factors || [];
+  result.riskAssessment.destructiveOperations =
+    (frontmatter as DossierFrontmatter).destructive_operations || [];
+  result.riskAssessment.requiresApproval =
+    (frontmatter as DossierFrontmatter).requires_approval !== false; // default true
 
   // 4. RECOMMENDATION
   if (result.recommendation === 'UNKNOWN') {
@@ -183,7 +213,7 @@ async function verifyDossier(dossierFile, trustedKeysFile) {
 }
 
 // Pretty print results
-function printResults(result) {
+function printResults(result: VerifyResult): void {
   console.log('\n🔍 Dossier Verification Report\n');
   console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
   console.log(`File: ${result.dossierFile}`);
@@ -292,10 +322,13 @@ function printResults(result) {
 }
 
 // Main
-async function main() {
+async function main(): Promise<void> {
   const options = parseArgs();
 
-  const result = await verifyDossier(options.dossierFile, options.trustedKeysFile);
+  const result = await verifyDossier(
+    options.dossierFile as string,
+    options.trustedKeysFile as string
+  );
 
   if (options.jsonOutput) {
     console.log(JSON.stringify(result, null, 2));
@@ -314,13 +347,9 @@ async function main() {
 }
 
 // Run
-if (require.main === module) {
-  try {
-    main();
-  } catch (err) {
-    console.error(`\nFatal error: ${err.message}`);
-    process.exit(1);
-  }
-}
+main().catch((err: unknown) => {
+  console.error(`\nFatal error: ${(err as Error).message}`);
+  process.exit(1);
+});
 
-module.exports = { verifyDossier };
+export { verifyDossier };


### PR DESCRIPTION
## Summary
- Migrates all 13 remaining JS source files to TypeScript, completing full type safety across the monorepo
- Adds `cli/tsconfig.json` (compiled) and `tools/tsconfig.json` (noEmit, type-checking only) infrastructure
- Moves `cli/lib/*.js` → `cli/src/*.ts` with compilation to `cli/dist/`, updates bin shim require paths
- Converts `tools/`, `mcp-server/test-*.js`, and `examples/validation/` to TypeScript with proper interfaces and typed imports
- Updates Makefile for CLI build step, adds `tsx` root devDep for tools/examples

Closes #51

## Test plan
- [x] `make rebuild` — full clean build succeeds (core → mcp-server → cli)
- [x] `npm test` — all 55 workspace tests pass
- [x] `cli/bin/dossier --version` — CLI runs correctly with compiled dist/
- [x] `npx tsx tools/verify-dossier.ts --help` — tools run via tsx
- [x] Zero `.js` source files remain outside `node_modules/`, `dist/`, `bin/`
- [x] All 4 tsconfigs have `strict: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)