### PR TITLE
feat: close remaining CLI parity gaps with dossier-tools

### DIFF
--- a/cli/src/__tests__/commands/keys.test.ts
+++ b/cli/src/__tests__/commands/keys.test.ts
@@ -49,6 +49,7 @@ describe('keys command', () => {
 
     it('should display trusted keys', async () => {
       mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readdirSync.mockReturnValue([] as any);
       mockedFs.readFileSync.mockReturnValue('abc123key team-key-2025\ndef456key other-key\n');
       const program = createTestProgram();
       registerKeysCommand(program);
@@ -60,8 +61,24 @@ describe('keys command', () => {
       expect(console.log).toHaveBeenCalledWith(expect.stringContaining('2 trusted key(s)'));
     });
 
+    it('should list generated key pairs', async () => {
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readdirSync.mockReturnValue(['default.pem', 'default.pub', 'mykey.pem'] as any);
+      mockedFs.readFileSync.mockReturnValue('abc123key team-key\n');
+      const program = createTestProgram();
+      registerKeysCommand(program);
+
+      await expect(program.parseAsync(['node', 'dossier', 'keys', 'list'])).rejects.toThrow(
+        'process.exit(0)'
+      );
+
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Generated Key Pairs'));
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('2 key pair(s)'));
+    });
+
     it('should output JSON with --json', async () => {
       mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readdirSync.mockReturnValue(['default.pem', 'default.pub'] as any);
       mockedFs.readFileSync.mockReturnValue('abc123key team-key\n');
       const program = createTestProgram();
       registerKeysCommand(program);
@@ -72,7 +89,7 @@ describe('keys command', () => {
 
       const jsonCalls = vi
         .mocked(console.log)
-        .mock.calls.filter((c) => typeof c[0] === 'string' && c[0].includes('public_key'));
+        .mock.calls.filter((c) => typeof c[0] === 'string' && c[0].includes('"trusted"'));
       expect(jsonCalls.length).toBeGreaterThan(0);
     });
   });

--- a/cli/src/commands/from-file.ts
+++ b/cli/src/commands/from-file.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { calculateChecksum, Ed25519Signer } from '@imboard-ai/dossier-core';
 import type { Command } from 'commander';
@@ -11,12 +12,12 @@ export function registerFromFileCommand(program: Command): void {
     .option('--name <name>', 'Dossier name')
     .option('--title <title>', 'Dossier title')
     .option('--version <version>', 'Dossier version', '1.0.0')
-    .option('--status <status>', 'Dossier status', 'stable')
+    .option('--status <status>', 'Dossier status', 'draft')
     .option('--objective <text>', 'Dossier objective')
     .option('--author <name>', 'Author name (repeatable)', collectValues, [])
     .option('--meta <path>', 'JSON file with frontmatter fields')
     .option('--sign', 'Sign the dossier')
-    .option('--key <path>', 'Private key path for signing')
+    .option('--key <name-or-path>', 'Key name from ~/.dossier/ or path to private key')
     .option('--signed-by <name>', 'Signer identity')
     .option('-o, --output <path>', 'Output file path')
     .action(
@@ -101,10 +102,18 @@ export function registerFromFileCommand(program: Command): void {
             console.error('\n❌ --key is required when using --sign\n');
             process.exit(1);
           }
-          const keyPath = path.resolve(options.key);
+          let keyPath = path.resolve(options.key);
+          // Support name-based lookup from ~/.dossier/
           if (!fs.existsSync(keyPath)) {
-            console.error(`\n❌ Key file not found: ${keyPath}\n`);
-            process.exit(1);
+            const namedPath = path.join(os.homedir(), '.dossier', `${options.key}.pem`);
+            if (fs.existsSync(namedPath)) {
+              keyPath = namedPath;
+            } else {
+              console.error(`\n❌ Key not found: ${options.key}`);
+              console.error(`   Checked: ${keyPath}`);
+              console.error(`   Checked: ${namedPath}\n`);
+              process.exit(1);
+            }
           }
 
           try {

--- a/cli/src/commands/keys.ts
+++ b/cli/src/commands/keys.ts
@@ -61,50 +61,96 @@ export function registerKeysCommand(program: Command): void {
 
   keysCmd
     .command('list')
-    .description('List trusted signing keys')
+    .description('List trusted and generated signing keys')
     .option('--json', 'JSON output')
     .action((options: { json?: boolean }) => {
-      const trustedKeysPath = path.join(os.homedir(), '.dossier', 'trusted-keys.txt');
+      const dossierDir = path.join(os.homedir(), '.dossier');
+      const trustedKeysPath = path.join(dossierDir, 'trusted-keys.txt');
 
-      console.log('\n🔑 Trusted Signing Keys\n');
-
-      if (!fs.existsSync(trustedKeysPath)) {
-        console.log('⚠️  No trusted keys file found');
-        console.log(`   Location: ${trustedKeysPath}`);
-        console.log('\nTo add a trusted key:');
-        console.log('   dossier keys add <public-key> <identifier>\n');
-        process.exit(0);
+      // Discover generated key pairs in ~/.dossier/
+      const generatedKeys: { name: string; privatePath: string; publicPath: string }[] = [];
+      if (fs.existsSync(dossierDir)) {
+        const files = fs.readdirSync(dossierDir);
+        const pemFiles = files.filter((f) => f.endsWith('.pem'));
+        for (const pem of pemFiles) {
+          const name = pem.replace('.pem', '');
+          const pubFile = `${name}.pub`;
+          generatedKeys.push({
+            name,
+            privatePath: path.join(dossierDir, pem),
+            publicPath: files.includes(pubFile) ? path.join(dossierDir, pubFile) : '',
+          });
+        }
       }
 
-      const content = fs.readFileSync(trustedKeysPath, 'utf8');
-      const lines = content.split('\n').filter((line) => line.trim() && !line.startsWith('#'));
-
-      if (lines.length === 0) {
-        console.log('⚠️  No trusted keys configured');
-        console.log(`   File exists at: ${trustedKeysPath}`);
-        console.log('\nTo add a trusted key:');
-        console.log('   dossier keys add <public-key> <identifier>\n');
-        process.exit(0);
+      // Load trusted keys
+      let trustedLines: string[] = [];
+      if (fs.existsSync(trustedKeysPath)) {
+        const content = fs.readFileSync(trustedKeysPath, 'utf8');
+        trustedLines = content.split('\n').filter((line) => line.trim() && !line.startsWith('#'));
       }
 
       if (options.json) {
-        const keys = lines.map((line) => {
+        const trusted = trustedLines.map((line) => {
           const [key, ...idParts] = line.trim().split(/\s+/);
-          return { public_key: key, identifier: idParts.join(' ') };
+          return { type: 'trusted', public_key: key, identifier: idParts.join(' ') };
         });
-        console.log(JSON.stringify(keys, null, 2));
-      } else {
-        console.log(`Total: ${lines.length} trusted key(s)\n`);
-        lines.forEach((line, index) => {
-          const [key, ...idParts] = line.trim().split(/\s+/);
-          const identifier = idParts.join(' ');
-          const shortKey = key.length > 60 ? key.substring(0, 60) + '...' : key;
-          console.log(`${index + 1}. ${identifier}`);
-          console.log(`   ${shortKey}`);
+        const generated = generatedKeys.map((k) => ({
+          type: 'generated',
+          name: k.name,
+          private_key: k.privatePath,
+          public_key: k.publicPath,
+        }));
+        console.log(JSON.stringify({ trusted, generated }, null, 2));
+        process.exit(0);
+      }
+
+      // Display generated keys
+      if (generatedKeys.length > 0) {
+        console.log('\n🔑 Generated Key Pairs\n');
+        console.log(`Total: ${generatedKeys.length} key pair(s)\n`);
+        generatedKeys.forEach((k, index) => {
+          console.log(`${index + 1}. ${k.name}`);
+          console.log(`   Private: ${k.privatePath}`);
+          if (k.publicPath) {
+            console.log(`   Public:  ${k.publicPath}`);
+          }
           console.log();
         });
-        console.log(`Location: ${trustedKeysPath}\n`);
       }
+
+      // Display trusted keys
+      console.log('🔑 Trusted Signing Keys\n');
+
+      if (trustedLines.length === 0) {
+        if (!fs.existsSync(trustedKeysPath)) {
+          console.log('⚠️  No trusted keys file found');
+          console.log(`   Location: ${trustedKeysPath}`);
+        } else {
+          console.log('⚠️  No trusted keys configured');
+          console.log(`   File exists at: ${trustedKeysPath}`);
+        }
+        console.log('\nTo add a trusted key:');
+        console.log('   dossier keys add <public-key> <identifier>\n');
+
+        if (generatedKeys.length === 0) {
+          console.log('To generate a new key pair:');
+          console.log('   dossier keys generate\n');
+        }
+
+        process.exit(0);
+      }
+
+      console.log(`Total: ${trustedLines.length} trusted key(s)\n`);
+      trustedLines.forEach((line, index) => {
+        const [key, ...idParts] = line.trim().split(/\s+/);
+        const identifier = idParts.join(' ');
+        const shortKey = key.length > 60 ? key.substring(0, 60) + '...' : key;
+        console.log(`${index + 1}. ${identifier}`);
+        console.log(`   ${shortKey}`);
+        console.log();
+      });
+      console.log(`Location: ${trustedKeysPath}\n`);
 
       process.exit(0);
     });

--- a/cli/src/commands/search.ts
+++ b/cli/src/commands/search.ts
@@ -12,6 +12,7 @@ export function registerSearchCommand(program: Command): void {
     )
     .option('--page <number>', 'Page number', '1')
     .option('--per-page <number>', 'Results per page', '20')
+    .option('--limit <number>', 'Maximum total results')
     .option('-c, --content', 'Also search dossier body content')
     .option('--json', 'Output as JSON')
     .action(
@@ -21,12 +22,14 @@ export function registerSearchCommand(program: Command): void {
           category?: string;
           page: string;
           perPage: string;
+          limit?: string;
           json?: boolean;
           content?: boolean;
         }
       ) => {
         const page = parseInt(options.page, 10) || 1;
         const perPage = parseInt(options.perPage, 10) || 20;
+        const limit = options.limit ? parseInt(options.limit, 10) : undefined;
 
         let allDossiers: any[];
         try {
@@ -108,6 +111,10 @@ export function registerSearchCommand(program: Command): void {
           for (const d of matched) {
             (d as any)._contentSnippet = contentMatches.get(d.name);
           }
+        }
+
+        if (limit && limit > 0) {
+          matched = matched.slice(0, limit);
         }
 
         const total = matched.length;

--- a/cli/src/commands/sign.ts
+++ b/cli/src/commands/sign.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import type { Command } from 'commander';
 import { OFFICIAL_KMS_KEYS, REPO_ROOT } from '../helpers';
@@ -10,7 +11,10 @@ export function registerSignCommand(program: Command): void {
     .description('Sign dossier with cryptographic key (supports any AWS KMS key)')
     .argument('<file>', 'Dossier file to sign')
     .option('--method <type>', 'Signing method: kms (AWS KMS) or ed25519 (local key)', 'kms')
-    .option('--key <path>', 'Path to Ed25519 private key (required for ed25519 method)')
+    .option(
+      '--key <name-or-path>',
+      'Key name from ~/.dossier/ or path to Ed25519 private key (required for ed25519 method)'
+    )
     .option(
       '--key-id <id>',
       'KMS key alias/ARN (e.g., alias/my-key or arn:aws:kms:...) or ed25519 key ID'
@@ -94,18 +98,26 @@ export function registerSignCommand(program: Command): void {
           if (!options.key && !options.dryRun) {
             console.log('\n❌ Error: --key is required for ed25519 signing');
             console.log('\nGenerate a key pair with:');
-            console.log('  openssl genpkey -algorithm ED25519 -out private-key.pem');
-            console.log('  openssl pkey -in private-key.pem -pubout -out public-key.pem');
+            console.log('  dossier keys generate --name my-key');
             console.log('\nThen sign with:');
-            console.log(`  dossier sign ${file} --method ed25519 --key private-key.pem`);
+            console.log(`  dossier sign ${file} --method ed25519 --key my-key`);
+            console.log(`  dossier sign ${file} --method ed25519 --key /path/to/key.pem`);
             process.exit(1);
           }
 
           if (options.key) {
-            const keyPath = path.resolve(options.key);
+            let keyPath = path.resolve(options.key);
+            // Support name-based lookup from ~/.dossier/
             if (!fs.existsSync(keyPath)) {
-              console.log(`\n❌ Key file not found: ${keyPath}`);
-              process.exit(1);
+              const namedPath = path.join(os.homedir(), '.dossier', `${options.key}.pem`);
+              if (fs.existsSync(namedPath)) {
+                keyPath = namedPath;
+              } else {
+                console.log(`\n❌ Key not found: ${options.key}`);
+                console.log(`   Checked: ${keyPath}`);
+                console.log(`   Checked: ${namedPath}`);
+                process.exit(1);
+              }
             }
             signArgs.push('--key', keyPath);
             console.log(`   Key: ${keyPath}`);


### PR DESCRIPTION
## Summary
- **search --limit**: Add `--limit` flag to cap total results across pages (matches Python's behavior)
- **from-file --status default**: Changed from `stable` to `draft` to match Python convention
- **sign/from-file --key name lookup**: `--key` now accepts a key name (e.g., `--key default`) which resolves to `~/.dossier/default.pem`, in addition to file paths
- **keys list**: Now shows both generated key pairs from `~/.dossier/*.pem` and trusted keys from `trusted-keys.txt`

Closes remaining parity gaps from #61

## Test plan
- [x] All 280 tests pass (1 new test for generated key listing)
- [x] TypeScript builds without errors
- [ ] CI lint and test workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)