### PR TITLE
feat: Implement registry commands (publish, remove, search, pull, export, install-skill, info, run)

### DIFF
--- a/cli/bin/dossier
+++ b/cli/bin/dossier
@@ -2405,17 +2405,304 @@ cacheCmd
   });
 
 // ============================================================================
-// COMMAND: info (TBD)
+// COMMAND: install-skill (IMPLEMENTED)
+// ============================================================================
+program
+  .command('install-skill')
+  .description('Install a registry dossier as a Claude Code skill')
+  .argument('[name]', 'Dossier name to install (use name@version for specific version)')
+  .option('--force', 'Overwrite if skill already exists')
+  .option('--list', 'List currently installed skills')
+  .option('--remove <skill>', 'Remove an installed skill')
+  .action(async (name, options) => {
+    const fs = require('fs');
+    const os = require('os');
+    const { getClient, parseNameVersion } = require('../dist/registry-client');
+
+    const skillsDir = path.join(os.homedir(), '.claude', 'skills');
+
+    // --list: show installed skills
+    if (options.list) {
+      if (!fs.existsSync(skillsDir)) {
+        console.log('\nNo installed skills.\n');
+        process.exit(0);
+      }
+
+      const entries = fs.readdirSync(skillsDir, { withFileTypes: true })
+        .filter(e => e.isDirectory())
+        .filter(e => fs.existsSync(path.join(skillsDir, e.name, 'SKILL.md')));
+
+      if (entries.length === 0) {
+        console.log('\nNo installed skills.\n');
+        process.exit(0);
+      }
+
+      console.log(`\n📋 Installed skills (${entries.length}):\n`);
+      for (const e of entries) {
+        const skillFile = path.join(skillsDir, e.name, 'SKILL.md');
+        const content = fs.readFileSync(skillFile, 'utf8');
+
+        // Extract description from YAML frontmatter
+        let description = '';
+        const yamlMatch = content.match(/^---\n([\s\S]*?)\n---/);
+        if (yamlMatch) {
+          const descMatch = yamlMatch[1].match(/description:\s*(.+?)(?:\n|$)/);
+          if (descMatch) description = descMatch[1].trim();
+        }
+
+        console.log(`  ${e.name}`);
+        if (description) {
+          const snippet = description.length > 80 ? description.slice(0, 80) + '...' : description;
+          console.log(`  ${snippet}`);
+        }
+        console.log('');
+      }
+      process.exit(0);
+    }
+
+    // --remove: uninstall a skill
+    if (options.remove) {
+      const skillDir = path.join(skillsDir, options.remove);
+      if (!fs.existsSync(skillDir)) {
+        console.error(`\n❌ Skill not found: ${options.remove}\n`);
+        process.exit(1);
+      }
+      fs.rmSync(skillDir, { recursive: true, force: true });
+      console.log(`\n✅ Removed skill: ${options.remove}\n`);
+      process.exit(0);
+    }
+
+    // Install a skill
+    if (!name) {
+      console.error('\n❌ Please provide a dossier name to install, or use --list / --remove\n');
+      process.exit(1);
+    }
+
+    const [dossierName, version] = parseNameVersion(name);
+
+    // Extract skill name from dossier path (last segment)
+    const skillName = dossierName.split('/').pop();
+    const skillDir = path.join(skillsDir, skillName);
+    const skillFile = path.join(skillDir, 'SKILL.md');
+
+    // Check if already installed
+    if (!options.force && fs.existsSync(skillFile)) {
+      console.error(`\n❌ Skill '${skillName}' already installed at ${skillDir}`);
+      console.error('   Use --force to overwrite\n');
+      process.exit(1);
+    }
+
+    try {
+      // Try cache first, then registry
+      const cacheDir = path.join(os.homedir(), '.dossier', 'cache');
+      let content = null;
+      let resolvedVersion = version;
+
+      if (!version) {
+        // Check cache for any version
+        const dossierCacheDir = path.join(cacheDir, ...dossierName.split('/'));
+        if (fs.existsSync(dossierCacheDir)) {
+          const metaFiles = fs.readdirSync(dossierCacheDir).filter(f => f.endsWith('.meta.json'));
+          if (metaFiles.length > 0) {
+            // Use most recent cached version
+            const ver = metaFiles[0].replace('.meta.json', '');
+            const contentFile = path.join(dossierCacheDir, `${ver}.ds.md`);
+            if (fs.existsSync(contentFile)) {
+              content = fs.readFileSync(contentFile, 'utf8');
+              resolvedVersion = ver;
+            }
+          }
+        }
+      } else {
+        // Check cache for specific version
+        const contentFile = path.join(cacheDir, ...dossierName.split('/'), `${version}.ds.md`);
+        if (fs.existsSync(contentFile)) {
+          content = fs.readFileSync(contentFile, 'utf8');
+          resolvedVersion = version;
+        }
+      }
+
+      // Fetch from registry if not cached
+      if (!content) {
+        const client = getClient();
+        if (!resolvedVersion) {
+          const meta = await client.getDossier(dossierName);
+          resolvedVersion = meta.version || 'latest';
+        }
+        const result = await client.getDossierContent(dossierName, resolvedVersion);
+        content = result.content;
+      }
+
+      // Write skill file
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(skillFile, content, 'utf8');
+
+      console.log(`\n✅ Installed skill '${skillName}'${resolvedVersion ? ' (v' + resolvedVersion + ')' : ''}`);
+      console.log(`   Location: ${skillFile}`);
+      console.log(`   Source: ${dossierName}\n`);
+    } catch (err) {
+      if (err.statusCode === 404) {
+        console.error(`\n❌ Not found in registry: ${name}\n`);
+      } else {
+        console.error(`\n❌ Install failed: ${err.message}\n`);
+      }
+      process.exit(1);
+    }
+  });
+
+// ============================================================================
+// COMMAND: info (IMPLEMENTED)
 // ============================================================================
 program
   .command('info')
-  .description('Show dossier metadata [TBD]')
-  .argument('<file>', 'Dossier file or URL')
-  .option('--json', 'JSON output')
-  .option('--short', 'Brief summary only')
-  .action((file, options) => {
-    console.log('⚠️  info tbd - follow docs/planning/cli-evolution.md');
-    process.exit(1);
+  .description('Show dossier metadata')
+  .argument('<file-or-name>', 'Local dossier file path or registry dossier name')
+  .option('--json', 'Output as JSON')
+  .action(async (fileOrName, options) => {
+    const fs = require('fs');
+    const crypto = require('crypto');
+
+    let frontmatter;
+    let body;
+    let source;
+
+    const resolved = path.resolve(fileOrName);
+    const isLocal = fs.existsSync(resolved);
+
+    if (isLocal) {
+      // Local file
+      source = resolved;
+      const content = fs.readFileSync(resolved, 'utf8');
+
+      // Try JSON frontmatter (---dossier)
+      const jsonMatch = content.match(/^---dossier\s*\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+      if (jsonMatch) {
+        try {
+          frontmatter = JSON.parse(jsonMatch[1]);
+          body = jsonMatch[2];
+        } catch (err) {
+          console.error(`\n❌ Invalid JSON in frontmatter: ${err.message}\n`);
+          process.exit(1);
+        }
+      } else {
+        // Try YAML frontmatter (---)
+        const yamlMatch = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+        if (yamlMatch) {
+          // Simple YAML key-value parsing
+          frontmatter = {};
+          const lines = yamlMatch[1].split('\n');
+          let currentKey = null;
+          for (const line of lines) {
+            const kvMatch = line.match(/^(\w[\w_-]*):\s*(.*)$/);
+            if (kvMatch) {
+              currentKey = kvMatch[1];
+              const val = kvMatch[2].trim();
+              if (val === '' || val === '|' || val === '>') {
+                frontmatter[currentKey] = '';
+              } else if (val.startsWith('[') || val.startsWith('{')) {
+                try { frontmatter[currentKey] = JSON.parse(val); } catch { frontmatter[currentKey] = val; }
+              } else {
+                frontmatter[currentKey] = val;
+              }
+            } else if (currentKey && line.match(/^\s*-\s+(.+)$/)) {
+              const item = line.match(/^\s*-\s+(.+)$/)[1].trim();
+              if (!Array.isArray(frontmatter[currentKey])) {
+                frontmatter[currentKey] = frontmatter[currentKey] ? [frontmatter[currentKey]] : [];
+              }
+              frontmatter[currentKey].push(item);
+            }
+          }
+          body = yamlMatch[2];
+        } else {
+          console.error('\n❌ Invalid dossier format: no frontmatter found\n');
+          process.exit(1);
+        }
+      }
+    } else {
+      // Registry name
+      source = `registry: ${fileOrName}`;
+      try {
+        const { getClient, parseNameVersion } = require('../dist/registry-client');
+        const [dossierName, version] = parseNameVersion(fileOrName);
+        const client = getClient();
+        const meta = await client.getDossier(dossierName, version || null);
+        frontmatter = meta;
+        body = null; // No body from metadata endpoint
+      } catch (err) {
+        if (err.statusCode === 404) {
+          console.error(`\n❌ Not found: ${fileOrName}`);
+          console.error('   Not a local file and not found in registry\n');
+        } else {
+          console.error(`\n❌ Error: ${err.message}\n`);
+        }
+        process.exit(1);
+      }
+    }
+
+    if (options.json) {
+      console.log(JSON.stringify(frontmatter, null, 2));
+      process.exit(0);
+    }
+
+    // Formatted output
+    console.log(`\n📄 Dossier Info\n`);
+    console.log(`   Source:    ${source}`);
+
+    const fields = [
+      ['Name', frontmatter.name || frontmatter.title || ''],
+      ['Title', frontmatter.title || ''],
+      ['Version', frontmatter.version || ''],
+      ['Status', frontmatter.status || ''],
+      ['Category', Array.isArray(frontmatter.category) ? frontmatter.category.join(', ') : (frontmatter.category || '')],
+      ['Risk Level', frontmatter.risk_level || ''],
+      ['Objective', frontmatter.objective || frontmatter.description || ''],
+    ];
+
+    for (const [label, value] of fields) {
+      if (value) {
+        console.log(`   ${label.padEnd(10)} ${value}`);
+      }
+    }
+
+    // Authors
+    const authors = frontmatter.authors;
+    if (Array.isArray(authors) && authors.length > 0) {
+      const authorStr = authors.map(a => {
+        if (typeof a === 'string') {
+          // Handle YAML "- name: Foo" parsed as string
+          const nameMatch = a.match(/^name:\s*(.+)$/);
+          return nameMatch ? nameMatch[1] : a;
+        }
+        return a.name || '';
+      }).filter(Boolean).join(', ');
+      if (authorStr) console.log(`   Authors:   ${authorStr}`);
+    }
+
+    // Tags
+    if (Array.isArray(frontmatter.tags) && frontmatter.tags.length > 0) {
+      console.log(`   Tags:      ${frontmatter.tags.join(', ')}`);
+    }
+
+    // Checksum
+    if (body !== null) {
+      const checksumInfo = frontmatter.checksum;
+      if (checksumInfo?.hash) {
+        const actual = crypto.createHash('sha256').update(body, 'utf8').digest('hex');
+        const valid = actual === checksumInfo.hash;
+        console.log(`   Checksum:  ${checksumInfo.hash.slice(0, 16)}... ${valid ? '✅ valid' : '❌ mismatch'}`);
+      } else {
+        console.log(`   Checksum:  missing`);
+      }
+    }
+
+    // Signature
+    if (frontmatter.signature) {
+      const sig = frontmatter.signature;
+      console.log(`   Signed by: ${sig.signed_by || sig.key_id || 'unknown'}`);
+    }
+
+    console.log('');
+    process.exit(0);
   });
 
 // ============================================================================

--- a/cli/bin/dossier
+++ b/cli/bin/dossier
@@ -891,7 +891,7 @@ function formatTable(dossiers, showPath = false) {
 
 program
   .command('list')
-  .description('List available dossiers in a directory or repository')
+  .description('List available dossiers from registry, directory, or repository')
   .argument('[source]', 'Directory, GitHub repo (github:owner/repo), or URL', '.')
   .option('-r, --recursive', 'Search subdirectories recursively (default for remote)')
   .option('--signed-only', 'Only show signed dossiers')
@@ -899,9 +899,68 @@ program
   .option('--category <category>', 'Filter by category')
   .option('--format <fmt>', 'Output format (table, json, simple)', 'table')
   .option('--show-path', 'Show full path instead of filename')
+  .option('--source <type>', 'Source type: registry, local, github')
+  .option('--page <number>', 'Page number (registry only)', '1')
+  .option('--per-page <number>', 'Results per page (registry only)', '20')
   .action(async (source, options) => {
     const fs = require('fs');
     const path = require('path');
+
+    // If --source registry, query the registry directly
+    if (options.source === 'registry') {
+      const { getClient } = require('../dist/registry-client');
+
+      const page = parseInt(options.page, 10) || 1;
+      const perPage = parseInt(options.perPage, 10) || 20;
+
+      try {
+        const client = getClient();
+        const result = await client.listDossiers({ category: options.category, page, perPage });
+
+        const dossiers = result.dossiers || result.data || [];
+
+        if (options.format === 'json') {
+          console.log(JSON.stringify(result, null, 2));
+          process.exit(0);
+        }
+
+        if (options.format === 'simple') {
+          for (const d of dossiers) {
+            console.log(d.name || '');
+          }
+          process.exit(0);
+        }
+
+        if (dossiers.length === 0) {
+          console.log('\n⚠️  No dossiers found in registry\n');
+          process.exit(0);
+        }
+
+        const total = result.total || dossiers.length;
+        console.log(`\n📋 Registry dossiers (${total} total):\n`);
+
+        for (const d of dossiers) {
+          const name = d.name || '';
+          const version = d.version || '';
+          const title = d.title || '';
+          const category = Array.isArray(d.category) ? d.category.join(', ') : (d.category || '');
+          console.log(`  ${name.padEnd(30)} ${('v' + version).padEnd(10)} ${category.padEnd(12)} ${title}`);
+        }
+
+        const totalPages = result.totalPages || Math.ceil(total / perPage);
+        if (totalPages > 1) {
+          console.log(`\nPage ${page}/${totalPages}`);
+          if (page < totalPages) {
+            console.log(`Use --page ${page + 1} to see more results`);
+          }
+        }
+        console.log('');
+      } catch (err) {
+        console.error(`\n❌ Registry list failed: ${err.message}\n`);
+        process.exit(1);
+      }
+      process.exit(0);
+    }
 
     // Parse the source to determine type
     const parsed = parseListSource(source);
@@ -1030,6 +1089,97 @@ program
     }
 
     process.exit(0);
+  });
+
+// ============================================================================
+// COMMAND: search (IMPLEMENTED)
+// ============================================================================
+program
+  .command('search')
+  .description('Search the registry for dossiers')
+  .argument('<query>', 'Search keywords')
+  .option('--category <category>', 'Filter by category (devops, database, development, security, etc.)')
+  .option('--page <number>', 'Page number', '1')
+  .option('--per-page <number>', 'Results per page', '20')
+  .option('--json', 'Output as JSON')
+  .action(async (query, options) => {
+    const { getClient } = require('../dist/registry-client');
+
+    const page = parseInt(options.page, 10) || 1;
+    const perPage = parseInt(options.perPage, 10) || 20;
+
+    try {
+      const client = getClient();
+
+      // Fetch all dossiers from registry, then filter client-side
+      // (the registry API does not yet have a dedicated search endpoint)
+      const result = await client.listDossiers({ category: options.category, page: 1, perPage: 100 });
+      const allDossiers = result.dossiers || [];
+
+      // Client-side full-text search across metadata fields
+      const queryLower = query.toLowerCase();
+      const terms = queryLower.split(/\s+/).filter(Boolean);
+
+      const matched = allDossiers.filter(d => {
+        const fields = [
+          d.name || '',
+          d.title || '',
+          d.description || d.objective || '',
+          ...(Array.isArray(d.category) ? d.category : [d.category || '']),
+          ...(d.tags || []),
+        ].map(f => String(f).toLowerCase()).join(' ');
+
+        return terms.every(term => fields.includes(term) || fields.indexOf(term) !== -1);
+      });
+
+      // Paginate client-side results
+      const total = matched.length;
+      const start = (page - 1) * perPage;
+      const dossiers = matched.slice(start, start + perPage);
+
+      if (options.json) {
+        console.log(JSON.stringify({ dossiers, total, page, perPage }, null, 2));
+        process.exit(0);
+      }
+
+      if (dossiers.length === 0) {
+        console.log(`\nNo dossiers found matching "${query}".\n`);
+        process.exit(0);
+      }
+
+      console.log(`\n🔍 Found ${total} dossier(s) matching "${query}":\n`);
+
+      for (const d of dossiers) {
+        const name = d.name || '';
+        const version = d.version || '';
+        const title = d.title || '';
+        const category = Array.isArray(d.category) ? d.category.join(', ') : (d.category || '');
+        const description = d.description || d.objective || '';
+
+        console.log(`  ${name} (v${version})${category ? '  [' + category + ']' : ''}`);
+        if (title) {
+          console.log(`  ${title}`);
+        }
+        if (description) {
+          const snippet = description.length > 100 ? description.slice(0, 100) + '...' : description;
+          console.log(`  ${snippet}`);
+        }
+        console.log('');
+      }
+
+      // Pagination info
+      const totalPages = Math.ceil(total / perPage);
+      if (totalPages > 1) {
+        console.log(`Page ${page}/${totalPages} (${perPage} per page)`);
+        if (page < totalPages) {
+          console.log(`Use --page ${page + 1} to see more results`);
+        }
+        console.log('');
+      }
+    } catch (err) {
+      console.error(`\n❌ Search failed: ${err.message}\n`);
+      process.exit(1);
+    }
   });
 
 // ============================================================================

--- a/cli/bin/dossier
+++ b/cli/bin/dossier
@@ -1205,24 +1205,215 @@ program
   });
 
 // ============================================================================
-// COMMAND: publish (TBD)
+// COMMAND: publish (IMPLEMENTED)
 // ============================================================================
 program
   .command('publish')
-  .description('Share dossier to registry [TBD]')
+  .description('Publish a dossier to the registry')
   .argument('<file>', 'Dossier file to publish')
-  .option('--registry <url>', 'Registry URL')
-  .option('--name <name>', 'Custom name in registry')
-  .option('--tags <tags>', 'Comma-separated tags')
-  .option('--private', 'Private publication')
-  .action((file, options) => {
-    console.log('⚠️  publish tbd - follow docs/planning/cli-evolution.md');
-    console.log('');
-    console.log('MVP simulation would show:');
-    console.log('Registry ID:  dsr-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
-    console.log('Public URL:   https://registry.dossier.ai/dsr-xxxxxxxx');
-    console.log('Install:      dossier run dsr-xxxxxxxx');
-    process.exit(1);
+  .option('--changelog <message>', 'Changelog message for this version')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .action(async (file, options) => {
+    const fs = require('fs');
+    const crypto = require('crypto');
+    const readline = require('readline');
+    const { loadCredentials, isExpired } = require('../dist/credentials');
+    const { getClient } = require('../dist/registry-client');
+
+    // 1. Check authentication
+    const credentials = loadCredentials();
+    if (!credentials) {
+      console.error('\n❌ Not logged in. Run `dossier login` first.\n');
+      process.exit(1);
+    }
+    if (isExpired(credentials)) {
+      console.error('\n❌ Credentials expired. Run `dossier login` to re-authenticate.\n');
+      process.exit(1);
+    }
+
+    // 2. Read and parse file
+    const dossierFile = path.resolve(file);
+    if (!fs.existsSync(dossierFile)) {
+      console.error(`\n❌ File not found: ${dossierFile}\n`);
+      process.exit(1);
+    }
+
+    const content = fs.readFileSync(dossierFile, 'utf8');
+
+    const jsonMatch = content.match(/^---dossier\s*\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+    if (!jsonMatch) {
+      console.error('\n❌ Invalid dossier format: missing ---dossier frontmatter\n');
+      process.exit(1);
+    }
+
+    let frontmatter;
+    try {
+      frontmatter = JSON.parse(jsonMatch[1]);
+    } catch (err) {
+      console.error(`\n❌ Invalid JSON in frontmatter: ${err.message}\n`);
+      process.exit(1);
+    }
+
+    const body = jsonMatch[2];
+
+    // 3. Validate frontmatter
+    const errors = [];
+    const required = ['title', 'version'];
+    for (const field of required) {
+      if (!frontmatter[field]) {
+        errors.push(`Missing required field: ${field}`);
+      }
+    }
+    const validRiskLevels = ['low', 'medium', 'high', 'critical'];
+    if (frontmatter.risk_level && !validRiskLevels.includes(frontmatter.risk_level)) {
+      errors.push(`Invalid risk_level: ${frontmatter.risk_level}`);
+    }
+    const validStatuses = ['draft', 'stable', 'deprecated', 'Draft', 'Stable', 'Deprecated', 'Experimental'];
+    if (frontmatter.status && !validStatuses.includes(frontmatter.status)) {
+      errors.push(`Invalid status: ${frontmatter.status}`);
+    }
+    if (errors.length > 0) {
+      console.error('\n❌ Validation errors:');
+      for (const err of errors) {
+        console.error(`   - ${err}`);
+      }
+      console.error('');
+      process.exit(1);
+    }
+
+    // 4. Verify checksum
+    const existingHash = frontmatter.checksum?.hash;
+    if (existingHash) {
+      const actualHash = crypto.createHash('sha256').update(body, 'utf8').digest('hex');
+      if (existingHash !== actualHash) {
+        console.error('\n❌ Checksum mismatch - content has been modified without updating checksum');
+        console.error(`   Expected: ${existingHash}`);
+        console.error(`   Actual:   ${actualHash}`);
+        console.error(`\n   Run 'dossier checksum ${file} --update' to fix\n`);
+        process.exit(1);
+      }
+    }
+
+    // 5. Determine namespace from authenticated user
+    const namespace = credentials.orgs.length > 0 ? credentials.orgs[0] : credentials.username;
+
+    const name = frontmatter.name || frontmatter.title || path.basename(dossierFile, '.ds.md');
+    const version = frontmatter.version || 'unknown';
+
+    // 6. Confirm before publishing
+    if (!options.yes) {
+      console.log('\n📦 Publishing dossier:\n');
+      console.log(`   File:      ${path.basename(dossierFile)}`);
+      console.log(`   Name:      ${name}`);
+      console.log(`   Version:   ${version}`);
+      console.log(`   Namespace: ${namespace}`);
+      if (options.changelog) {
+        console.log(`   Changelog: ${options.changelog}`);
+      }
+      console.log('');
+
+      const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+      const answer = await new Promise((resolve) => {
+        rl.question('Proceed with publishing? (y/N) ', resolve);
+      });
+      rl.close();
+
+      if (answer.toString().toLowerCase() !== 'y') {
+        console.log('\nAborted.\n');
+        process.exit(0);
+      }
+    }
+
+    // 7. Publish to registry
+    try {
+      const client = getClient(credentials.token);
+      const result = await client.publishDossier(namespace, content, options.changelog || null);
+
+      const fullName = result.name || `${namespace}/${name}`;
+      console.log(`\n✅ Published ${fullName}@${version}`);
+      if (result.content_url) {
+        console.log(`   URL: ${result.content_url}`);
+      }
+      console.log('');
+    } catch (err) {
+      if (err.statusCode === 401) {
+        console.error('\n❌ Session expired. Run `dossier login` to re-authenticate.\n');
+      } else if (err.statusCode === 403) {
+        console.error(`\n❌ Permission denied: ${err.message}\n`);
+      } else if (err.statusCode === 409) {
+        console.error(`\n❌ Version conflict: ${err.message}\n`);
+      } else {
+        console.error(`\n❌ Publish failed: ${err.message}\n`);
+      }
+      process.exit(1);
+    }
+  });
+
+// ============================================================================
+// COMMAND: remove (IMPLEMENTED)
+// ============================================================================
+program
+  .command('remove')
+  .description('Remove a dossier from the registry')
+  .argument('<name>', 'Dossier name (use name@version to remove a specific version)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .action(async (name, options) => {
+    const readline = require('readline');
+    const { loadCredentials, isExpired } = require('../dist/credentials');
+    const { getClient, parseNameVersion } = require('../dist/registry-client');
+
+    // 1. Check authentication
+    const credentials = loadCredentials();
+    if (!credentials) {
+      console.error('\n❌ Not logged in. Run `dossier login` first.\n');
+      process.exit(1);
+    }
+    if (isExpired(credentials)) {
+      console.error('\n❌ Credentials expired. Run `dossier login` to re-authenticate.\n');
+      process.exit(1);
+    }
+
+    // 2. Parse name@version
+    const [dossierName, version] = parseNameVersion(name);
+    const target = version ? `${dossierName}@${version}` : dossierName;
+
+    // 3. Confirm deletion
+    if (!options.yes) {
+      const msg = version
+        ? `Are you sure you want to remove version '${version}' of '${dossierName}'?`
+        : `Are you sure you want to remove '${dossierName}' and ALL its versions?`;
+
+      console.log(`\n⚠️  ${msg}\n`);
+
+      const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+      const answer = await new Promise((resolve) => {
+        rl.question('Confirm removal? (y/N) ', resolve);
+      });
+      rl.close();
+
+      if (answer.toString().toLowerCase() !== 'y') {
+        console.log('\nAborted.\n');
+        process.exit(0);
+      }
+    }
+
+    // 4. Remove from registry
+    try {
+      const client = getClient(credentials.token);
+      await client.removeDossier(dossierName, version || null);
+      console.log(`\n✅ Removed: ${target}\n`);
+    } catch (err) {
+      if (err.statusCode === 401) {
+        console.error('\n❌ Session expired. Run `dossier login` to re-authenticate.\n');
+      } else if (err.statusCode === 403) {
+        console.error(`\n❌ Permission denied: ${err.message}\n`);
+      } else if (err.statusCode === 404) {
+        console.error(`\n❌ Not found: ${target}\n`);
+      } else {
+        console.error(`\n❌ Remove failed: ${err.message}\n`);
+      }
+      process.exit(1);
+    }
   });
 
 // ============================================================================

--- a/cli/bin/dossier
+++ b/cli/bin/dossier
@@ -2037,6 +2037,374 @@ program
   });
 
 // ============================================================================
+// COMMAND: pull (IMPLEMENTED)
+// ============================================================================
+program
+  .command('pull')
+  .description('Download a dossier from the registry to local cache')
+  .argument('<name...>', 'Dossier name(s) (use name@version for a specific version)')
+  .option('--force', 'Re-download even if already cached')
+  .action(async (names, options) => {
+    const fs = require('fs');
+    const os = require('os');
+    const crypto = require('crypto');
+    const { getClient, parseNameVersion } = require('../dist/registry-client');
+
+    const cacheDir = path.join(os.homedir(), '.dossier', 'cache');
+
+    const client = getClient();
+
+    for (const nameArg of names) {
+      let [dossierName, version] = parseNameVersion(nameArg);
+
+      try {
+        // If no version specified, resolve latest
+        if (!version) {
+          const meta = await client.getDossier(dossierName);
+          version = meta.version || 'latest';
+        }
+
+        // Check cache
+        const dossierDir = path.join(cacheDir, ...dossierName.split('/'));
+        const contentFile = path.join(dossierDir, `${version}.ds.md`);
+        const metaFile = path.join(dossierDir, `${version}.meta.json`);
+
+        if (!options.force && fs.existsSync(contentFile) && fs.existsSync(metaFile)) {
+          console.log(`✅ ${dossierName}@${version} (already cached)`);
+          console.log(`   ${contentFile}`);
+          continue;
+        }
+
+        // Download
+        const result = await client.getDossierContent(dossierName, version);
+        const content = result.content;
+        const digest = result.digest;
+
+        // Verify checksum if provided
+        if (digest) {
+          const actual = crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+          if (actual !== digest) {
+            console.error(`❌ ${dossierName}@${version}: checksum mismatch after download`);
+            continue;
+          }
+        }
+
+        // Write to cache
+        fs.mkdirSync(dossierDir, { recursive: true, mode: 0o700 });
+        fs.writeFileSync(contentFile, content, 'utf8');
+        fs.writeFileSync(metaFile, JSON.stringify({
+          cached_at: new Date().toISOString(),
+          version,
+          source_registry_url: client.baseUrl.replace(/\/api\/v1$/, ''),
+        }, null, 2), 'utf8');
+
+        const status = options.force ? 'updated' : 'downloaded';
+        console.log(`✅ ${dossierName}@${version} (${status})`);
+        console.log(`   ${contentFile}`);
+      } catch (err) {
+        if (err.statusCode === 404) {
+          console.error(`❌ ${nameArg}: not found in registry`);
+        } else {
+          console.error(`❌ ${nameArg}: ${err.message}`);
+        }
+      }
+    }
+  });
+
+// ============================================================================
+// COMMAND: export (IMPLEMENTED)
+// ============================================================================
+program
+  .command('export')
+  .description('Download a dossier and save to a local file')
+  .argument('<name>', 'Dossier name (use name@version for a specific version)')
+  .option('-o, --output <path>', 'Output file path')
+  .option('--stdout', 'Print to stdout instead of saving to file')
+  .action(async (name, options) => {
+    const fs = require('fs');
+    const crypto = require('crypto');
+    const { getClient, parseNameVersion } = require('../dist/registry-client');
+
+    const [dossierName, version] = parseNameVersion(name);
+
+    try {
+      const client = getClient();
+      const result = await client.getDossierContent(dossierName, version || null);
+      const content = result.content;
+      const digest = result.digest;
+
+      if (options.stdout) {
+        process.stdout.write(content);
+        process.exit(0);
+      }
+
+      // Determine output path
+      const outputPath = options.output || `${dossierName.replace(/\//g, '-')}.ds.md`;
+      const outputDir = path.dirname(path.resolve(outputPath));
+
+      if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+      }
+
+      fs.writeFileSync(path.resolve(outputPath), content, 'utf8');
+
+      console.log(`\n✅ Exported: ${outputPath}`);
+      console.log(`   Source: ${dossierName}${version ? '@' + version : ''}`);
+      if (digest) {
+        console.log(`   Digest: ${digest}`);
+      }
+      console.log('');
+    } catch (err) {
+      if (err.statusCode === 404) {
+        console.error(`\n❌ Not found: ${name}\n`);
+      } else {
+        console.error(`\n❌ Export failed: ${err.message}\n`);
+      }
+      process.exit(1);
+    }
+  });
+
+// ============================================================================
+// COMMAND: cache (IMPLEMENTED)
+// ============================================================================
+const cacheCmd = program
+  .command('cache')
+  .description('Manage local dossier cache');
+
+// cache list
+cacheCmd
+  .command('list')
+  .description('Show all cached dossiers')
+  .option('--json', 'Output as JSON')
+  .action((options) => {
+    const fs = require('fs');
+    const os = require('os');
+
+    const cacheDir = path.join(os.homedir(), '.dossier', 'cache');
+
+    if (!fs.existsSync(cacheDir)) {
+      if (options.json) {
+        console.log(JSON.stringify([]));
+      } else {
+        console.log('\nNo cached dossiers.\n');
+      }
+      process.exit(0);
+    }
+
+    // Recursively find all .meta.json files
+    const entries = [];
+    function walk(dir) {
+      if (!fs.existsSync(dir)) return;
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+        } else if (entry.name.endsWith('.meta.json')) {
+          try {
+            const meta = JSON.parse(fs.readFileSync(full, 'utf8'));
+            const version = entry.name.replace('.meta.json', '');
+            const contentFile = path.join(dir, `${version}.ds.md`);
+            if (!fs.existsSync(contentFile)) return;
+
+            const rel = path.relative(cacheDir, dir);
+            const stats = fs.statSync(contentFile);
+            entries.push({
+              name: rel,
+              version,
+              size: stats.size,
+              cached_at: meta.cached_at,
+              path: contentFile,
+            });
+          } catch {
+            // skip invalid entries
+          }
+        }
+      }
+    }
+    walk(cacheDir);
+
+    if (entries.length === 0) {
+      if (options.json) {
+        console.log(JSON.stringify([]));
+      } else {
+        console.log('\nNo cached dossiers.\n');
+      }
+      process.exit(0);
+    }
+
+    entries.sort((a, b) => a.name.localeCompare(b.name) || a.version.localeCompare(b.version));
+
+    if (options.json) {
+      console.log(JSON.stringify(entries, null, 2));
+      process.exit(0);
+    }
+
+    // Format size
+    function formatSize(bytes) {
+      if (bytes < 1024) return `${bytes}B`;
+      if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+      return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+    }
+
+    console.log(`\n📦 Cached dossiers (${entries.length}):\n`);
+    console.log(`  ${'NAME'.padEnd(40)} ${'VERSION'.padEnd(10)} ${'SIZE'.padEnd(8)} CACHED AT`);
+    console.log(`  ${'─'.repeat(40)} ${'─'.repeat(10)} ${'─'.repeat(8)} ${'─'.repeat(19)}`);
+
+    for (const e of entries) {
+      const date = e.cached_at ? e.cached_at.slice(0, 19).replace('T', ' ') : '';
+      console.log(`  ${e.name.padEnd(40)} ${e.version.padEnd(10)} ${formatSize(e.size).padEnd(8)} ${date}`);
+    }
+    console.log('');
+    process.exit(0);
+  });
+
+// cache clean
+cacheCmd
+  .command('clean')
+  .description('Remove cached dossiers')
+  .argument('[name]', 'Specific dossier to remove')
+  .option('-V, --ver <version>', 'Remove specific version only')
+  .option('--older-than <days>', 'Remove entries older than N days')
+  .option('--all', 'Remove all cached dossiers')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .action(async (name, options) => {
+    const fs = require('fs');
+    const os = require('os');
+    const readline = require('readline');
+
+    const cacheDir = path.join(os.homedir(), '.dossier', 'cache');
+
+    if (!fs.existsSync(cacheDir)) {
+      console.log('\nNo cached dossiers.\n');
+      process.exit(0);
+    }
+
+    // Helper: confirm prompt
+    async function confirm(msg) {
+      if (options.yes) return true;
+      const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+      const answer = await new Promise((resolve) => {
+        rl.question(`${msg} (y/N) `, resolve);
+      });
+      rl.close();
+      return answer.toString().toLowerCase() === 'y';
+    }
+
+    // Helper: remove directory recursively, clean empty parents
+    function rmDir(dir) {
+      fs.rmSync(dir, { recursive: true, force: true });
+      // Clean up empty parent dirs up to cacheDir
+      let parent = path.dirname(dir);
+      while (parent !== cacheDir && parent.startsWith(cacheDir)) {
+        try {
+          const contents = fs.readdirSync(parent);
+          if (contents.length === 0) {
+            fs.rmdirSync(parent);
+            parent = path.dirname(parent);
+          } else {
+            break;
+          }
+        } catch {
+          break;
+        }
+      }
+    }
+
+    // --all: remove everything
+    if (options.all) {
+      if (!(await confirm('Remove ALL cached dossiers?'))) {
+        console.log('\nAborted.\n');
+        process.exit(0);
+      }
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+      console.log('\n✅ Cache cleared.\n');
+      process.exit(0);
+    }
+
+    // --older-than: remove stale entries
+    if (options.olderThan) {
+      const days = parseInt(options.olderThan, 10);
+      if (isNaN(days) || days <= 0) {
+        console.error('\n❌ --older-than must be a positive number\n');
+        process.exit(1);
+      }
+
+      const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+      let count = 0;
+
+      function walkClean(dir) {
+        if (!fs.existsSync(dir)) return;
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          const full = path.join(dir, entry.name);
+          if (entry.isDirectory()) {
+            walkClean(full);
+          } else if (entry.name.endsWith('.meta.json')) {
+            try {
+              const meta = JSON.parse(fs.readFileSync(full, 'utf8'));
+              if (meta.cached_at && new Date(meta.cached_at).getTime() < cutoff) {
+                const version = entry.name.replace('.meta.json', '');
+                const contentFile = path.join(dir, `${version}.ds.md`);
+                fs.unlinkSync(full);
+                if (fs.existsSync(contentFile)) fs.unlinkSync(contentFile);
+                count++;
+              }
+            } catch {
+              // skip
+            }
+          }
+        }
+      }
+
+      if (!(await confirm(`Remove dossiers cached more than ${days} days ago?`))) {
+        console.log('\nAborted.\n');
+        process.exit(0);
+      }
+
+      walkClean(cacheDir);
+      console.log(`\n✅ Removed ${count} cached dossier(s).\n`);
+      process.exit(0);
+    }
+
+    // Specific dossier
+    if (name) {
+      const dossierDir = path.join(cacheDir, ...name.split('/'));
+      if (!fs.existsSync(dossierDir)) {
+        console.error(`\n❌ Not cached: ${name}\n`);
+        process.exit(1);
+      }
+
+      if (options.ver) {
+        const contentFile = path.join(dossierDir, `${options.ver}.ds.md`);
+        const metaFile = path.join(dossierDir, `${options.ver}.meta.json`);
+        if (!fs.existsSync(contentFile) && !fs.existsSync(metaFile)) {
+          console.error(`\n❌ Version ${options.ver} not cached for ${name}\n`);
+          process.exit(1);
+        }
+        if (fs.existsSync(contentFile)) fs.unlinkSync(contentFile);
+        if (fs.existsSync(metaFile)) fs.unlinkSync(metaFile);
+        console.log(`\n✅ Removed: ${name}@${options.ver}\n`);
+      } else {
+        if (!(await confirm(`Remove all cached versions of '${name}'?`))) {
+          console.log('\nAborted.\n');
+          process.exit(0);
+        }
+        rmDir(dossierDir);
+        console.log(`\n✅ Removed: ${name} (all versions)\n`);
+      }
+      process.exit(0);
+    }
+
+    // No arguments — show help
+    console.log('\nUsage:');
+    console.log('  dossier cache clean <name>              Remove all versions of a dossier');
+    console.log('  dossier cache clean <name> --ver X      Remove specific version');
+    console.log('  dossier cache clean --older-than <days>  Remove stale entries');
+    console.log('  dossier cache clean --all                Remove everything');
+    console.log('');
+    process.exit(0);
+  });
+
+// ============================================================================
 // COMMAND: info (TBD)
 // ============================================================================
 program

--- a/cli/bin/dossier
+++ b/cli/bin/dossier
@@ -260,12 +260,14 @@ program
 program
   .command('run')
   .description('Verify, audit, and execute dossier')
-  .argument('<file>', 'Dossier file or URL to run')
+  .argument('<file>', 'Dossier file, URL, or registry name to run')
   .option('--llm <name>', 'LLM to use (claude-code, auto)')
   .option('--headless', 'Run in headless mode (non-interactive, for CI/CD)')
   .option('--dry-run', 'Show plan without executing')
   .option('--force', 'Skip risk warnings')
   .option('--no-prompt', 'Don\'t ask for confirmation')
+  .option('--fresh', 'Skip cache, fetch fresh from registry')
+  .option('--pull', 'Update cache before running')
   .option('--skip-checksum', 'Skip checksum verification (DANGEROUS)')
   .option('--skip-signature', 'Skip signature verification')
   .option('--skip-author-check', 'Skip author whitelist/blacklist')
@@ -276,8 +278,136 @@ program
   .option('--review-dossier <file>', 'Custom review dossier')
   .option('--review-llm <name>', 'LLM for review step')
   .action(async (file, options) => {
+    const fs = require('fs');
+    const os = require('os');
+
+    let resolvedFile = file;
+    const isUrl = file.startsWith('http://') || file.startsWith('https://');
+    const isLocalFile = !isUrl && fs.existsSync(path.resolve(file));
+    const isNested = process.env.CLAUDE_CODE === '1' || process.env.CLAUDECODE === '1';
+    // When nested inside Claude Code, use stderr for status so stdout is clean for content
+    const log = isNested ? (...args) => console.error(...args) : (...args) => console.log(...args);
+
+    // If not a URL or local file, treat as a registry name
+    if (!isUrl && !isLocalFile) {
+      const { getClient, parseNameVersion } = require('../dist/registry-client');
+      const [dossierName, version] = parseNameVersion(file);
+
+      const cacheDir = path.join(os.homedir(), '.dossier', 'cache');
+      let cached = false;
+
+      // Check cache first (unless --no-cache)
+      if (!options.fresh) {
+        const dossierCacheDir = path.join(cacheDir, ...dossierName.split('/'));
+        if (fs.existsSync(dossierCacheDir)) {
+          const metaFiles = fs.readdirSync(dossierCacheDir).filter(f => f.endsWith('.meta.json'));
+          for (const mf of metaFiles) {
+            const ver = mf.replace('.meta.json', '');
+            if (version && ver !== version) continue;
+            const contentFile = path.join(dossierCacheDir, `${ver}.ds.md`);
+            if (fs.existsSync(contentFile)) {
+              if (!options.pull) {
+                resolvedFile = contentFile;
+                cached = true;
+                log(`📦 Using cached: ${dossierName}@${ver}\n`);
+                break;
+              }
+            }
+          }
+        }
+      }
+
+      // Fetch from registry if not cached (or --pull / --no-cache)
+      if (!cached) {
+        try {
+          const client = getClient();
+          let resolvedVersion = version;
+          if (!resolvedVersion) {
+            const meta = await client.getDossier(dossierName);
+            resolvedVersion = meta.version || 'latest';
+          }
+          const result = await client.getDossierContent(dossierName, resolvedVersion);
+
+          // Cache it (unless --no-cache)
+          if (!options.fresh) {
+            const dossierCacheDir = path.join(cacheDir, ...dossierName.split('/'));
+            fs.mkdirSync(dossierCacheDir, { recursive: true, mode: 0o700 });
+            const contentFile = path.join(dossierCacheDir, `${resolvedVersion}.ds.md`);
+            fs.writeFileSync(contentFile, result.content, 'utf8');
+            fs.writeFileSync(path.join(dossierCacheDir, `${resolvedVersion}.meta.json`), JSON.stringify({
+              cached_at: new Date().toISOString(),
+              version: resolvedVersion,
+              source_registry_url: client.baseUrl.replace(/\/api\/v1$/, ''),
+            }, null, 2), 'utf8');
+            resolvedFile = contentFile;
+            log(`📥 Fetched: ${dossierName}@${resolvedVersion}\n`);
+          } else {
+            // Write to temp file
+            const tmpFile = path.join(os.tmpdir(), `dossier-${Date.now()}.ds.md`);
+            fs.writeFileSync(tmpFile, result.content, 'utf8');
+            resolvedFile = tmpFile;
+            log(`📥 Fetched: ${dossierName}@${resolvedVersion} (not cached)\n`);
+          }
+        } catch (err) {
+          if (err.statusCode === 404) {
+            console.error(`\n❌ Not found: ${file}`);
+            console.error('   Not a local file and not found in registry\n');
+          } else {
+            console.error(`\n❌ Failed to fetch: ${err.message}\n`);
+          }
+          process.exit(1);
+        }
+      }
+    }
+
+    // Show metadata summary
+    try {
+      const content = fs.readFileSync(path.resolve(resolvedFile), 'utf8');
+      const jsonMatch = content.match(/^---dossier\s*\n([\s\S]*?)\n---\n?/);
+      const yamlMatch = !jsonMatch && content.match(/^---\n([\s\S]*?)\n---\n?/);
+      let fm = null;
+
+      if (jsonMatch) {
+        try { fm = JSON.parse(jsonMatch[1]); } catch {}
+      } else if (yamlMatch) {
+        fm = {};
+        for (const line of yamlMatch[1].split('\n')) {
+          const kv = line.match(/^(\w[\w_-]*):\s*(.+)$/);
+          if (kv) fm[kv[1]] = kv[2].trim();
+        }
+      }
+
+      if (fm && (fm.title || fm.risk_level || fm.objective)) {
+        log('📄 Dossier Summary:');
+        if (fm.title) log(`   Title:      ${fm.title}`);
+        if (fm.version) log(`   Version:    ${fm.version}`);
+        if (fm.risk_level) log(`   Risk Level: ${fm.risk_level}`);
+        if (fm.objective || fm.description) {
+          const obj = fm.objective || fm.description;
+          const snippet = obj.length > 100 ? obj.slice(0, 100) + '...' : obj;
+          log(`   Objective:  ${snippet}`);
+        }
+        log('');
+      }
+    } catch {
+      // Non-fatal — skip metadata summary
+    }
+
+    // Nested session detection: if inside Claude Code, print content instead of spawning
+    if (process.env.CLAUDE_CODE === '1' || process.env.CLAUDECODE === '1') {
+      console.error('ℹ️  Running inside Claude Code — outputting dossier content\n');
+      try {
+        const content = fs.readFileSync(path.resolve(resolvedFile), 'utf8');
+        process.stdout.write(content);
+        process.exit(0);
+      } catch (err) {
+        console.error(`\n❌ Failed to read dossier: ${err.message}\n`);
+        process.exit(1);
+      }
+    }
+
     // Use shared verification function
-    const result = await runVerification(file, options);
+    const result = await runVerification(resolvedFile, options);
 
     if (!result.passed) {
       console.log('❌ Verification failed - cannot execute\n');
@@ -304,12 +434,12 @@ program
     if (options.dryRun) {
       console.log('🧪 DRY RUN MODE - No execution\n');
       console.log('Would execute:');
-      console.log(`   File: ${file}`);
+      console.log(`   File: ${resolvedFile}`);
       console.log(`   LLM: ${llmOption}`);
 
       // Detect LLM and build command
       const llmToUse = detectLlm(llmOption, true);
-      const command = llmToUse ? buildLlmCommand(llmToUse, file, options.headless) : 'No LLM detected - would show error';
+      const command = llmToUse ? buildLlmCommand(llmToUse, resolvedFile, options.headless) : 'No LLM detected - would show error';
 
       console.log(`   Command: ${command}\n`);
       console.log('✅ All verifications passed - ready to execute');
@@ -325,7 +455,7 @@ program
     }
 
     // Build and execute command (interactive by default, headless if flag set)
-    const command = buildLlmCommand(llmToUse, file, options.headless);
+    const command = buildLlmCommand(llmToUse, resolvedFile, options.headless);
     if (!command) {
       console.log(`❌ Unknown LLM: ${llmToUse}\n`);
       console.log('Supported: claude-code, auto\n');


### PR DESCRIPTION
## Summary
- Implement publish and remove commands for registry (#41)
- Add search command and registry source to list (#42)
- Implement pull, export, and cache management commands (#43)
- Implement install-skill and info commands (#44)
- Improve run command with nested detection and cache integration (#45)

## Details
These 5 commits add the full suite of registry interaction commands to the CLI, including publishing, searching, pulling, exporting, installing skills, and an improved run command with nested dossier detection and local cache integration.

## Test plan
- [ ] Verify `dossier publish` works against registry
- [ ] Verify `dossier search` returns results
- [ ] Verify `dossier pull` and `dossier export` work
- [ ] Verify `dossier install-skill` and `dossier info` work
- [ ] Verify `dossier run` with nested detection and cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)