### PR TITLE
fix: correct default registry URL and audit registry API

### DIFF
--- a/cli/src/registry-client.ts
+++ b/cli/src/registry-client.ts
@@ -3,7 +3,7 @@
  * Uses Node.js built-in fetch (Node 18+).
  */
 
-const DEFAULT_REGISTRY_URL = 'https://dossier-registry-mvp-ten.vercel.app';
+const DEFAULT_REGISTRY_URL = 'https://dossier-registry-mvp.vercel.app';
 
 class RegistryError extends Error {
   statusCode: number | null;


### PR DESCRIPTION
## Summary
- Fix `DEFAULT_REGISTRY_URL` in `cli/src/registry-client.ts` from stale auto-generated Vercel URL (`dossier-registry-mvp-ten.vercel.app`) to the actual production alias (`dossier-registry-mvp.vercel.app`)
- Registry API changes (deployed separately to `dossier-registry-mvp`):
  - Added `GET /api/v1/search` endpoint with case-insensitive substring matching
  - Changed content endpoint from 302 redirect to direct content delivery with `X-Dossier-Digest` header
  - Added CORS headers and OPTIONS preflight to all endpoints

Closes #46

## Test plan
- [x] Registry deployed to production and verified:
  - `GET /api/v1/search?q=hello` — returns matching results
  - `GET /api/v1/dossiers/.../content` — returns markdown body with `X-Dossier-Digest: sha256:...`
  - `OPTIONS /api/v1/dossiers` — returns 204 with CORS headers
- [ ] Verify `dossier search` CLI command works against production registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)