### PR TITLE
feat: implement CLI parity gaps with dossier-tools (#61)

### DIFF
--- a/cli/src/__tests__/commands/cache.test.ts
+++ b/cli/src/__tests__/commands/cache.test.ts
@@ -41,6 +41,46 @@ describe('cache command', () => {
       expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Cached dossiers'));
     });
 
+    it('should show sizes with --size flag', async () => {
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readdirSync.mockReturnValue([
+        { name: '1.0.0.meta.json', isDirectory: () => false } as any,
+      ] as any);
+      mockedFs.readFileSync.mockReturnValue(JSON.stringify({ cached_at: '2025-01-01T00:00:00Z' }));
+      mockedFs.statSync.mockReturnValue({ size: 2048 } as any);
+
+      const program = createTestProgram();
+      registerCacheCommand(program);
+
+      await expect(
+        program.parseAsync(['node', 'dossier', 'cache', 'list', '--size'])
+      ).rejects.toThrow('process.exit(0)');
+
+      // SIZE header should appear with --size
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('SIZE'));
+    });
+
+    it('should not show sizes without --size flag', async () => {
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readdirSync.mockReturnValue([
+        { name: '1.0.0.meta.json', isDirectory: () => false } as any,
+      ] as any);
+      mockedFs.readFileSync.mockReturnValue(JSON.stringify({ cached_at: '2025-01-01T00:00:00Z' }));
+      mockedFs.statSync.mockReturnValue({ size: 512 } as any);
+
+      const program = createTestProgram();
+      registerCacheCommand(program);
+
+      await expect(program.parseAsync(['node', 'dossier', 'cache', 'list'])).rejects.toThrow(
+        'process.exit(0)'
+      );
+
+      // Check that SIZE header is NOT in any log call
+      const logCalls = vi.mocked(console.log).mock.calls;
+      const hasSizeHeader = logCalls.some((c) => typeof c[0] === 'string' && c[0].includes('SIZE'));
+      expect(hasSizeHeader).toBe(false);
+    });
+
     it('should output JSON with --json', async () => {
       mockedFs.existsSync.mockReturnValue(true);
       mockedFs.readdirSync.mockReturnValue([

--- a/cli/src/__tests__/commands/from-file.test.ts
+++ b/cli/src/__tests__/commands/from-file.test.ts
@@ -1,0 +1,182 @@
+import fs from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { registerFromFileCommand } from '../../commands/from-file';
+import { createTestProgram } from '../helpers/test-utils';
+
+vi.mock('node:fs');
+vi.mock('@imboard-ai/dossier-core', () => ({
+  calculateChecksum: vi.fn().mockReturnValue('abc123hash'),
+  Ed25519Signer: vi.fn().mockImplementation(() => ({
+    sign: vi.fn().mockResolvedValue({
+      algorithm: 'ed25519',
+      signature: 'sig-base64',
+      public_key: 'pub-pem',
+      signed_at: '2025-01-01T00:00:00Z',
+    }),
+  })),
+}));
+
+const mockedFs = vi.mocked(fs);
+
+describe('from-file command', () => {
+  it('should create a dossier from a text file', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue('Body content here.');
+
+    const program = createTestProgram();
+    registerFromFileCommand(program);
+
+    await expect(
+      program.parseAsync([
+        'node',
+        'dossier',
+        'from-file',
+        'input.txt',
+        '--name',
+        'test-dossier',
+        '--title',
+        'Test Dossier',
+        '--objective',
+        'Test objective',
+        '--author',
+        'Alice',
+      ])
+    ).rejects.toThrow('process.exit(0)');
+
+    expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('test-dossier.ds.md'),
+      expect.stringContaining('---dossier'),
+      'utf8'
+    );
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Dossier created'));
+  });
+
+  it('should fail when input file not found', async () => {
+    mockedFs.existsSync.mockReturnValue(false);
+
+    const program = createTestProgram();
+    registerFromFileCommand(program);
+
+    await expect(
+      program.parseAsync([
+        'node',
+        'dossier',
+        'from-file',
+        'missing.txt',
+        '--name',
+        'test',
+        '--title',
+        'Test',
+        '--objective',
+        'Test',
+        '--author',
+        'Alice',
+      ])
+    ).rejects.toThrow('process.exit(1)');
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Input file not found'));
+  });
+
+  it('should fail when required fields are missing', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue('Body content.');
+
+    const program = createTestProgram();
+    registerFromFileCommand(program);
+
+    await expect(program.parseAsync(['node', 'dossier', 'from-file', 'input.txt'])).rejects.toThrow(
+      'process.exit(1)'
+    );
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Missing required fields'));
+  });
+
+  it('should load metadata from --meta file', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockImplementation((filePath: any) => {
+      if (String(filePath).includes('meta.json')) {
+        return JSON.stringify({
+          name: 'meta-dossier',
+          title: 'Meta Title',
+          objective: 'Meta objective',
+          authors: ['Bob'],
+        });
+      }
+      return 'Body from file.';
+    });
+
+    const program = createTestProgram();
+    registerFromFileCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'dossier', 'from-file', 'input.txt', '--meta', 'meta.json'])
+    ).rejects.toThrow('process.exit(0)');
+
+    expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('meta-dossier.ds.md'),
+      expect.stringContaining('Meta Title'),
+      'utf8'
+    );
+  });
+
+  it('should use custom output path with -o', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue('Body.');
+
+    const program = createTestProgram();
+    registerFromFileCommand(program);
+
+    await expect(
+      program.parseAsync([
+        'node',
+        'dossier',
+        'from-file',
+        'input.txt',
+        '--name',
+        'test',
+        '--title',
+        'Test',
+        '--objective',
+        'Test',
+        '--author',
+        'Alice',
+        '-o',
+        'custom-output.ds.md',
+      ])
+    ).rejects.toThrow('process.exit(0)');
+
+    expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('custom-output.ds.md'),
+      expect.any(String),
+      'utf8'
+    );
+  });
+
+  it('should fail --sign without --key', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue('Body.');
+
+    const program = createTestProgram();
+    registerFromFileCommand(program);
+
+    await expect(
+      program.parseAsync([
+        'node',
+        'dossier',
+        'from-file',
+        'input.txt',
+        '--name',
+        'test',
+        '--title',
+        'Test',
+        '--objective',
+        'Test',
+        '--author',
+        'Alice',
+        '--sign',
+      ])
+    ).rejects.toThrow('process.exit(1)');
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('--key is required'));
+  });
+});

--- a/cli/src/__tests__/commands/get.test.ts
+++ b/cli/src/__tests__/commands/get.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { registerGetCommand } from '../../commands/get';
+import * as registryClient from '../../registry-client';
+import { createTestProgram } from '../helpers/test-utils';
+
+vi.mock('../../registry-client');
+
+describe('get command', () => {
+  const mockClient = { getDossier: vi.fn() };
+
+  beforeEach(() => {
+    vi.mocked(registryClient.getClient).mockReturnValue(mockClient as any);
+    vi.mocked(registryClient.parseNameVersion).mockImplementation((name: string) => {
+      if (name.includes('@')) {
+        const idx = name.lastIndexOf('@');
+        return [name.slice(0, idx), name.slice(idx + 1)];
+      }
+      return [name, null];
+    });
+  });
+
+  it('should display dossier metadata from registry', async () => {
+    mockClient.getDossier.mockResolvedValue({
+      name: 'deploy-app',
+      title: 'Deploy Application',
+      version: '1.0.0',
+      status: 'stable',
+      category: ['devops'],
+      objective: 'Deploy to production',
+      authors: [{ name: 'Alice' }],
+      tags: ['deploy', 'ci'],
+    });
+
+    const program = createTestProgram();
+    registerGetCommand(program);
+
+    await expect(program.parseAsync(['node', 'dossier', 'get', 'deploy-app'])).rejects.toThrow(
+      'process.exit(0)'
+    );
+
+    expect(mockClient.getDossier).toHaveBeenCalledWith('deploy-app', null);
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('deploy-app'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Deploy Application'));
+  });
+
+  it('should pass version when using name@version', async () => {
+    mockClient.getDossier.mockResolvedValue({
+      name: 'deploy-app',
+      title: 'Deploy Application',
+      version: '2.0.0',
+    });
+
+    const program = createTestProgram();
+    registerGetCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'dossier', 'get', 'deploy-app@2.0.0'])
+    ).rejects.toThrow('process.exit(0)');
+
+    expect(mockClient.getDossier).toHaveBeenCalledWith('deploy-app', '2.0.0');
+  });
+
+  it('should output JSON with --json', async () => {
+    mockClient.getDossier.mockResolvedValue({
+      name: 'test',
+      title: 'Test',
+      version: '1.0.0',
+    });
+
+    const program = createTestProgram();
+    registerGetCommand(program);
+
+    await expect(program.parseAsync(['node', 'dossier', 'get', 'test', '--json'])).rejects.toThrow(
+      'process.exit(0)'
+    );
+
+    const jsonCalls = vi
+      .mocked(console.log)
+      .mock.calls.filter((c) => typeof c[0] === 'string' && c[0].includes('"name"'));
+    expect(jsonCalls.length).toBeGreaterThan(0);
+  });
+
+  it('should exit 1 on 404', async () => {
+    const err = new Error('Not found');
+    (err as any).statusCode = 404;
+    mockClient.getDossier.mockRejectedValue(err);
+
+    const program = createTestProgram();
+    registerGetCommand(program);
+
+    await expect(program.parseAsync(['node', 'dossier', 'get', 'nonexistent'])).rejects.toThrow(
+      'process.exit(1)'
+    );
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Not found in registry'));
+  });
+
+  it('should exit 1 on other errors', async () => {
+    mockClient.getDossier.mockRejectedValue(new Error('Network error'));
+
+    const program = createTestProgram();
+    registerGetCommand(program);
+
+    await expect(program.parseAsync(['node', 'dossier', 'get', 'some-dossier'])).rejects.toThrow(
+      'process.exit(1)'
+    );
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Registry error'));
+  });
+});

--- a/cli/src/__tests__/commands/keys.test.ts
+++ b/cli/src/__tests__/commands/keys.test.ts
@@ -1,9 +1,35 @@
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
 import { registerKeysCommand } from '../../commands/keys';
 import { createTestProgram } from '../helpers/test-utils';
 
 vi.mock('node:fs');
+vi.mock('node:crypto', async () => {
+  const actual = await vi.importActual<typeof import('node:crypto')>('node:crypto');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      generateKeyPairSync: vi.fn().mockReturnValue({
+        privateKey: {
+          export: vi
+            .fn()
+            .mockReturnValue('-----BEGIN PRIVATE KEY-----\nmock\n-----END PRIVATE KEY-----\n'),
+        },
+        publicKey: {
+          export: vi.fn().mockImplementation((opts: any) => {
+            if (opts.format === 'der') {
+              // Return a buffer with 44 bytes (12 header + 32 key)
+              return Buffer.alloc(44, 0);
+            }
+            return '-----BEGIN PUBLIC KEY-----\nmock\n-----END PUBLIC KEY-----\n';
+          }),
+        },
+      }),
+    },
+  };
+});
 
 const mockedFs = vi.mocked(fs);
 
@@ -48,6 +74,67 @@ describe('keys command', () => {
         .mocked(console.log)
         .mock.calls.filter((c) => typeof c[0] === 'string' && c[0].includes('public_key'));
       expect(jsonCalls.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('keys generate', () => {
+    it('should generate a key pair', async () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const program = createTestProgram();
+      registerKeysCommand(program);
+
+      await expect(program.parseAsync(['node', 'dossier', 'keys', 'generate'])).rejects.toThrow(
+        'process.exit(0)'
+      );
+
+      expect(mockedFs.writeFileSync).toHaveBeenCalledTimes(2);
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Key pair generated'));
+    });
+
+    it('should use custom name', async () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const program = createTestProgram();
+      registerKeysCommand(program);
+
+      await expect(
+        program.parseAsync(['node', 'dossier', 'keys', 'generate', '--name', 'mykey'])
+      ).rejects.toThrow('process.exit(0)');
+
+      expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('mykey.pem'),
+        expect.any(String),
+        expect.any(Object)
+      );
+    });
+
+    it('should refuse to overwrite without --force', async () => {
+      mockedFs.existsSync.mockReturnValue(true);
+
+      const program = createTestProgram();
+      registerKeysCommand(program);
+
+      await expect(program.parseAsync(['node', 'dossier', 'keys', 'generate'])).rejects.toThrow(
+        'process.exit(1)'
+      );
+
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('already exist'));
+    });
+
+    it('should overwrite with --force', async () => {
+      mockedFs.existsSync.mockImplementation(() => true);
+      mockedFs.writeFileSync.mockClear();
+
+      const program = createTestProgram();
+      registerKeysCommand(program);
+
+      await expect(
+        program.parseAsync(['node', 'dossier', 'keys', 'generate', '--force'])
+      ).rejects.toThrow('process.exit(0)');
+
+      expect(mockedFs.writeFileSync).toHaveBeenCalledTimes(2);
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Key pair generated'));
     });
   });
 

--- a/cli/src/__tests__/commands/search.test.ts
+++ b/cli/src/__tests__/commands/search.test.ts
@@ -6,7 +6,7 @@ import { createTestProgram } from '../helpers/test-utils';
 vi.mock('../../registry-client');
 
 describe('search command', () => {
-  const mockClient = { listDossiers: vi.fn() };
+  const mockClient = { listDossiers: vi.fn(), getDossierContent: vi.fn() };
 
   beforeEach(() => {
     vi.mocked(registryClient.getClient).mockReturnValue(mockClient as any);
@@ -71,6 +71,46 @@ describe('search command', () => {
       .mocked(console.log)
       .mock.calls.filter((c) => typeof c[0] === 'string' && c[0].includes('"dossiers"'));
     expect(jsonCalls.length).toBeGreaterThan(0);
+  });
+
+  it('should filter by content with --content flag', async () => {
+    mockClient.listDossiers.mockResolvedValue({
+      dossiers: [
+        {
+          name: 'deploy-app',
+          title: 'Deploy Application',
+          description: 'Deploy to production',
+          category: 'devops',
+          tags: ['deploy'],
+          version: '1.0.0',
+        },
+        {
+          name: 'setup-db',
+          title: 'Setup Database',
+          description: 'Initialize database',
+          category: 'database',
+          tags: ['db'],
+          version: '1.0.0',
+        },
+      ],
+    });
+
+    mockClient.getDossierContent.mockImplementation(async (name: string) => {
+      if (name === 'deploy-app') {
+        return { content: 'This is about deploying kubernetes clusters', digest: null };
+      }
+      return { content: 'This is about postgres setup', digest: null };
+    });
+
+    const program = createTestProgram();
+    registerSearchCommand(program);
+
+    // Search for "kubernetes" with --content; only deploy-app body contains it
+    // First, metadata filter for "deploy" matches deploy-app
+    await program.parseAsync(['node', 'dossier', 'search', 'deploy', '--content']);
+
+    expect(mockClient.getDossierContent).toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('deploy-app'));
   });
 
   it('should exit 1 on API error', async () => {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -14,6 +14,8 @@ import { registerConfigCommand } from './commands/config-cmd';
 import { registerCreateCommand } from './commands/create';
 import { registerExportCommand } from './commands/export';
 import { registerFormatCommand } from './commands/format';
+import { registerFromFileCommand } from './commands/from-file';
+import { registerGetCommand } from './commands/get';
 import { registerInfoCommand } from './commands/info';
 import { registerInitCommand } from './commands/init';
 import { registerInstallSkillCommand } from './commands/install-skill';
@@ -67,6 +69,8 @@ registerInstallSkillCommand(program);
 registerKeysCommand(program);
 registerLintCommand(program);
 registerFormatCommand(program);
+registerFromFileCommand(program);
+registerGetCommand(program);
 
 // Parse and execute
 program.parse(process.argv);

--- a/cli/src/commands/cache.ts
+++ b/cli/src/commands/cache.ts
@@ -12,7 +12,8 @@ export function registerCacheCommand(program: Command): void {
     .command('list')
     .description('Show all cached dossiers')
     .option('--json', 'Output as JSON')
-    .action((options: { json?: boolean }) => {
+    .option('--size', 'Show file sizes')
+    .action((options: { json?: boolean; size?: boolean }) => {
       const cacheDir = path.join(os.homedir(), '.dossier', 'cache');
 
       if (!fs.existsSync(cacheDir)) {
@@ -78,14 +79,23 @@ export function registerCacheCommand(program: Command): void {
       }
 
       console.log(`\n📦 Cached dossiers (${entries.length}):\n`);
-      console.log(`  ${'NAME'.padEnd(40)} ${'VERSION'.padEnd(10)} ${'SIZE'.padEnd(8)} CACHED AT`);
-      console.log(`  ${'─'.repeat(40)} ${'─'.repeat(10)} ${'─'.repeat(8)} ${'─'.repeat(19)}`);
+      if (options.size) {
+        console.log(`  ${'NAME'.padEnd(40)} ${'VERSION'.padEnd(10)} ${'SIZE'.padEnd(8)} CACHED AT`);
+        console.log(`  ${'─'.repeat(40)} ${'─'.repeat(10)} ${'─'.repeat(8)} ${'─'.repeat(19)}`);
+      } else {
+        console.log(`  ${'NAME'.padEnd(40)} ${'VERSION'.padEnd(10)} CACHED AT`);
+        console.log(`  ${'─'.repeat(40)} ${'─'.repeat(10)} ${'─'.repeat(19)}`);
+      }
 
       for (const e of entries) {
         const date = e.cached_at ? e.cached_at.slice(0, 19).replace('T', ' ') : '';
-        console.log(
-          `  ${e.name.padEnd(40)} ${e.version.padEnd(10)} ${formatSize(e.size).padEnd(8)} ${date}`
-        );
+        if (options.size) {
+          console.log(
+            `  ${e.name.padEnd(40)} ${e.version.padEnd(10)} ${formatSize(e.size).padEnd(8)} ${date}`
+          );
+        } else {
+          console.log(`  ${e.name.padEnd(40)} ${e.version.padEnd(10)} ${date}`);
+        }
       }
       console.log('');
       process.exit(0);

--- a/cli/src/commands/from-file.ts
+++ b/cli/src/commands/from-file.ts
@@ -1,0 +1,146 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { calculateChecksum, Ed25519Signer } from '@imboard-ai/dossier-core';
+import type { Command } from 'commander';
+
+export function registerFromFileCommand(program: Command): void {
+  program
+    .command('from-file')
+    .description('Create a dossier from a plain text file')
+    .argument('<input>', 'Path to text file (body content)')
+    .option('--name <name>', 'Dossier name')
+    .option('--title <title>', 'Dossier title')
+    .option('--version <version>', 'Dossier version', '1.0.0')
+    .option('--status <status>', 'Dossier status', 'stable')
+    .option('--objective <text>', 'Dossier objective')
+    .option('--author <name>', 'Author name (repeatable)', collectValues, [])
+    .option('--meta <path>', 'JSON file with frontmatter fields')
+    .option('--sign', 'Sign the dossier')
+    .option('--key <path>', 'Private key path for signing')
+    .option('--signed-by <name>', 'Signer identity')
+    .option('-o, --output <path>', 'Output file path')
+    .action(
+      async (
+        input: string,
+        options: {
+          name?: string;
+          title?: string;
+          version: string;
+          status: string;
+          objective?: string;
+          author: string[];
+          meta?: string;
+          sign?: boolean;
+          key?: string;
+          signedBy?: string;
+          output?: string;
+        }
+      ) => {
+        const inputPath = path.resolve(input);
+        if (!fs.existsSync(inputPath)) {
+          console.error(`\n❌ Input file not found: ${inputPath}\n`);
+          process.exit(1);
+        }
+
+        const body = fs.readFileSync(inputPath, 'utf8');
+
+        // Load meta file if provided
+        let meta: Record<string, unknown> = {};
+        if (options.meta) {
+          const metaPath = path.resolve(options.meta);
+          if (!fs.existsSync(metaPath)) {
+            console.error(`\n❌ Meta file not found: ${metaPath}\n`);
+            process.exit(1);
+          }
+          try {
+            meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+          } catch (err: unknown) {
+            console.error(`\n❌ Invalid JSON in meta file: ${(err as Error).message}\n`);
+            process.exit(1);
+          }
+        }
+
+        // Flags override meta
+        const name = options.name || (meta.name as string);
+        const title = options.title || (meta.title as string);
+        const objective = options.objective || (meta.objective as string);
+        const authors =
+          options.author.length > 0 ? options.author : (meta.authors as string[]) || [];
+
+        // Validate required fields
+        const missing: string[] = [];
+        if (!name) missing.push('name');
+        if (!title) missing.push('title');
+        if (!objective) missing.push('objective');
+        if (authors.length === 0) missing.push('author');
+
+        if (missing.length > 0) {
+          console.error(`\n❌ Missing required fields: ${missing.join(', ')}`);
+          console.error('   Provide them via flags or --meta file\n');
+          process.exit(1);
+        }
+
+        // Build frontmatter
+        const frontmatter: Record<string, unknown> = {
+          ...meta,
+          name,
+          title,
+          version: options.version,
+          status: options.status,
+          objective,
+          authors: authors.map((a) => ({ name: a })),
+          checksum: {
+            algorithm: 'sha256',
+            hash: calculateChecksum(body),
+          },
+        };
+
+        // Sign if requested
+        if (options.sign) {
+          if (!options.key) {
+            console.error('\n❌ --key is required when using --sign\n');
+            process.exit(1);
+          }
+          const keyPath = path.resolve(options.key);
+          if (!fs.existsSync(keyPath)) {
+            console.error(`\n❌ Key file not found: ${keyPath}\n`);
+            process.exit(1);
+          }
+
+          try {
+            const signer = new Ed25519Signer(keyPath);
+            const sigResult = await signer.sign(body);
+            frontmatter.signature = {
+              ...sigResult,
+              signed_by: options.signedBy || 'unknown',
+            };
+          } catch (err: unknown) {
+            console.error(`\n❌ Signing failed: ${(err as Error).message}\n`);
+            process.exit(1);
+          }
+        }
+
+        const output = `---dossier\n${JSON.stringify(frontmatter, null, 2)}\n---\n${body}`;
+        const outputPath = options.output
+          ? path.resolve(options.output)
+          : path.resolve(`${name}.ds.md`);
+
+        fs.writeFileSync(outputPath, output, 'utf8');
+
+        console.log(`\n✅ Dossier created: ${outputPath}`);
+        console.log(`   Name:    ${name}`);
+        console.log(`   Title:   ${title}`);
+        console.log(`   Version: ${options.version}`);
+        if (options.sign) {
+          console.log('   Signed:  yes');
+        }
+        console.log('');
+
+        process.exit(0);
+      }
+    );
+}
+
+function collectValues(value: string, previous: string[]): string[] {
+  return previous.concat([value]);
+}

--- a/cli/src/commands/get.ts
+++ b/cli/src/commands/get.ts
@@ -1,0 +1,71 @@
+import type { Command } from 'commander';
+import { getClient, parseNameVersion } from '../registry-client';
+
+export function registerGetCommand(program: Command): void {
+  program
+    .command('get')
+    .description('Get dossier metadata from the registry')
+    .argument('<name>', 'Dossier name (optionally with @version, e.g., my-dossier@1.0.0)')
+    .option('--json', 'Output as JSON')
+    .action(async (nameArg: string, options: { json?: boolean }) => {
+      const [dossierName, version] = parseNameVersion(nameArg);
+
+      let meta: any;
+      try {
+        const client = getClient();
+        meta = await client.getDossier(dossierName, version || null);
+      } catch (err: any) {
+        if (err.statusCode === 404) {
+          console.error(`\n❌ Not found in registry: ${nameArg}\n`);
+        } else {
+          console.error(`\n❌ Registry error: ${err.message}\n`);
+        }
+        process.exit(1);
+      }
+
+      if (options.json) {
+        console.log(JSON.stringify(meta, null, 2));
+        process.exit(0);
+      }
+
+      console.log(`\n📄 Dossier: ${meta.name || dossierName}\n`);
+
+      const fields: [string, string][] = [
+        ['Name', meta.name || ''],
+        ['Title', meta.title || ''],
+        ['Version', meta.version || ''],
+        ['Status', meta.status || ''],
+        ['Category', Array.isArray(meta.category) ? meta.category.join(', ') : meta.category || ''],
+        ['Risk Level', meta.risk_level || ''],
+        ['Objective', meta.objective || meta.description || ''],
+      ];
+
+      for (const [label, value] of fields) {
+        if (value) {
+          console.log(`   ${label.padEnd(12)} ${value}`);
+        }
+      }
+
+      const authors = meta.authors;
+      if (Array.isArray(authors) && authors.length > 0) {
+        const authorStr = authors
+          .map((a: any) => (typeof a === 'string' ? a : a.name || ''))
+          .filter(Boolean)
+          .join(', ');
+        if (authorStr) console.log(`   Authors      ${authorStr}`);
+      }
+
+      if (Array.isArray(meta.tags) && meta.tags.length > 0) {
+        console.log(`   Tags         ${meta.tags.join(', ')}`);
+      }
+
+      if (meta.signature) {
+        console.log(
+          `   Signed by    ${meta.signature.signed_by || meta.signature.key_id || 'unknown'}`
+        );
+      }
+
+      console.log('');
+      process.exit(0);
+    });
+}

--- a/cli/src/commands/keys.ts
+++ b/cli/src/commands/keys.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -5,6 +6,58 @@ import type { Command } from 'commander';
 
 export function registerKeysCommand(program: Command): void {
   const keysCmd = program.command('keys').description('Manage trusted signing keys');
+
+  keysCmd
+    .command('generate')
+    .description('Generate a new Ed25519 signing key pair')
+    .option('--name <name>', 'Key pair name', 'default')
+    .option('--force', 'Overwrite existing key files')
+    .action((options: { name: string; force?: boolean }) => {
+      const dossierDir = path.join(os.homedir(), '.dossier');
+      const privatePath = path.join(dossierDir, `${options.name}.pem`);
+      const publicPath = path.join(dossierDir, `${options.name}.pub`);
+
+      console.log('\n🔑 Generating Ed25519 Key Pair\n');
+
+      if (!options.force) {
+        if (fs.existsSync(privatePath) || fs.existsSync(publicPath)) {
+          console.error(
+            `❌ Key files already exist for "${options.name}". Use --force to overwrite.`
+          );
+          process.exit(1);
+        }
+      }
+
+      if (!fs.existsSync(dossierDir)) {
+        fs.mkdirSync(dossierDir, { recursive: true });
+      }
+
+      const { privateKey, publicKey } = crypto.generateKeyPairSync('ed25519');
+
+      const privatePem = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+      const publicPem = publicKey.export({ type: 'spki', format: 'pem' }) as string;
+
+      fs.writeFileSync(privatePath, privatePem, { mode: 0o600 });
+      fs.writeFileSync(publicPath, publicPem, { mode: 0o644 });
+
+      // Extract raw public key bytes for base64 sharing
+      const publicDer = publicKey.export({ type: 'spki', format: 'der' });
+      // Ed25519 SPKI DER has 12-byte header, raw key is last 32 bytes
+      const rawPublicKey = publicDer.subarray(publicDer.length - 32);
+      const publicKeyBase64 = rawPublicKey.toString('base64');
+
+      console.log(`✅ Key pair generated successfully`);
+      console.log(`   Name:        ${options.name}`);
+      console.log(`   Private key: ${privatePath}`);
+      console.log(`   Public key:  ${publicPath}`);
+      console.log(`   Public key (base64): ${publicKeyBase64}`);
+      console.log('\nTo sign a dossier:');
+      console.log(`   dossier sign <file> --method ed25519 --key ${privatePath}`);
+      console.log('\nTo add this public key as trusted:');
+      console.log(`   dossier keys add ${publicKeyBase64} "${options.name}"\n`);
+
+      process.exit(0);
+    });
 
   keysCmd
     .command('list')

--- a/cli/src/commands/search.ts
+++ b/cli/src/commands/search.ts
@@ -12,11 +12,18 @@ export function registerSearchCommand(program: Command): void {
     )
     .option('--page <number>', 'Page number', '1')
     .option('--per-page <number>', 'Results per page', '20')
+    .option('-c, --content', 'Also search dossier body content')
     .option('--json', 'Output as JSON')
     .action(
       async (
         query: string,
-        options: { category?: string; page: string; perPage: string; json?: boolean }
+        options: {
+          category?: string;
+          page: string;
+          perPage: string;
+          json?: boolean;
+          content?: boolean;
+        }
       ) => {
         const page = parseInt(options.page, 10) || 1;
         const perPage = parseInt(options.perPage, 10) || 20;
@@ -39,7 +46,7 @@ export function registerSearchCommand(program: Command): void {
         const queryLower = query.toLowerCase();
         const terms = queryLower.split(/\s+/).filter(Boolean);
 
-        const matched = allDossiers.filter((d: any) => {
+        let matched = allDossiers.filter((d: any) => {
           const fields = [
             d.name || '',
             d.title || '',
@@ -52,6 +59,56 @@ export function registerSearchCommand(program: Command): void {
 
           return terms.every((term) => fields.includes(term) || fields.indexOf(term) !== -1);
         });
+
+        // Content search: fetch body and filter by content match
+        if (options.content) {
+          const client = getClient();
+          const CONCURRENCY = 5;
+          const contentMatches: Map<string, string> = new Map();
+
+          // Process in batches for concurrency limiting
+          for (let i = 0; i < matched.length; i += CONCURRENCY) {
+            const batch = matched.slice(i, i + CONCURRENCY);
+            const results = await Promise.all(
+              batch.map(async (d: any) => {
+                try {
+                  const { content } = await client.getDossierContent(d.name, d.version || null);
+                  const bodyLower = content.toLowerCase();
+                  if (terms.some((term) => bodyLower.includes(term))) {
+                    // Extract snippet around first match
+                    const firstTerm = terms.find((t) => bodyLower.includes(t))!;
+                    const idx = bodyLower.indexOf(firstTerm);
+                    const start = Math.max(0, idx - 50);
+                    const end = Math.min(content.length, idx + firstTerm.length + 50);
+                    const snippet =
+                      (start > 0 ? '...' : '') +
+                      content.slice(start, end).replace(/\n/g, ' ') +
+                      (end < content.length ? '...' : '');
+                    contentMatches.set(d.name, snippet);
+                    return d;
+                  }
+                  return null;
+                } catch {
+                  return null;
+                }
+              })
+            );
+            // We don't filter here yet; we collect results
+            for (const r of results) {
+              if (r === null) {
+                // Mark for removal
+              }
+            }
+          }
+
+          // Keep only dossiers that matched in content
+          matched = matched.filter((d: any) => contentMatches.has(d.name));
+
+          // Attach snippets for display
+          for (const d of matched) {
+            (d as any)._contentSnippet = contentMatches.get(d.name);
+          }
+        }
 
         const total = matched.length;
         const start = (page - 1) * perPage;
@@ -84,6 +141,9 @@ export function registerSearchCommand(program: Command): void {
             const snippet =
               description.length > 100 ? description.slice(0, 100) + '...' : description;
             console.log(`  ${snippet}`);
+          }
+          if ((d as any)._contentSnippet) {
+            console.log(`  Content match: ${(d as any)._contentSnippet}`);
           }
           console.log('');
         }


### PR DESCRIPTION
## Summary
- **keys generate**: Ed25519 key pair generation as `keys generate` subcommand with `--name` and `--force` options
- **from-file**: New command to create dossiers from plain text files with metadata flags, optional signing
- **get**: Dedicated registry-only dossier lookup command with `--json` output
- **search --content**: Body content search with context snippets and concurrency-limited fetching
- **cache list --size**: Optional `--size` flag to show file sizes in cache listing

Closes #61

## Test plan
- [x] All 279 tests pass (18 new tests added)
- [x] TypeScript builds without errors
- [ ] CI linter and test workflows pass
- [ ] Manual: `dossier keys generate --name test` creates key files
- [ ] Manual: `dossier from-file body.txt --name test --title "Test" --objective "test" --author "Me"` creates dossier
- [ ] Manual: `dossier get <known-dossier>` fetches from registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)