### PR TITLE
feat: Add dossier lint and format commands

### DIFF
--- a/cli/bin/dossier
+++ b/cli/bin/dossier
@@ -3019,6 +3019,176 @@ keysCmd
   });
 
 // ============================================================================
+// COMMAND: lint (IMPLEMENTED)
+// ============================================================================
+program
+  .command('lint')
+  .description('Lint dossier files for errors and warnings')
+  .argument('[file]', 'Dossier file to lint')
+  .option('--strict', 'Treat warnings as errors')
+  .option('--json', 'Output diagnostics as JSON')
+  .option('--quiet', 'Only show errors (suppress warnings and info)')
+  .option('--config <path>', 'Path to .dossierrc.json config file')
+  .option('--list-rules', 'List all available lint rules and exit')
+  .action((file, options) => {
+    const core = require('@imboard-ai/dossier-core');
+
+    // List rules mode
+    if (options.listRules) {
+      const registry = new core.LintRuleRegistry();
+      registry.registerAll(core.defaultRules);
+      const rules = registry.getRules();
+
+      if (options.json) {
+        console.log(JSON.stringify(rules.map(r => ({
+          id: r.id,
+          description: r.description,
+          defaultSeverity: r.defaultSeverity,
+        })), null, 2));
+      } else {
+        console.log('Available lint rules:\n');
+        for (const rule of rules) {
+          const severity = rule.defaultSeverity.toUpperCase().padEnd(7);
+          console.log(`  ${severity}  ${rule.id}`);
+          console.log(`           ${rule.description}\n`);
+        }
+      }
+      process.exit(0);
+    }
+
+    if (!file) {
+      console.error('Error: missing required argument "file"');
+      process.exit(2);
+    }
+
+    // Load config
+    let lintConfig;
+    if (options.config) {
+      const fs = require('fs');
+      try {
+        const raw = fs.readFileSync(options.config, 'utf8');
+        const parsed = JSON.parse(raw);
+        lintConfig = { rules: parsed.rules || {} };
+      } catch (err) {
+        console.error(`Error loading config: ${err.message}`);
+        process.exit(2);
+      }
+    }
+
+    // Run linter
+    let result;
+    try {
+      result = core.lintDossierFile(file, lintConfig);
+    } catch (err) {
+      console.error(`Error: ${err.message}`);
+      process.exit(2);
+    }
+
+    // Filter diagnostics based on --quiet
+    let diagnostics = result.diagnostics;
+    if (options.quiet) {
+      diagnostics = diagnostics.filter(d => d.severity === 'error');
+    }
+
+    // JSON output
+    if (options.json) {
+      console.log(JSON.stringify({
+        file,
+        diagnostics,
+        errorCount: result.errorCount,
+        warningCount: result.warningCount,
+        infoCount: result.infoCount,
+      }, null, 2));
+    } else {
+      // Human-readable output
+      if (diagnostics.length === 0) {
+        console.log(`${file}: no issues found`);
+      } else {
+        for (const d of diagnostics) {
+          const icon = d.severity === 'error' ? 'x' : d.severity === 'warning' ? '!' : 'i';
+          const field = d.field ? ` (${d.field})` : '';
+          console.log(`  ${icon} ${d.severity.padEnd(7)}  ${d.message}${field}  [${d.ruleId}]`);
+        }
+        console.log(`\n  ${result.errorCount} error(s), ${result.warningCount} warning(s), ${result.infoCount} info`);
+      }
+    }
+
+    // Exit codes: 0 = clean, 1 = warnings only, 2 = errors
+    const effectiveErrors = options.strict
+      ? result.errorCount + result.warningCount
+      : result.errorCount;
+
+    if (effectiveErrors > 0) {
+      process.exit(2);
+    } else if (result.warningCount > 0) {
+      process.exit(1);
+    } else {
+      process.exit(0);
+    }
+  });
+
+// ============================================================================
+// COMMAND: format (IMPLEMENTED)
+// ============================================================================
+program
+  .command('format')
+  .description('Format dossier files')
+  .argument('<file>', 'Dossier file to format')
+  .option('--check', 'Check if file is already formatted (exit 1 if not)')
+  .option('--no-checksum', 'Do not update checksum after formatting')
+  .option('--no-sort-keys', 'Do not sort frontmatter keys')
+  .option('--indent <n>', 'JSON indentation spaces', '2')
+  .option('--json', 'Output result as JSON')
+  .action((file, options) => {
+    const core = require('@imboard-ai/dossier-core');
+    const fs = require('fs');
+
+    const formatOptions = {
+      indent: parseInt(options.indent, 10),
+      sortKeys: options.sortKeys !== false,
+      updateChecksum: options.checksum !== false,
+    };
+
+    try {
+      if (options.check) {
+        // Check mode: read file, format in memory, compare
+        const content = fs.readFileSync(file, 'utf8');
+        const result = core.formatDossierContent(content, formatOptions);
+
+        if (options.json) {
+          console.log(JSON.stringify({ file, formatted: !result.changed }, null, 2));
+        } else {
+          if (result.changed) {
+            console.log(`${file}: needs formatting`);
+          } else {
+            console.log(`${file}: already formatted`);
+          }
+        }
+
+        process.exit(result.changed ? 1 : 0);
+      } else {
+        // Format mode: format file in place
+        const result = core.formatDossierFile(file, formatOptions);
+
+        if (options.json) {
+          console.log(JSON.stringify({ file, changed: result.changed }, null, 2));
+        } else {
+          if (result.changed) {
+            console.log(`${file}: formatted`);
+          } else {
+            console.log(`${file}: already formatted`);
+          }
+        }
+
+        process.exit(0);
+      }
+    } catch (err) {
+      console.error(`Error: ${err.message}`);
+      process.exit(2);
+    }
+  });
+
+// ============================================================================
 // Parse and execute
 // ============================================================================
 program.parse(process.argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,20 +99,6 @@
         "node": ">= 0.6"
       }
     },
-    "mcp-server/node_modules/ajv": {
-      "version": "8.17.1",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "mcp-server/node_modules/ajv-formats": {
       "version": "3.0.1",
       "license": "MIT",
@@ -264,24 +250,6 @@
         "express": ">= 4.11"
       }
     },
-    "mcp-server/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "license": "MIT"
-    },
-    "mcp-server/node_modules/fast-uri": {
-      "version": "3.1.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "mcp-server/node_modules/finalhandler": {
       "version": "2.1.0",
       "license": "MIT",
@@ -346,10 +314,6 @@
     "mcp-server/node_modules/isexe": {
       "version": "2.0.0",
       "license": "ISC"
-    },
-    "mcp-server/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "license": "MIT"
     },
     "mcp-server/node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -427,13 +391,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "mcp-server/node_modules/require-from-string": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "mcp-server/node_modules/router": {
@@ -2997,6 +2954,22 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3259,6 +3232,28 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
@@ -3540,6 +3535,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3765,6 +3766,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -4793,7 +4803,8 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-kms": "^3.927.0"
+        "@aws-sdk/client-kms": "^3.927.0",
+        "ajv": "^8.18.0"
       },
       "devDependencies": {
         "@types/node": "^24.10.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,8 @@
     "registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
-    "@aws-sdk/client-kms": "^3.927.0"
+    "@aws-sdk/client-kms": "^3.927.0",
+    "ajv": "^8.18.0"
   },
   "devDependencies": {
     "@types/node": "^24.10.0",

--- a/packages/core/src/__tests__/formatter.test.ts
+++ b/packages/core/src/__tests__/formatter.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+import { calculateChecksum } from '../checksum';
+import { formatDossierContent } from '../formatter';
+
+function makeDossier(frontmatter: Record<string, unknown>, body = '# Test\n\n## Section\nContent') {
+  const json = JSON.stringify(frontmatter, null, 2);
+  return `---dossier\n${json}\n---\n${body}`;
+}
+
+const baseFrontmatter = {
+  dossier_schema_version: '1.0.0',
+  title: 'Test Dossier',
+  version: '1.0.0',
+  protocol_version: '1.0',
+  status: 'Stable',
+  objective: 'Test formatting',
+  risk_level: 'low',
+  requires_approval: false,
+  checksum: {
+    algorithm: 'sha256',
+    hash: '',
+  },
+};
+
+describe('formatDossierContent', () => {
+  describe('key sorting', () => {
+    it('should sort frontmatter keys in conventional order', () => {
+      const body = '# Test\n\n## Section\nContent';
+      const fm = {
+        version: '1.0.0',
+        title: 'Test',
+        dossier_schema_version: '1.0.0',
+        checksum: { algorithm: 'sha256', hash: calculateChecksum(body) },
+        objective: 'Test formatting',
+        status: 'Stable',
+        protocol_version: '1.0',
+        risk_level: 'low',
+        requires_approval: false,
+      };
+      const content = makeDossier(fm, body);
+      const result = formatDossierContent(content);
+
+      // Parse the formatted output to check key order
+      const match = result.formatted.match(/^---dossier\n([\s\S]*?)\n---/);
+      const formatted = JSON.parse(match![1]);
+      const keys = Object.keys(formatted);
+
+      // dossier_schema_version should be first
+      expect(keys[0]).toBe('dossier_schema_version');
+      // title before version
+      expect(keys.indexOf('title')).toBeLessThan(keys.indexOf('version'));
+      // checksum should be last
+      expect(keys[keys.length - 1]).toBe('checksum');
+    });
+
+    it('should not sort keys when sortKeys is false', () => {
+      const body = '# Test\n\n## Section\nContent';
+      const fm = {
+        version: '1.0.0',
+        title: 'Test',
+        checksum: { algorithm: 'sha256', hash: calculateChecksum(body) },
+      };
+      const content = makeDossier(fm, body);
+      const result = formatDossierContent(content, { sortKeys: false });
+
+      const match = result.formatted.match(/^---dossier\n([\s\S]*?)\n---/);
+      const formatted = JSON.parse(match![1]);
+      const keys = Object.keys(formatted);
+
+      expect(keys[0]).toBe('version');
+      expect(keys[1]).toBe('title');
+    });
+  });
+
+  describe('indentation', () => {
+    it('should use 2-space indent by default', () => {
+      const body = '# Test\n\n## Section\nContent';
+      const content = makeDossier(
+        { title: 'Test', checksum: { algorithm: 'sha256', hash: calculateChecksum(body) } },
+        body
+      );
+      const result = formatDossierContent(content);
+      expect(result.formatted).toContain('  "title"');
+    });
+
+    it('should respect custom indent', () => {
+      const body = '# Test\n\n## Section\nContent';
+      const content = makeDossier(
+        { title: 'Test', checksum: { algorithm: 'sha256', hash: calculateChecksum(body) } },
+        body
+      );
+      const result = formatDossierContent(content, { indent: 4 });
+      expect(result.formatted).toContain('    "title"');
+    });
+  });
+
+  describe('trailing whitespace', () => {
+    it('should trim trailing whitespace from body lines', () => {
+      const body = '# Test   \n\n## Section  \nContent   ';
+      const content = makeDossier(baseFrontmatter, body);
+      const result = formatDossierContent(content);
+
+      // Extract the body from the formatted output
+      const parts = result.formatted.split('---\n');
+      const formattedBody = parts[parts.length - 1];
+
+      expect(formattedBody).not.toMatch(/[ \t]+\n/);
+      expect(formattedBody).toContain('# Test\n');
+      expect(formattedBody).toContain('## Section\n');
+    });
+  });
+
+  describe('final newline', () => {
+    it('should ensure file ends with newline', () => {
+      const body = '# Test\n\n## Section\nContent';
+      const content = `---dossier\n${JSON.stringify(baseFrontmatter, null, 2)}\n---\n${body}`;
+      const result = formatDossierContent(content);
+      expect(result.formatted.endsWith('\n')).toBe(true);
+    });
+  });
+
+  describe('checksum update', () => {
+    it('should update checksum after formatting', () => {
+      const body = '# Test\n\n## Section\nContent';
+      const fm = {
+        ...baseFrontmatter,
+        checksum: {
+          algorithm: 'sha256',
+          hash: 'oldhash0000000000000000000000000000000000000000000000000000000000',
+        },
+      };
+      const content = makeDossier(fm, body);
+      const result = formatDossierContent(content);
+
+      const match = result.formatted.match(/^---dossier\n([\s\S]*?)\n---/);
+      const formatted = JSON.parse(match![1]);
+      const expectedHash = calculateChecksum(body);
+      expect(formatted.checksum.hash).toBe(expectedHash);
+    });
+
+    it('should not update checksum when disabled', () => {
+      const body = '# Test\n\n## Section\nContent';
+      const oldHash = 'oldhash0000000000000000000000000000000000000000000000000000000000';
+      const fm = {
+        ...baseFrontmatter,
+        checksum: { algorithm: 'sha256', hash: oldHash },
+      };
+      const content = makeDossier(fm, body);
+      const result = formatDossierContent(content, { updateChecksum: false });
+
+      const match = result.formatted.match(/^---dossier\n([\s\S]*?)\n---/);
+      const formatted = JSON.parse(match![1]);
+      expect(formatted.checksum.hash).toBe(oldHash);
+    });
+  });
+
+  describe('changed detection', () => {
+    it('should report changed=false when content is already formatted', () => {
+      const body = '# Test\n\n## Section\nContent';
+      const fm = {
+        ...baseFrontmatter,
+        checksum: { algorithm: 'sha256', hash: calculateChecksum(body) },
+      };
+      const content = makeDossier(fm, body);
+      // Format once to get canonical form
+      const first = formatDossierContent(content);
+      // Format again — should be unchanged
+      const second = formatDossierContent(first.formatted);
+      expect(second.changed).toBe(false);
+    });
+
+    it('should report changed=true when content needs formatting', () => {
+      const body = '# Test   \n\n## Section\nContent';
+      const content = makeDossier(baseFrontmatter, body);
+      const result = formatDossierContent(content);
+      expect(result.changed).toBe(true);
+    });
+  });
+
+  describe('unknown keys', () => {
+    it('should place unknown keys alphabetically but before checksum/signature', () => {
+      const body = '# Test\n\n## Section\nContent';
+      const fm = {
+        title: 'Test',
+        dossier_schema_version: '1.0.0',
+        custom_field_b: 'b',
+        custom_field_a: 'a',
+        checksum: { algorithm: 'sha256', hash: calculateChecksum(body) },
+      };
+      const content = makeDossier(fm, body);
+      const result = formatDossierContent(content);
+
+      const match = result.formatted.match(/^---dossier\n([\s\S]*?)\n---/);
+      const formatted = JSON.parse(match![1]);
+      const keys = Object.keys(formatted);
+
+      const aIdx = keys.indexOf('custom_field_a');
+      const bIdx = keys.indexOf('custom_field_b');
+      const checksumIdx = keys.indexOf('checksum');
+
+      // custom_field_a before custom_field_b (alphabetical)
+      expect(aIdx).toBeLessThan(bIdx);
+      // Both before checksum
+      expect(bIdx).toBeLessThan(checksumIdx);
+    });
+  });
+});

--- a/packages/core/src/__tests__/linter.test.ts
+++ b/packages/core/src/__tests__/linter.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from 'vitest';
+import { calculateChecksum } from '../checksum';
+import type { LintConfig } from '../linter';
+import { lintDossier } from '../linter';
+
+function makeDossier(frontmatter: Record<string, unknown>, body = '# Test\n\n## Section\nContent') {
+  const json = JSON.stringify(frontmatter, null, 2);
+  return `---dossier\n${json}\n---\n${body}`;
+}
+
+const validFrontmatter = {
+  dossier_schema_version: '1.0.0',
+  title: 'Test Dossier',
+  version: '1.0.0',
+  protocol_version: '1.0',
+  status: 'Stable',
+  objective: 'Simple test dossier for verifying lint rules work correctly',
+  risk_level: 'low',
+  risk_factors: [],
+  requires_approval: false,
+  destructive_operations: [],
+  checksum: {
+    algorithm: 'sha256',
+    hash: '', // Will be filled by helper
+  },
+};
+
+function makeValidDossier(overrides: Record<string, unknown> = {}, body?: string) {
+  const fm = { ...validFrontmatter, ...overrides };
+  const content = body ?? '# Test\n\n## Section\nContent';
+  if (fm.checksum && typeof fm.checksum === 'object') {
+    (fm.checksum as any).hash = calculateChecksum(content);
+  }
+  return makeDossier(fm, content);
+}
+
+describe('lintDossier', () => {
+  describe('schema-valid rule', () => {
+    it('should pass for valid frontmatter', () => {
+      const content = makeValidDossier();
+      const result = lintDossier(content);
+      const schemaErrors = result.diagnostics.filter((d) => d.ruleId === 'schema-valid');
+      expect(schemaErrors).toHaveLength(0);
+    });
+
+    it('should detect missing required fields', () => {
+      const content = makeDossier({ title: 'Incomplete' });
+      const result = lintDossier(content);
+      const schemaErrors = result.diagnostics.filter((d) => d.ruleId === 'schema-valid');
+      expect(schemaErrors.length).toBeGreaterThan(0);
+      expect(schemaErrors.some((d) => d.message.includes('dossier_schema_version'))).toBe(true);
+    });
+
+    it('should detect invalid status enum', () => {
+      const content = makeValidDossier({ status: 'invalid' });
+      const result = lintDossier(content);
+      const schemaErrors = result.diagnostics.filter((d) => d.ruleId === 'schema-valid');
+      expect(schemaErrors.some((d) => d.message.includes('status'))).toBe(true);
+    });
+
+    it('should accept valid schema-compliant status values', () => {
+      for (const status of ['Draft', 'Stable', 'Deprecated', 'Experimental']) {
+        const content = makeValidDossier({ status });
+        const result = lintDossier(content);
+        const schemaErrors = result.diagnostics.filter((d) => d.ruleId === 'schema-valid');
+        expect(schemaErrors).toHaveLength(0);
+      }
+    });
+  });
+
+  describe('checksum-valid rule', () => {
+    it('should pass when checksum matches', () => {
+      const content = makeValidDossier();
+      const result = lintDossier(content);
+      const checksumErrors = result.diagnostics.filter((d) => d.ruleId === 'checksum-valid');
+      expect(checksumErrors).toHaveLength(0);
+    });
+
+    it('should fail when checksum mismatches', () => {
+      const fm = {
+        ...validFrontmatter,
+        checksum: {
+          algorithm: 'sha256',
+          hash: 'badbad0000000000000000000000000000000000000000000000000000000000',
+        },
+      };
+      const content = makeDossier(fm);
+      const result = lintDossier(content);
+      const checksumErrors = result.diagnostics.filter((d) => d.ruleId === 'checksum-valid');
+      expect(checksumErrors).toHaveLength(1);
+      expect(checksumErrors[0].message).toContain('Checksum mismatch');
+    });
+
+    it('should fail when checksum is missing', () => {
+      const fm = { ...validFrontmatter };
+      delete (fm as any).checksum;
+      const content = makeDossier(fm);
+      const result = lintDossier(content);
+      const checksumErrors = result.diagnostics.filter((d) => d.ruleId === 'checksum-valid');
+      expect(checksumErrors.some((d) => d.message.includes('Missing checksum'))).toBe(true);
+    });
+  });
+
+  describe('semver-version rule', () => {
+    it('should pass for valid semver', () => {
+      const content = makeValidDossier({ version: '1.2.3' });
+      const result = lintDossier(content);
+      const semverErrors = result.diagnostics.filter((d) => d.ruleId === 'semver-version');
+      expect(semverErrors).toHaveLength(0);
+    });
+
+    it('should pass for semver with prerelease', () => {
+      const content = makeValidDossier({ version: '1.0.0-beta.1' });
+      const result = lintDossier(content);
+      const semverErrors = result.diagnostics.filter((d) => d.ruleId === 'semver-version');
+      expect(semverErrors).toHaveLength(0);
+    });
+
+    it('should fail for invalid semver', () => {
+      const content = makeValidDossier({ version: 'not-semver' });
+      const result = lintDossier(content);
+      const semverErrors = result.diagnostics.filter((d) => d.ruleId === 'semver-version');
+      expect(semverErrors).toHaveLength(1);
+      expect(semverErrors[0].message).toContain('Invalid semver');
+    });
+  });
+
+  describe('risk-level-consistency rule', () => {
+    it('should warn when low risk has destructive operations', () => {
+      const content = makeValidDossier({
+        risk_level: 'low',
+        destructive_operations: ['Deletes all data'],
+      });
+      const result = lintDossier(content);
+      const riskWarnings = result.diagnostics.filter((d) => d.ruleId === 'risk-level-consistency');
+      expect(riskWarnings).toHaveLength(1);
+      expect(riskWarnings[0].severity).toBe('warning');
+    });
+
+    it('should not warn when low risk has no destructive operations', () => {
+      const content = makeValidDossier({
+        risk_level: 'low',
+        destructive_operations: [],
+      });
+      const result = lintDossier(content);
+      const riskWarnings = result.diagnostics.filter((d) => d.ruleId === 'risk-level-consistency');
+      expect(riskWarnings).toHaveLength(0);
+    });
+
+    it('should not warn when high risk has destructive operations', () => {
+      const content = makeValidDossier({
+        risk_level: 'high',
+        destructive_operations: ['Deletes all data'],
+      });
+      const result = lintDossier(content);
+      const riskWarnings = result.diagnostics.filter((d) => d.ruleId === 'risk-level-consistency');
+      expect(riskWarnings).toHaveLength(0);
+    });
+  });
+
+  describe('tools-check-command rule', () => {
+    it('should warn when tool has no check_command', () => {
+      const content = makeValidDossier({
+        tools_required: [{ name: 'docker' }],
+      });
+      const result = lintDossier(content);
+      const toolWarnings = result.diagnostics.filter((d) => d.ruleId === 'tools-check-command');
+      expect(toolWarnings).toHaveLength(1);
+      expect(toolWarnings[0].message).toContain('docker');
+    });
+
+    it('should not warn when tool has check_command', () => {
+      const content = makeValidDossier({
+        tools_required: [{ name: 'docker', check_command: 'docker --version' }],
+      });
+      const result = lintDossier(content);
+      const toolWarnings = result.diagnostics.filter((d) => d.ruleId === 'tools-check-command');
+      expect(toolWarnings).toHaveLength(0);
+    });
+
+    it('should not warn when no tools_required', () => {
+      const content = makeValidDossier();
+      const result = lintDossier(content);
+      const toolWarnings = result.diagnostics.filter((d) => d.ruleId === 'tools-check-command');
+      expect(toolWarnings).toHaveLength(0);
+    });
+  });
+
+  describe('objective-quality rule', () => {
+    it('should info when objective is too short', () => {
+      const content = makeValidDossier({ objective: 'Short obj.' }); // 10 chars, meets schema min
+      const result = lintDossier(content);
+      const objInfo = result.diagnostics.filter((d) => d.ruleId === 'objective-quality');
+      expect(objInfo.some((d) => d.message.includes('very short'))).toBe(true);
+    });
+
+    it('should info when objective starts with non-verb', () => {
+      const content = makeValidDossier({
+        objective: 'This is a test objective that describes something',
+      });
+      const result = lintDossier(content);
+      const objInfo = result.diagnostics.filter((d) => d.ruleId === 'objective-quality');
+      expect(objInfo.some((d) => d.message.includes('start with a verb'))).toBe(true);
+    });
+
+    it('should not warn for good objectives', () => {
+      const content = makeValidDossier({
+        objective: 'Configure the application for production deployment',
+      });
+      const result = lintDossier(content);
+      const objInfo = result.diagnostics.filter((d) => d.ruleId === 'objective-quality');
+      expect(objInfo).toHaveLength(0);
+    });
+  });
+
+  describe('required-sections rule', () => {
+    it('should warn when body is empty', () => {
+      const content = makeValidDossier({}, '');
+      const result = lintDossier(content);
+      const sectionWarnings = result.diagnostics.filter((d) => d.ruleId === 'required-sections');
+      expect(sectionWarnings).toHaveLength(1);
+      expect(sectionWarnings[0].message).toContain('empty');
+    });
+
+    it('should warn when body has no ## headings', () => {
+      const content = makeValidDossier({}, 'Just some text without headings');
+      const result = lintDossier(content);
+      const sectionWarnings = result.diagnostics.filter((d) => d.ruleId === 'required-sections');
+      expect(sectionWarnings).toHaveLength(1);
+      expect(sectionWarnings[0].message).toContain('no ## headings');
+    });
+
+    it('should pass when body has ## headings', () => {
+      const content = makeValidDossier({}, '# Title\n\n## Section\nContent');
+      const result = lintDossier(content);
+      const sectionWarnings = result.diagnostics.filter((d) => d.ruleId === 'required-sections');
+      expect(sectionWarnings).toHaveLength(0);
+    });
+  });
+
+  describe('config overrides', () => {
+    it('should disable rules when set to off', () => {
+      const fm = { ...validFrontmatter };
+      delete (fm as any).checksum;
+      const content = makeDossier(fm);
+      const config: LintConfig = { rules: { 'checksum-valid': 'off' } };
+      const result = lintDossier(content, config);
+      const checksumErrors = result.diagnostics.filter((d) => d.ruleId === 'checksum-valid');
+      expect(checksumErrors).toHaveLength(0);
+    });
+
+    it('should escalate severity when configured', () => {
+      const content = makeValidDossier({
+        tools_required: [{ name: 'docker' }],
+      });
+      const config: LintConfig = { rules: { 'tools-check-command': 'error' } };
+      const result = lintDossier(content, config);
+      const toolErrors = result.diagnostics.filter((d) => d.ruleId === 'tools-check-command');
+      expect(toolErrors).toHaveLength(1);
+      expect(toolErrors[0].severity).toBe('error');
+    });
+  });
+
+  describe('result counts', () => {
+    it('should correctly count errors, warnings, and info', () => {
+      const content = makeValidDossier({
+        objective: 'This is a test objective that describes something',
+        tools_required: [{ name: 'docker' }],
+      });
+      const result = lintDossier(content);
+      expect(result.errorCount).toBe(0);
+      expect(result.warningCount).toBeGreaterThanOrEqual(1); // tools-check-command
+      expect(result.infoCount).toBeGreaterThanOrEqual(1); // objective-quality
+    });
+  });
+});

--- a/packages/core/src/formatter/formatter.ts
+++ b/packages/core/src/formatter/formatter.ts
@@ -1,0 +1,138 @@
+import { calculateChecksum } from '../checksum';
+import { parseDossierContent } from '../parser';
+import type { FormatOptions, FormatResult } from './types';
+import { defaultFormatOptions } from './types';
+
+/**
+ * Conventional key ordering for dossier frontmatter.
+ * Keys not in this list are sorted alphabetically after the known keys.
+ * checksum and signature are always last.
+ */
+const KEY_ORDER: string[] = [
+  'dossier_schema_version',
+  'title',
+  'version',
+  'protocol_version',
+  'status',
+  'last_updated',
+  'objective',
+  'category',
+  'tags',
+  'tools_required',
+  'estimated_duration',
+  'risk_level',
+  'risk_factors',
+  'requires_approval',
+  'destructive_operations',
+  'prerequisites',
+  'inputs',
+  'outputs',
+  'relationships',
+  'coupling',
+  'validation',
+  'rollback',
+  'authors',
+  'license',
+  'homepage',
+  'repository',
+  'custom',
+  'mcp_integration',
+  // Always last:
+  'checksum',
+  'signature',
+];
+
+function sortFrontmatterKeys(frontmatter: Record<string, unknown>): Record<string, unknown> {
+  const sorted: Record<string, unknown> = {};
+  const knownSet = new Set(KEY_ORDER);
+
+  // Add known keys in order
+  for (const key of KEY_ORDER) {
+    if (key in frontmatter) {
+      sorted[key] = frontmatter[key];
+    }
+  }
+
+  // Add unknown keys alphabetically
+  const unknownKeys = Object.keys(frontmatter)
+    .filter((k) => !knownSet.has(k))
+    .sort();
+  for (const key of unknownKeys) {
+    // Insert before checksum/signature
+    sorted[key] = frontmatter[key];
+  }
+
+  // If we added unknown keys, we need to re-order to ensure checksum/signature are last
+  if (unknownKeys.length > 0) {
+    const result: Record<string, unknown> = {};
+    const tailKeys = ['checksum', 'signature'];
+
+    for (const [k, v] of Object.entries(sorted)) {
+      if (!tailKeys.includes(k)) {
+        result[k] = v;
+      }
+    }
+    for (const k of tailKeys) {
+      if (k in sorted) {
+        result[k] = sorted[k];
+      }
+    }
+    return result;
+  }
+
+  return sorted;
+}
+
+function trimTrailingWhitespace(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .join('\n');
+}
+
+function ensureFinalNewline(text: string): string {
+  if (!text.endsWith('\n')) {
+    return `${text}\n`;
+  }
+  return text;
+}
+
+export function formatDossierContent(
+  content: string,
+  options?: Partial<FormatOptions>
+): FormatResult {
+  const opts: FormatOptions = { ...defaultFormatOptions, ...options };
+  const parsed = parseDossierContent(content);
+
+  let frontmatter: Record<string, unknown> = parsed.frontmatter as Record<string, unknown>;
+
+  if (opts.sortKeys) {
+    frontmatter = sortFrontmatterKeys(frontmatter);
+  }
+
+  // Normalize body: trim trailing whitespace per line, then trim trailing newlines from body
+  const body = trimTrailingWhitespace(parsed.body).replace(/\n+$/, '');
+
+  // Update checksum if enabled
+  if (opts.updateChecksum && frontmatter.checksum) {
+    const checksumObj = frontmatter.checksum as Record<string, unknown>;
+    if (checksumObj && typeof checksumObj === 'object') {
+      const newHash = calculateChecksum(body);
+      frontmatter.checksum = { ...checksumObj, hash: newHash };
+    }
+  }
+
+  // Serialize frontmatter with controlled indentation
+  const jsonStr = JSON.stringify(frontmatter, null, opts.indent);
+
+  // Build the formatted output
+  let result = `---dossier\n${jsonStr}\n---\n${body}`;
+
+  // Ensure final newline
+  result = ensureFinalNewline(result);
+
+  return {
+    formatted: result,
+    changed: result !== content,
+  };
+}

--- a/packages/core/src/formatter/index.ts
+++ b/packages/core/src/formatter/index.ts
@@ -1,0 +1,20 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { formatDossierContent } from './formatter';
+import type { FormatOptions, FormatResult } from './types';
+
+export { formatDossierContent } from './formatter';
+export * from './types';
+
+export function formatDossierFile(
+  filePath: string,
+  options?: Partial<FormatOptions>
+): FormatResult {
+  const content = readFileSync(filePath, 'utf8');
+  const result = formatDossierContent(content, options);
+
+  if (result.changed) {
+    writeFileSync(filePath, result.formatted, 'utf8');
+  }
+
+  return result;
+}

--- a/packages/core/src/formatter/types.ts
+++ b/packages/core/src/formatter/types.ts
@@ -1,0 +1,16 @@
+export interface FormatOptions {
+  indent: number;
+  sortKeys: boolean;
+  updateChecksum: boolean;
+}
+
+export interface FormatResult {
+  formatted: string;
+  changed: boolean;
+}
+
+export const defaultFormatOptions: FormatOptions = {
+  indent: 2,
+  sortKeys: true,
+  updateChecksum: true,
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,26 @@
 
 // Checksum exports
 export { calculateChecksum, verifyIntegrity } from './checksum';
-
+export type { FormatOptions, FormatResult } from './formatter';
+// Formatter exports
+export { formatDossierContent, formatDossierFile } from './formatter';
+export type {
+  LintConfig,
+  LintDiagnostic,
+  LintResult,
+  LintRule,
+  LintRuleContext,
+  LintSeverity,
+  RuleSeverityOverride,
+} from './linter';
+// Linter exports
+export {
+  defaultRules,
+  LintRuleRegistry,
+  lintDossier,
+  lintDossierFile,
+  loadLintConfig,
+} from './linter';
 // Parser exports
 export { parseDossierContent, parseDossierFile, validateFrontmatter } from './parser';
 // Signature exports

--- a/packages/core/src/linter/config.ts
+++ b/packages/core/src/linter/config.ts
@@ -1,0 +1,43 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import type { LintConfig } from './types';
+
+const CONFIG_FILENAME = '.dossierrc.json';
+
+export const defaultConfig: LintConfig = {
+  rules: {},
+};
+
+export function loadLintConfig(startDir?: string): LintConfig {
+  const configPath = findConfigFile(startDir || process.cwd());
+  if (!configPath) {
+    return { ...defaultConfig };
+  }
+
+  try {
+    const raw = readFileSync(configPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    return {
+      rules: parsed.rules || {},
+    };
+  } catch {
+    return { ...defaultConfig };
+  }
+}
+
+function findConfigFile(startDir: string): string | null {
+  let dir = resolve(startDir);
+  const root = resolve('/');
+
+  while (true) {
+    const candidate = join(dir, CONFIG_FILENAME);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = dirname(dir);
+    if (parent === dir || dir === root) {
+      return null;
+    }
+    dir = parent;
+  }
+}

--- a/packages/core/src/linter/index.ts
+++ b/packages/core/src/linter/index.ts
@@ -1,0 +1,56 @@
+import { parseDossierContent, parseDossierFile } from '../parser';
+import { loadLintConfig } from './config';
+import { LintRuleRegistry } from './registry';
+import { defaultRules } from './rules';
+import type { LintConfig, LintDiagnostic, LintResult, LintRuleContext } from './types';
+
+export { loadLintConfig } from './config';
+export { LintRuleRegistry } from './registry';
+export { defaultRules } from './rules';
+export * from './types';
+
+function createRegistry(): LintRuleRegistry {
+  const registry = new LintRuleRegistry();
+  registry.registerAll(defaultRules);
+  return registry;
+}
+
+function buildResult(diagnostics: LintDiagnostic[], file?: string): LintResult {
+  return {
+    file,
+    diagnostics,
+    errorCount: diagnostics.filter((d) => d.severity === 'error').length,
+    warningCount: diagnostics.filter((d) => d.severity === 'warning').length,
+    infoCount: diagnostics.filter((d) => d.severity === 'info').length,
+  };
+}
+
+export function lintDossier(content: string, config?: LintConfig): LintResult {
+  const parsed = parseDossierContent(content);
+  const resolvedConfig = config || loadLintConfig();
+  const registry = createRegistry();
+
+  const context: LintRuleContext = {
+    frontmatter: parsed.frontmatter,
+    body: parsed.body,
+    raw: parsed.raw,
+  };
+
+  const diagnostics = registry.run(context, resolvedConfig);
+  return buildResult(diagnostics);
+}
+
+export function lintDossierFile(filePath: string, config?: LintConfig): LintResult {
+  const parsed = parseDossierFile(filePath);
+  const resolvedConfig = config || loadLintConfig();
+  const registry = createRegistry();
+
+  const context: LintRuleContext = {
+    frontmatter: parsed.frontmatter,
+    body: parsed.body,
+    raw: parsed.raw,
+  };
+
+  const diagnostics = registry.run(context, resolvedConfig);
+  return buildResult(diagnostics, filePath);
+}

--- a/packages/core/src/linter/registry.ts
+++ b/packages/core/src/linter/registry.ts
@@ -1,0 +1,52 @@
+import type {
+  LintConfig,
+  LintDiagnostic,
+  LintRule,
+  LintRuleContext,
+  LintSeverity,
+  RuleSeverityOverride,
+} from './types';
+
+export class LintRuleRegistry {
+  private rules: Map<string, LintRule> = new Map();
+
+  register(rule: LintRule): void {
+    this.rules.set(rule.id, rule);
+  }
+
+  registerAll(rules: LintRule[]): void {
+    for (const rule of rules) {
+      this.register(rule);
+    }
+  }
+
+  getRules(): LintRule[] {
+    return Array.from(this.rules.values());
+  }
+
+  getRule(id: string): LintRule | undefined {
+    return this.rules.get(id);
+  }
+
+  run(context: LintRuleContext, config: LintConfig): LintDiagnostic[] {
+    const diagnostics: LintDiagnostic[] = [];
+
+    for (const rule of this.rules.values()) {
+      const override: RuleSeverityOverride | undefined = config.rules[rule.id];
+
+      if (override === 'off') {
+        continue;
+      }
+
+      const severity: LintSeverity = override ? (override as LintSeverity) : rule.defaultSeverity;
+
+      const ruleDiagnostics = rule.run(context);
+
+      for (const d of ruleDiagnostics) {
+        diagnostics.push({ ...d, severity });
+      }
+    }
+
+    return diagnostics;
+  }
+}

--- a/packages/core/src/linter/rules/checksum-valid.ts
+++ b/packages/core/src/linter/rules/checksum-valid.ts
@@ -1,0 +1,48 @@
+import { calculateChecksum } from '../../checksum';
+import type { LintRule } from '../types';
+
+export const checksumValidRule: LintRule = {
+  id: 'checksum-valid',
+  description: 'Verify checksum hash matches body content',
+  defaultSeverity: 'error',
+  run(context) {
+    const checksum = context.frontmatter.checksum;
+
+    if (!checksum) {
+      return [
+        {
+          ruleId: 'checksum-valid',
+          severity: 'error',
+          message: 'Missing checksum field in frontmatter',
+          field: 'checksum',
+        },
+      ];
+    }
+
+    const checksumObj = checksum as { algorithm?: string; hash?: string };
+    if (!checksumObj.hash) {
+      return [
+        {
+          ruleId: 'checksum-valid',
+          severity: 'error',
+          message: 'Checksum object missing hash field',
+          field: 'checksum.hash',
+        },
+      ];
+    }
+
+    const actualHash = calculateChecksum(context.body);
+    if (actualHash !== checksumObj.hash) {
+      return [
+        {
+          ruleId: 'checksum-valid',
+          severity: 'error',
+          message: `Checksum mismatch: expected ${checksumObj.hash.slice(0, 16)}..., got ${actualHash.slice(0, 16)}...`,
+          field: 'checksum.hash',
+        },
+      ];
+    }
+
+    return [];
+  },
+};

--- a/packages/core/src/linter/rules/index.ts
+++ b/packages/core/src/linter/rules/index.ts
@@ -1,0 +1,28 @@
+import type { LintRule } from '../types';
+import { checksumValidRule } from './checksum-valid';
+import { objectiveQualityRule } from './objective-quality';
+import { requiredSectionsRule } from './required-sections';
+import { riskLevelConsistencyRule } from './risk-level-consistency';
+import { schemaValidRule } from './schema-valid';
+import { semverVersionRule } from './semver-version';
+import { toolsCheckCommandRule } from './tools-check-command';
+
+export {
+  checksumValidRule,
+  objectiveQualityRule,
+  requiredSectionsRule,
+  riskLevelConsistencyRule,
+  schemaValidRule,
+  semverVersionRule,
+  toolsCheckCommandRule,
+};
+
+export const defaultRules: LintRule[] = [
+  schemaValidRule,
+  checksumValidRule,
+  semverVersionRule,
+  riskLevelConsistencyRule,
+  toolsCheckCommandRule,
+  objectiveQualityRule,
+  requiredSectionsRule,
+];

--- a/packages/core/src/linter/rules/objective-quality.ts
+++ b/packages/core/src/linter/rules/objective-quality.ts
@@ -1,0 +1,48 @@
+import type { LintRule } from '../types';
+
+export const objectiveQualityRule: LintRule = {
+  id: 'objective-quality',
+  description: 'Objective should be a clear, concise statement',
+  defaultSeverity: 'info',
+  run(context) {
+    const objective = context.frontmatter.objective;
+    const diagnostics = [];
+
+    if (!objective) {
+      return [];
+    }
+
+    if (objective.length < 20) {
+      diagnostics.push({
+        ruleId: 'objective-quality',
+        severity: 'info' as const,
+        message: `Objective is very short (${objective.length} chars) — consider being more descriptive`,
+        field: 'objective',
+      });
+    }
+
+    if (objective.length > 300) {
+      diagnostics.push({
+        ruleId: 'objective-quality',
+        severity: 'info' as const,
+        message: `Objective is very long (${objective.length} chars) — consider being more concise (1-3 sentences)`,
+        field: 'objective',
+      });
+    }
+
+    // Check if objective starts with a verb (common best practice)
+    const firstWord = objective.split(/\s+/)[0]?.toLowerCase();
+    const commonNonVerbs = ['the', 'this', 'a', 'an', 'it', 'my'];
+    if (firstWord && commonNonVerbs.includes(firstWord)) {
+      diagnostics.push({
+        ruleId: 'objective-quality',
+        severity: 'info' as const,
+        message:
+          'Objective should start with a verb (e.g., "Configure...", "Deploy...", "Set up...")',
+        field: 'objective',
+      });
+    }
+
+    return diagnostics;
+  },
+};

--- a/packages/core/src/linter/rules/required-sections.ts
+++ b/packages/core/src/linter/rules/required-sections.ts
@@ -1,0 +1,33 @@
+import type { LintRule } from '../types';
+
+export const requiredSectionsRule: LintRule = {
+  id: 'required-sections',
+  description: 'Markdown body should contain at least one ## heading',
+  defaultSeverity: 'warning',
+  run(context) {
+    const body = context.body;
+
+    if (!body || body.trim().length === 0) {
+      return [
+        {
+          ruleId: 'required-sections',
+          severity: 'warning',
+          message: 'Dossier body is empty — add markdown content with ## sections',
+        },
+      ];
+    }
+
+    const headingRegex = /^##\s+.+/m;
+    if (!headingRegex.test(body)) {
+      return [
+        {
+          ruleId: 'required-sections',
+          severity: 'warning',
+          message: 'Dossier body has no ## headings — add sections to organize content',
+        },
+      ];
+    }
+
+    return [];
+  },
+};

--- a/packages/core/src/linter/rules/risk-level-consistency.ts
+++ b/packages/core/src/linter/rules/risk-level-consistency.ts
@@ -1,0 +1,26 @@
+import type { LintRule } from '../types';
+
+export const riskLevelConsistencyRule: LintRule = {
+  id: 'risk-level-consistency',
+  description: 'Risk level should be consistent with destructive operations',
+  defaultSeverity: 'warning',
+  run(context) {
+    const { risk_level, destructive_operations } = context.frontmatter;
+    const diagnostics = [];
+
+    if (
+      risk_level === 'low' &&
+      Array.isArray(destructive_operations) &&
+      destructive_operations.length > 0
+    ) {
+      diagnostics.push({
+        ruleId: 'risk-level-consistency',
+        severity: 'warning' as const,
+        message: `risk_level is "low" but ${destructive_operations.length} destructive operation(s) declared — consider "medium" or higher`,
+        field: 'risk_level',
+      });
+    }
+
+    return diagnostics;
+  },
+};

--- a/packages/core/src/linter/rules/schema-valid.ts
+++ b/packages/core/src/linter/rules/schema-valid.ts
@@ -1,0 +1,57 @@
+import Ajv from 'ajv';
+import dossierSchema from '../../schema/dossier-schema.json';
+import type { LintRule } from '../types';
+
+const ajv = new Ajv({ allErrors: true, strict: false, validateFormats: false });
+const validate = ajv.compile(dossierSchema);
+
+export const schemaValidRule: LintRule = {
+  id: 'schema-valid',
+  description: 'Validate frontmatter against the full JSON Schema',
+  defaultSeverity: 'error',
+  run(context) {
+    const valid = validate(context.frontmatter);
+    if (valid) {
+      return [];
+    }
+
+    return (validate.errors || []).map((err) => {
+      const path = err.instancePath || '';
+      const field = path.replace(/^\//, '').replace(/\//g, '.');
+
+      // Simplify oneOf errors for signature field
+      if (err.keyword === 'oneOf' && field === 'signature') {
+        return {
+          ruleId: 'schema-valid',
+          severity: 'error',
+          message: 'signature must match either AWS KMS (ecdsa-sha256) or Ed25519 format',
+          field: 'signature',
+        };
+      }
+
+      let message: string;
+      if (err.keyword === 'required') {
+        message = `Missing required field: ${err.params.missingProperty}`;
+      } else if (err.keyword === 'enum') {
+        message = `${field || 'value'} must be one of: ${err.params.allowedValues.join(', ')}`;
+      } else if (err.keyword === 'const') {
+        message = `${field || 'value'} must be ${JSON.stringify(err.params.allowedValue)}`;
+      } else if (err.keyword === 'minLength') {
+        message = `${field || 'value'} is too short (minimum ${err.params.limit} characters)`;
+      } else if (err.keyword === 'maxLength') {
+        message = `${field || 'value'} is too long (maximum ${err.params.limit} characters)`;
+      } else if (err.keyword === 'pattern') {
+        message = `${field || 'value'} does not match expected pattern`;
+      } else {
+        message = `${field || 'value'}: ${err.message}`;
+      }
+
+      return {
+        ruleId: 'schema-valid',
+        severity: 'error' as const,
+        message,
+        field: field || undefined,
+      };
+    });
+  },
+};

--- a/packages/core/src/linter/rules/semver-version.ts
+++ b/packages/core/src/linter/rules/semver-version.ts
@@ -1,0 +1,36 @@
+import type { LintRule } from '../types';
+
+const SEMVER_REGEX = /^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/;
+
+export const semverVersionRule: LintRule = {
+  id: 'semver-version',
+  description: 'Version field must be valid semver',
+  defaultSeverity: 'error',
+  run(context) {
+    const version = context.frontmatter.version;
+
+    if (!version) {
+      return [
+        {
+          ruleId: 'semver-version',
+          severity: 'error',
+          message: 'Missing version field',
+          field: 'version',
+        },
+      ];
+    }
+
+    if (!SEMVER_REGEX.test(version)) {
+      return [
+        {
+          ruleId: 'semver-version',
+          severity: 'error',
+          message: `Invalid semver version: "${version}"`,
+          field: 'version',
+        },
+      ];
+    }
+
+    return [];
+  },
+};

--- a/packages/core/src/linter/rules/tools-check-command.ts
+++ b/packages/core/src/linter/rules/tools-check-command.ts
@@ -1,0 +1,34 @@
+import type { LintRule } from '../types';
+
+interface ToolRequired {
+  name: string;
+  check_command?: string;
+}
+
+export const toolsCheckCommandRule: LintRule = {
+  id: 'tools-check-command',
+  description: 'tools_required entries should have a check_command',
+  defaultSeverity: 'warning',
+  run(context) {
+    const tools = context.frontmatter.tools_required as ToolRequired[] | undefined;
+
+    if (!Array.isArray(tools) || tools.length === 0) {
+      return [];
+    }
+
+    const diagnostics = [];
+
+    for (const tool of tools) {
+      if (!tool.check_command) {
+        diagnostics.push({
+          ruleId: 'tools-check-command',
+          severity: 'warning' as const,
+          message: `Tool "${tool.name}" is missing check_command — users cannot verify availability`,
+          field: 'tools_required',
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/packages/core/src/linter/types.ts
+++ b/packages/core/src/linter/types.ts
@@ -1,0 +1,37 @@
+import type { DossierFrontmatter } from '../types';
+
+export type LintSeverity = 'error' | 'warning' | 'info';
+
+export interface LintDiagnostic {
+  ruleId: string;
+  severity: LintSeverity;
+  message: string;
+  field?: string;
+}
+
+export interface LintRuleContext {
+  frontmatter: DossierFrontmatter;
+  body: string;
+  raw: string;
+}
+
+export interface LintRule {
+  id: string;
+  description: string;
+  defaultSeverity: LintSeverity;
+  run(context: LintRuleContext): LintDiagnostic[];
+}
+
+export type RuleSeverityOverride = LintSeverity | 'off';
+
+export interface LintConfig {
+  rules: Record<string, RuleSeverityOverride>;
+}
+
+export interface LintResult {
+  file?: string;
+  diagnostics: LintDiagnostic[];
+  errorCount: number;
+  warningCount: number;
+  infoCount: number;
+}

--- a/packages/core/src/schema/dossier-schema.json
+++ b/packages/core/src/schema/dossier-schema.json
@@ -1,0 +1,745 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/imboard-ai/dossier/schema/v1.0.0",
+  "title": "Dossier Schema",
+  "description": "JSON Schema for Dossier frontmatter metadata, providing deterministic structure for LLM agent automation",
+  "type": "object",
+  "required": [
+    "dossier_schema_version",
+    "title",
+    "version",
+    "protocol_version",
+    "status",
+    "objective",
+    "checksum",
+    "risk_level",
+    "requires_approval"
+  ],
+  "properties": {
+    "dossier_schema_version": {
+      "type": "string",
+      "description": "Version of the Dossier Schema specification being used",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "const": "1.0.0"
+    },
+    "title": {
+      "type": "string",
+      "description": "Human-readable title of the Dossier",
+      "minLength": 3,
+      "maxLength": 200
+    },
+    "version": {
+      "type": "string",
+      "description": "Semantic version of this specific Dossier",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9.-]+)?(\\+[a-zA-Z0-9.-]+)?$"
+    },
+    "protocol_version": {
+      "type": "string",
+      "description": "Dossier Protocol version this Dossier adheres to",
+      "pattern": "^\\d+\\.\\d+$"
+    },
+    "status": {
+      "type": "string",
+      "description": "Lifecycle status of this Dossier",
+      "enum": ["Draft", "Stable", "Deprecated", "Experimental"]
+    },
+    "last_updated": {
+      "type": "string",
+      "description": "ISO 8601 date when the Dossier was last updated",
+      "format": "date"
+    },
+    "objective": {
+      "type": "string",
+      "description": "Clear, single-purpose statement (1-3 sentences) describing what this Dossier accomplishes",
+      "minLength": 10,
+      "maxLength": 500
+    },
+    "category": {
+      "type": "array",
+      "description": "Categories for organizing and discovering Dossiers",
+      "items": {
+        "type": "string",
+        "enum": [
+          "devops",
+          "database",
+          "development",
+          "data-science",
+          "security",
+          "testing",
+          "deployment",
+          "maintenance",
+          "setup",
+          "migration",
+          "monitoring",
+          "infrastructure",
+          "ci-cd",
+          "documentation"
+        ]
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "tags": {
+      "type": "array",
+      "description": "Free-form tags for searchability (e.g., 'docker', 'aws', 'postgresql')",
+      "items": {
+        "type": "string",
+        "minLength": 2,
+        "maxLength": 50
+      },
+      "uniqueItems": true
+    },
+    "tools_required": {
+      "type": "array",
+      "description": "List of tools/commands that must be available for execution",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Tool or command name (e.g., 'docker', 'terraform', 'npm')"
+          },
+          "version": {
+            "type": "string",
+            "description": "Minimum version required (optional)"
+          },
+          "check_command": {
+            "type": "string",
+            "description": "Command to verify tool availability (e.g., 'docker --version')"
+          },
+          "install_url": {
+            "type": "string",
+            "description": "URL to installation instructions",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "estimated_duration": {
+      "type": "object",
+      "description": "Estimated time to complete this Dossier",
+      "properties": {
+        "min_minutes": {
+          "type": "number",
+          "description": "Minimum estimated duration in minutes",
+          "minimum": 0
+        },
+        "max_minutes": {
+          "type": "number",
+          "description": "Maximum estimated duration in minutes",
+          "minimum": 0
+        }
+      }
+    },
+    "risk_level": {
+      "type": "string",
+      "description": "Risk assessment of executing this Dossier (REQUIRED for security)",
+      "enum": ["low", "medium", "high", "critical"]
+    },
+    "risk_factors": {
+      "type": "array",
+      "description": "Specific risk factors this dossier involves",
+      "items": {
+        "type": "string",
+        "enum": [
+          "modifies_files",
+          "deletes_files",
+          "modifies_cloud_resources",
+          "requires_credentials",
+          "network_access",
+          "executes_external_code",
+          "database_operations",
+          "system_configuration"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "requires_approval": {
+      "type": "boolean",
+      "description": "Whether user approval is required before execution (REQUIRED)",
+      "default": true
+    },
+    "destructive_operations": {
+      "type": "array",
+      "description": "Human-readable list of potentially destructive operations this dossier performs",
+      "items": {
+        "type": "string",
+        "minLength": 10
+      }
+    },
+    "checksum": {
+      "type": "object",
+      "description": "Content integrity hash (REQUIRED for security - verifies dossier hasn't been tampered with)",
+      "required": ["algorithm", "hash"],
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "description": "Hash algorithm used",
+          "enum": ["sha256"],
+          "const": "sha256"
+        },
+        "hash": {
+          "type": "string",
+          "description": "SHA256 hash of dossier body content (after frontmatter)",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "signature": {
+      "type": "object",
+      "description": "Optional cryptographic signature for authenticity verification (dual-signature system: AWS KMS for official, minisign for community)",
+      "required": ["algorithm", "signed_by"],
+      "oneOf": [
+        {
+          "description": "AWS KMS signature (official dossiers)",
+          "required": ["algorithm", "key_id", "signature", "signed_by"],
+          "properties": {
+            "algorithm": {
+              "type": "string",
+              "const": "ecdsa-sha256",
+              "description": "ECDSA signature with SHA256 (AWS KMS)"
+            },
+            "key_id": {
+              "type": "string",
+              "description": "AWS KMS key identifier (e.g., 'imboard-ai-2024-kms' or ARN)",
+              "examples": ["imboard-ai-2024-kms", "arn:aws:kms:us-east-1:942039714848:key/xxx"]
+            },
+            "signature": {
+              "type": "string",
+              "description": "Base64-encoded ECDSA signature (DER format)",
+              "pattern": "^[A-Za-z0-9+/]+=*$"
+            },
+            "public_key": {
+              "type": "string",
+              "description": "Base64-encoded DER public key from AWS KMS (optional, can be fetched from KMS)"
+            },
+            "signed_by": {
+              "type": "string",
+              "description": "Signer identity",
+              "examples": ["Imboard AI Security Team <security@imboard.ai>"]
+            },
+            "timestamp": {
+              "type": "string",
+              "description": "When the signature was created (ISO 8601 format)",
+              "format": "date-time"
+            }
+          }
+        },
+        {
+          "description": "minisign signature (community dossiers)",
+          "required": ["algorithm", "public_key", "signature", "signed_by"],
+          "properties": {
+            "algorithm": {
+              "type": "string",
+              "const": "ed25519",
+              "description": "Ed25519 signature (minisign)"
+            },
+            "public_key": {
+              "type": "string",
+              "description": "Minisign public key (base64 encoded, starts with 'RWT')",
+              "pattern": "^RWT[A-Za-z0-9+/=]+$"
+            },
+            "signature": {
+              "type": "string",
+              "description": "Minisign signature data (includes trusted comment)"
+            },
+            "key_id": {
+              "type": "string",
+              "description": "Human-readable key identifier",
+              "examples": ["author-2024", "community-member-2024"]
+            },
+            "signed_by": {
+              "type": "string",
+              "description": "Signer identity",
+              "examples": ["Author Name <author@example.com>"]
+            },
+            "timestamp": {
+              "type": "string",
+              "description": "When the signature was created (ISO 8601 format)",
+              "format": "date-time"
+            }
+          }
+        }
+      ]
+    },
+    "relationships": {
+      "type": "object",
+      "description": "Relationships with other Dossiers",
+      "properties": {
+        "preceded_by": {
+          "type": "array",
+          "description": "Dossiers that should run before this one",
+          "items": {
+            "type": "object",
+            "required": ["dossier"],
+            "properties": {
+              "dossier": {
+                "type": "string",
+                "description": "Name or path of the preceding Dossier"
+              },
+              "condition": {
+                "type": "string",
+                "enum": ["required", "optional", "suggested"],
+                "description": "Whether this prerequisite is required, optional, or suggested"
+              },
+              "reason": {
+                "type": "string",
+                "description": "Why this prerequisite exists"
+              }
+            }
+          }
+        },
+        "followed_by": {
+          "type": "array",
+          "description": "Dossiers that should run after this one",
+          "items": {
+            "type": "object",
+            "required": ["dossier"],
+            "properties": {
+              "dossier": {
+                "type": "string",
+                "description": "Name or path of the following Dossier"
+              },
+              "condition": {
+                "type": "string",
+                "enum": ["required", "suggested"],
+                "description": "Whether this follow-up is required or suggested"
+              },
+              "purpose": {
+                "type": "string",
+                "description": "Purpose of the follow-up Dossier"
+              }
+            }
+          }
+        },
+        "alternatives": {
+          "type": "array",
+          "description": "Alternative Dossiers that accomplish similar goals",
+          "items": {
+            "type": "object",
+            "required": ["dossier"],
+            "properties": {
+              "dossier": {
+                "type": "string",
+                "description": "Name or path of the alternative Dossier"
+              },
+              "when_to_use": {
+                "type": "string",
+                "description": "When to use the alternative instead"
+              }
+            }
+          }
+        },
+        "conflicts_with": {
+          "type": "array",
+          "description": "Dossiers that conflict with this one",
+          "items": {
+            "type": "object",
+            "required": ["dossier", "reason"],
+            "properties": {
+              "dossier": {
+                "type": "string",
+                "description": "Name or path of the conflicting Dossier"
+              },
+              "reason": {
+                "type": "string",
+                "description": "Why they conflict"
+              }
+            }
+          }
+        },
+        "can_run_parallel_with": {
+          "type": "array",
+          "description": "Dossiers that can be executed in parallel",
+          "items": {
+            "type": "string",
+            "description": "Name or path of parallelizable Dossier"
+          }
+        }
+      }
+    },
+    "inputs": {
+      "type": "object",
+      "description": "Input parameters and data required",
+      "properties": {
+        "required": {
+          "type": "array",
+          "description": "Required inputs that must be provided",
+          "items": {
+            "type": "object",
+            "required": ["name", "description"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Input parameter name"
+              },
+              "description": {
+                "type": "string",
+                "description": "Description of the input"
+              },
+              "type": {
+                "type": "string",
+                "description": "Data type (e.g., 'string', 'number', 'file', 'array')"
+              },
+              "validation": {
+                "type": "string",
+                "description": "Validation rules or regex pattern"
+              },
+              "example": {
+                "type": "string",
+                "description": "Example value"
+              }
+            }
+          }
+        },
+        "optional": {
+          "type": "array",
+          "description": "Optional inputs with default behaviors",
+          "items": {
+            "type": "object",
+            "required": ["name", "description"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Input parameter name"
+              },
+              "description": {
+                "type": "string",
+                "description": "Description of the input"
+              },
+              "type": {
+                "type": "string",
+                "description": "Data type"
+              },
+              "default": {
+                "description": "Default value if not provided"
+              },
+              "example": {
+                "type": "string",
+                "description": "Example value"
+              }
+            }
+          }
+        },
+        "from_dossiers": {
+          "type": "array",
+          "description": "Inputs sourced from other Dossiers' outputs",
+          "items": {
+            "type": "object",
+            "required": ["source_dossier", "output_name"],
+            "properties": {
+              "source_dossier": {
+                "type": "string",
+                "description": "Name or path of source Dossier"
+              },
+              "output_name": {
+                "type": "string",
+                "description": "Name of the output from source Dossier"
+              },
+              "usage": {
+                "type": "string",
+                "description": "How this input is used"
+              }
+            }
+          }
+        }
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "description": "Outputs produced by this Dossier",
+      "properties": {
+        "files": {
+          "type": "array",
+          "description": "Files created or modified",
+          "items": {
+            "type": "object",
+            "required": ["path", "description"],
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "File path (may include variables like ${PROJECT_ROOT})"
+              },
+              "description": {
+                "type": "string",
+                "description": "Description of the file"
+              },
+              "required": {
+                "type": "boolean",
+                "description": "Whether this file is always created",
+                "default": true
+              },
+              "format": {
+                "type": "string",
+                "description": "File format (e.g., 'json', 'yaml', 'sql')"
+              }
+            }
+          }
+        },
+        "configuration": {
+          "type": "array",
+          "description": "Configuration values produced",
+          "items": {
+            "type": "object",
+            "required": ["key", "description"],
+            "properties": {
+              "key": {
+                "type": "string",
+                "description": "Configuration key or variable name"
+              },
+              "description": {
+                "type": "string",
+                "description": "Description of the configuration"
+              },
+              "consumed_by": {
+                "type": "array",
+                "description": "Dossiers that consume this configuration",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "export_as": {
+                "type": "string",
+                "description": "How to export (e.g., 'env_var', 'file', 'terraform_output')"
+              }
+            }
+          }
+        },
+        "state_changes": {
+          "type": "array",
+          "description": "State changes made by this Dossier",
+          "items": {
+            "type": "object",
+            "required": ["description"],
+            "properties": {
+              "description": {
+                "type": "string",
+                "description": "Description of the state change"
+              },
+              "affects": {
+                "type": "string",
+                "description": "What this state change affects"
+              },
+              "reversible": {
+                "type": "boolean",
+                "description": "Whether this change can be rolled back"
+              }
+            }
+          }
+        },
+        "artifacts": {
+          "type": "array",
+          "description": "Generated artifacts (scripts, reports, logs)",
+          "items": {
+            "type": "object",
+            "required": ["path", "purpose"],
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Artifact path"
+              },
+              "purpose": {
+                "type": "string",
+                "description": "Purpose of the artifact"
+              },
+              "type": {
+                "type": "string",
+                "description": "Type of artifact (e.g., 'script', 'log', 'report')"
+              }
+            }
+          }
+        }
+      }
+    },
+    "coupling": {
+      "type": "object",
+      "description": "Coupling level with other systems and Dossiers",
+      "required": ["level"],
+      "properties": {
+        "level": {
+          "type": "string",
+          "enum": ["None", "Loose", "Medium", "Tight"],
+          "description": "Coupling level"
+        },
+        "details": {
+          "type": "string",
+          "description": "Explanation of coupling level and dependencies"
+        }
+      }
+    },
+    "prerequisites": {
+      "type": "array",
+      "description": "Prerequisites that must exist before execution",
+      "items": {
+        "type": "object",
+        "required": ["description"],
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Description of the prerequisite"
+          },
+          "validation_command": {
+            "type": "string",
+            "description": "Command to validate this prerequisite exists"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["file", "directory", "tool", "service", "permission", "environment"],
+            "description": "Type of prerequisite"
+          }
+        }
+      }
+    },
+    "validation": {
+      "type": "object",
+      "description": "Success criteria and validation commands",
+      "properties": {
+        "success_criteria": {
+          "type": "array",
+          "description": "Verifiable criteria for success",
+          "items": {
+            "type": "string"
+          }
+        },
+        "verification_commands": {
+          "type": "array",
+          "description": "Commands to verify success",
+          "items": {
+            "type": "object",
+            "required": ["command", "expected"],
+            "properties": {
+              "command": {
+                "type": "string",
+                "description": "Command to run"
+              },
+              "expected": {
+                "type": "string",
+                "description": "Expected output or result"
+              },
+              "description": {
+                "type": "string",
+                "description": "What this verifies"
+              }
+            }
+          }
+        }
+      }
+    },
+    "rollback": {
+      "type": "object",
+      "description": "Rollback information for reversing this Dossier",
+      "properties": {
+        "supported": {
+          "type": "boolean",
+          "description": "Whether rollback is supported"
+        },
+        "procedure": {
+          "type": "string",
+          "description": "Description of rollback procedure"
+        },
+        "automated": {
+          "type": "boolean",
+          "description": "Whether rollback can be automated"
+        },
+        "backup_required": {
+          "type": "boolean",
+          "description": "Whether backup is required before execution"
+        }
+      }
+    },
+    "authors": {
+      "type": "array",
+      "description": "Authors or maintainers of this Dossier",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Author name"
+          },
+          "email": {
+            "type": "string",
+            "description": "Author email",
+            "format": "email"
+          },
+          "url": {
+            "type": "string",
+            "description": "Author URL",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "license": {
+      "type": "string",
+      "description": "License identifier (SPDX format recommended)"
+    },
+    "homepage": {
+      "type": "string",
+      "description": "URL to Dossier homepage or documentation",
+      "format": "uri"
+    },
+    "repository": {
+      "type": "string",
+      "description": "URL to Dossier source repository",
+      "format": "uri"
+    },
+    "custom": {
+      "type": "object",
+      "description": "Custom metadata fields (prefixed with X- in markdown)",
+      "additionalProperties": true
+    },
+    "mcp_integration": {
+      "type": "object",
+      "description": "MCP (Model Context Protocol) server integration metadata for automatic dossier execution",
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Whether the dossier MCP server is required for execution",
+          "default": false
+        },
+        "server_name": {
+          "type": "string",
+          "description": "npm package name of the required MCP server",
+          "default": "@dossier/mcp-server"
+        },
+        "min_version": {
+          "type": "string",
+          "description": "Minimum MCP server version required (semver format)",
+          "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "features_used": {
+          "type": "array",
+          "description": "List of MCP tools and resources this dossier uses",
+          "items": {
+            "type": "string",
+            "enum": [
+              "verify_dossier",
+              "read_dossier",
+              "list_dossiers",
+              "validate_dossier",
+              "dossier://protocol",
+              "dossier://security",
+              "dossier://concept"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "fallback": {
+          "type": "string",
+          "description": "Behavior when MCP server is not available",
+          "enum": ["manual_execution", "degraded", "error"],
+          "default": "manual_execution"
+        },
+        "benefits": {
+          "type": "array",
+          "description": "Benefits of using MCP server for this dossier",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `dossier lint` command with 7 configurable rules powered by ajv JSON Schema validation
- Add `dossier format` command with key sorting, whitespace normalization, and checksum auto-update
- Reusable core library in `packages/core/src/linter/` and `packages/core/src/formatter/`
- 36 new tests (25 linter + 11 formatter), all passing

## Lint Rules

| Rule | Severity | Description |
|------|----------|-------------|
| `schema-valid` | error | Full JSON Schema validation via ajv |
| `checksum-valid` | error | Checksum hash matches body SHA256 |
| `semver-version` | error | Version is valid semver |
| `risk-level-consistency` | warning | Low risk + destructive ops = suspicious |
| `tools-check-command` | warning | tools_required entries should have check_command |
| `objective-quality` | info | Objective length/quality heuristics |
| `required-sections` | warning | Body has at least one ## heading |

## CLI Usage

```
dossier lint <file> [--strict] [--json] [--quiet] [--config <path>] [--list-rules]
dossier format <file> [--check] [--no-checksum] [--no-sort-keys] [--indent <n>] [--json]
```

Rules are configurable via `.dossierrc.json`:
```json
{ "rules": { "checksum-valid": "off", "tools-check-command": "error" } }
```

## Test plan

- [x] `cd packages/core && npm run build` — TypeScript compiles clean
- [x] `cd packages/core && npm test` — all 91 tests pass (25 linter + 11 formatter + existing)
- [x] `dossier lint examples/test/hello-world.ds.md` — runs against real dossier
- [x] `dossier lint --list-rules` — lists all available rules
- [x] `dossier format examples/test/hello-world.ds.md --check` — check mode works
- [x] `dossier lint examples/test/hello-world.ds.md --json` — JSON output works

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)