### PR TITLE
feat(mcp): dependency graph resolver for dossier relationships

### DIFF
--- a/PLANNING-70-mcp-dependency-graph-resolver.md
+++ b/PLANNING-70-mcp-dependency-graph-resolver.md
@@ -1,0 +1,56 @@
+# Issue #70: MCP: Dependency graph resolver for dossier relationships
+
+## Type
+feature
+
+## Problem Statement
+Build a dependency graph resolver that reads dossier `relationships` fields (`preceded_by`, `followed_by`, `conflicts_with`, `can_run_parallel_with`) and produces an execution plan as a DAG.
+
+Part of the **MCP Server Refactor** epic. This is the foundational orchestration capability — everything else (journey execution, output mapping) builds on top of the resolved graph.
+
+## Implementation Checklist
+- [ ] Understand the issue and gather context
+- [ ] Identify files that need modification
+- [ ] `orchestration/graph.ts` — DAG builder (cycle detection, topological sort, parallel groups, conflicts)
+- [ ] `orchestration/resolver.ts` — Dossier reference resolution (local files, registry via CLI, caching)
+- [ ] `tools/resolveGraph.ts` — MCP tool (input: dossier path/name, output: execution plan)
+- [ ] Add/update tests (unit tests for graph operations)
+- [ ] Update documentation if needed
+- [ ] Self-review the changes
+- [ ] Create pull request
+
+## Files to Modify
+- `orchestration/graph.ts` — new file: DAG builder
+- `orchestration/resolver.ts` — new file: dossier reference resolution
+- `tools/resolveGraph.ts` — new file: MCP tool exposing the graph resolver
+
+## Testing Strategy
+- [ ] Unit tests for cycle detection
+- [ ] Unit tests for topological sort
+- [ ] Unit tests for parallel group identification
+- [ ] Unit tests for `conflicts_with` violation detection
+- [ ] Unit tests for dossier reference resolution (local + registry)
+- [ ] Integration test for full graph resolution
+
+## Schema Fields Consumed
+
+```json
+{
+  "relationships": {
+    "preceded_by": [{ "dossier": "name", "condition": "required|optional|suggested", "reason": "..." }],
+    "followed_by": [{ "dossier": "name", "condition": "required|suggested", "purpose": "..." }],
+    "conflicts_with": [{ "dossier": "name", "reason": "..." }],
+    "can_run_parallel_with": ["name1", "name2"]
+  }
+}
+```
+
+## Dependencies
+- #69 (CLI wrappers — uses `dossier get --json` for registry resolution)
+
+## Notes
+<!-- Additional notes, questions, or considerations -->
+
+## Related Issues/PRs
+- Issue: #70
+- Depends on: #69

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -10,7 +10,7 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
-    "test": "echo \"No tests yet for mcp-server\""
+    "test": "vitest run"
   },
   "keywords": [
     "mcp",
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@types/node": "^24.10.0",
     "tsx": "^4.20.6",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^3.1.1"
   }
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -21,6 +21,7 @@ import { getProtocolResource } from './resources/protocol.js';
 import { getSecurityResource } from './resources/security.js';
 import { type ListDossiersInput, listDossiers } from './tools/listDossiers.js';
 import { type ReadDossierInput, readDossier } from './tools/readDossier.js';
+import { type ResolveGraphInput, resolveGraph } from './tools/resolveGraph.js';
 import { type SearchDossiersInput, searchDossiers } from './tools/searchDossiers.js';
 import { type VerifyDossierInput, verifyDossier } from './tools/verifyDossier.js';
 import { logger } from './utils/logger.js';
@@ -113,6 +114,21 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           required: ['query'],
         },
       },
+      {
+        name: 'resolve_graph',
+        description:
+          'Resolve a dossier dependency graph into an execution plan. Reads relationships (preceded_by, followed_by, conflicts_with) and produces a DAG with ordered phases, parallel groups, and conflict detection.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            dossier: {
+              type: 'string',
+              description: 'Path to dossier file (.ds.md) or registry name',
+            },
+          },
+          required: ['dossier'],
+        },
+      },
     ],
   };
 });
@@ -142,6 +158,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case 'search_dossiers': {
         const result = await searchDossiers(args as unknown as SearchDossiersInput);
+        return createToolResponse(result);
+      }
+
+      case 'resolve_graph': {
+        const result = await resolveGraph(args as unknown as ResolveGraphInput);
         return createToolResponse(result);
       }
 

--- a/mcp-server/src/orchestration/__tests__/graph.test.ts
+++ b/mcp-server/src/orchestration/__tests__/graph.test.ts
@@ -1,0 +1,418 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildExecutionPlan,
+  buildGraph,
+  CycleError,
+  detectConflicts,
+  detectCycle,
+  topologicalSort,
+} from '../graph';
+import type { DossierNode } from '../types';
+
+function makeNode(name: string, overrides: Partial<DossierNode> = {}): [string, DossierNode] {
+  return [
+    name,
+    {
+      name,
+      source: 'local',
+      ...overrides,
+    },
+  ];
+}
+
+describe('buildGraph', () => {
+  it('should create edges from preceded_by relationships', () => {
+    const nodes = new Map<string, DossierNode>([
+      makeNode('setup-infra', {}),
+      makeNode('deploy-app', {
+        relationships: {
+          preceded_by: [
+            { dossier: 'setup-infra', condition: 'required', reason: 'Needs infra first' },
+          ],
+        },
+      }),
+    ]);
+
+    const graph = buildGraph(nodes);
+
+    expect(graph.edges).toHaveLength(1);
+    expect(graph.edges[0]).toEqual({
+      from: 'setup-infra',
+      to: 'deploy-app',
+      condition: 'required',
+      reason: 'Needs infra first',
+    });
+  });
+
+  it('should create edges from followed_by relationships', () => {
+    const nodes = new Map<string, DossierNode>([
+      makeNode('deploy-app', {
+        relationships: {
+          followed_by: [
+            { dossier: 'configure-monitoring', condition: 'suggested', purpose: 'Setup alerts' },
+          ],
+        },
+      }),
+      makeNode('configure-monitoring', {}),
+    ]);
+
+    const graph = buildGraph(nodes);
+
+    expect(graph.edges).toHaveLength(1);
+    expect(graph.edges[0]).toEqual({
+      from: 'deploy-app',
+      to: 'configure-monitoring',
+      condition: 'suggested',
+      reason: 'Setup alerts',
+    });
+  });
+
+  it('should skip edges to nodes not in the graph', () => {
+    const nodes = new Map<string, DossierNode>([
+      makeNode('deploy-app', {
+        relationships: {
+          preceded_by: [{ dossier: 'nonexistent', condition: 'optional' }],
+        },
+      }),
+    ]);
+
+    const graph = buildGraph(nodes);
+
+    expect(graph.edges).toHaveLength(0);
+  });
+
+  it('should default condition to required when not specified', () => {
+    const nodes = new Map<string, DossierNode>([
+      makeNode('a'),
+      makeNode('b', {
+        relationships: {
+          preceded_by: [{ dossier: 'a' }],
+        },
+      }),
+    ]);
+
+    const graph = buildGraph(nodes);
+
+    expect(graph.edges[0].condition).toBe('required');
+  });
+});
+
+describe('detectCycle', () => {
+  it('should return null for acyclic graph', () => {
+    const nodes = new Map<string, DossierNode>([
+      makeNode('a'),
+      makeNode('b', {
+        relationships: { preceded_by: [{ dossier: 'a' }] },
+      }),
+      makeNode('c', {
+        relationships: { preceded_by: [{ dossier: 'b' }] },
+      }),
+    ]);
+
+    const graph = buildGraph(nodes);
+    expect(detectCycle(graph)).toBeNull();
+  });
+
+  it('should detect a simple 2-node cycle', () => {
+    const nodes = new Map<string, DossierNode>([
+      makeNode('a', {
+        relationships: { preceded_by: [{ dossier: 'b' }] },
+      }),
+      makeNode('b', {
+        relationships: { preceded_by: [{ dossier: 'a' }] },
+      }),
+    ]);
+
+    const graph = buildGraph(nodes);
+    const cycle = detectCycle(graph);
+
+    expect(cycle).not.toBeNull();
+    expect(cycle!.length).toBeGreaterThanOrEqual(3); // at least [a, b, a]
+    // Cycle should contain both nodes
+    expect(cycle).toContain('a');
+    expect(cycle).toContain('b');
+  });
+
+  it('should detect a 3-node cycle', () => {
+    const nodes = new Map<string, DossierNode>([
+      makeNode('a', {
+        relationships: { preceded_by: [{ dossier: 'c' }] },
+      }),
+      makeNode('b', {
+        relationships: { preceded_by: [{ dossier: 'a' }] },
+      }),
+      makeNode('c', {
+        relationships: { preceded_by: [{ dossier: 'b' }] },
+      }),
+    ]);
+
+    const graph = buildGraph(nodes);
+    const cycle = detectCycle(graph);
+
+    expect(cycle).not.toBeNull();
+    expect(cycle).toContain('a');
+    expect(cycle).toContain('b');
+    expect(cycle).toContain('c');
+  });
+
+  it('should return null for single node with no edges', () => {
+    const nodes = new Map<string, DossierNode>([makeNode('solo')]);
+
+    const graph = buildGraph(nodes);
+    expect(detectCycle(graph)).toBeNull();
+  });
+});
+
+describe('topologicalSort', () => {
+  it('should sort a linear chain A -> B -> C', () => {
+    const nodes = new Map<string, DossierNode>([
+      makeNode('a'),
+      makeNode('b', {
+        relationships: { preceded_by: [{ dossier: 'a' }] },
+      }),
+      makeNode('c', {
+        relationships: { preceded_by: [{ dossier: 'b' }] },
+      }),
+    ]);
+
+    const graph = buildGraph(nodes);
+    const phases = topologicalSort(graph);
+
+    expect(phases).toHaveLength(3);
+    expect(phases[0]).toEqual(['a']);
+    expect(phases[1]).toEqual(['b']);
+    expect(phases[2]).toEqual(['c']);
+  });
+
+  it('should group independent nodes in the same phase', () => {
+    const nodes = new Map<string, DossierNode>([
+      makeNode('root'),
+      makeNode('child-1', {
+        relationships: { preceded_by: [{ dossier: 'root' }] },
+      }),
+      makeNode('child-2', {
+        relationships: { preceded_by: [{ dossier: 'root' }] },
+      }),
+    ]);
+
+    const graph = buildGraph(nodes);
+    const phases = topologicalSort(graph);
+
+    expect(phases).toHaveLength(2);
+    expect(phases[0]).toEqual(['root']);
+    expect(phases[1]).toHaveLength(2);
+    expect(phases[1]).toContain('child-1');
+    expect(phases[1]).toContain('child-2');
+  });
+
+  it('should handle a diamond dependency pattern', () => {
+    //   A
+    //  / \
+    // B   C
+    //  \ /
+    //   D
+    const nodes = new Map<string, DossierNode>([
+      makeNode('a'),
+      makeNode('b', {
+        relationships: { preceded_by: [{ dossier: 'a' }] },
+      }),
+      makeNode('c', {
+        relationships: { preceded_by: [{ dossier: 'a' }] },
+      }),
+      makeNode('d', {
+        relationships: { preceded_by: [{ dossier: 'b' }, { dossier: 'c' }] },
+      }),
+    ]);
+
+    const graph = buildGraph(nodes);
+    const phases = topologicalSort(graph);
+
+    expect(phases).toHaveLength(3);
+    expect(phases[0]).toEqual(['a']);
+    expect(phases[1]).toHaveLength(2);
+    expect(phases[1]).toContain('b');
+    expect(phases[1]).toContain('c');
+    expect(phases[2]).toEqual(['d']);
+  });
+
+  it('should handle single node graph', () => {
+    const nodes = new Map<string, DossierNode>([makeNode('solo')]);
+
+    const graph = buildGraph(nodes);
+    const phases = topologicalSort(graph);
+
+    expect(phases).toHaveLength(1);
+    expect(phases[0]).toEqual(['solo']);
+  });
+
+  it('should handle multiple disconnected components', () => {
+    const nodes = new Map<string, DossierNode>([makeNode('a'), makeNode('b')]);
+
+    const graph = buildGraph(nodes);
+    const phases = topologicalSort(graph);
+
+    expect(phases).toHaveLength(1);
+    expect(phases[0]).toHaveLength(2);
+    expect(phases[0]).toContain('a');
+    expect(phases[0]).toContain('b');
+  });
+});
+
+describe('detectConflicts', () => {
+  it('should detect conflicts between two dossiers in the graph', () => {
+    const nodes = new Map<string, DossierNode>([
+      makeNode('mysql-setup', {
+        relationships: {
+          conflicts_with: [{ dossier: 'postgres-setup', reason: 'Both set up primary DB' }],
+        },
+      }),
+      makeNode('postgres-setup'),
+    ]);
+
+    const graph = buildGraph(nodes);
+    const conflicts = detectConflicts(graph);
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toEqual({
+      dossierA: 'mysql-setup',
+      dossierB: 'postgres-setup',
+      reason: 'Both set up primary DB',
+    });
+  });
+
+  it('should not report conflicts with dossiers not in the graph', () => {
+    const nodes = new Map<string, DossierNode>([
+      makeNode('mysql-setup', {
+        relationships: {
+          conflicts_with: [{ dossier: 'not-in-graph', reason: 'some reason' }],
+        },
+      }),
+    ]);
+
+    const graph = buildGraph(nodes);
+    const conflicts = detectConflicts(graph);
+
+    expect(conflicts).toHaveLength(0);
+  });
+
+  it('should deduplicate bidirectional conflicts', () => {
+    const nodes = new Map<string, DossierNode>([
+      makeNode('a', {
+        relationships: {
+          conflicts_with: [{ dossier: 'b', reason: 'conflict' }],
+        },
+      }),
+      makeNode('b', {
+        relationships: {
+          conflicts_with: [{ dossier: 'a', reason: 'conflict reverse' }],
+        },
+      }),
+    ]);
+
+    const graph = buildGraph(nodes);
+    const conflicts = detectConflicts(graph);
+
+    expect(conflicts).toHaveLength(1);
+  });
+
+  it('should return empty array when no conflicts exist', () => {
+    const nodes = new Map<string, DossierNode>([makeNode('a'), makeNode('b')]);
+
+    const graph = buildGraph(nodes);
+    const conflicts = detectConflicts(graph);
+
+    expect(conflicts).toHaveLength(0);
+  });
+});
+
+describe('buildExecutionPlan', () => {
+  it('should build a plan for a simple dependency chain', () => {
+    const nodes = new Map<string, DossierNode>([
+      makeNode('setup', { riskLevel: 'low' }),
+      makeNode('deploy', {
+        riskLevel: 'high',
+        relationships: {
+          preceded_by: [{ dossier: 'setup', condition: 'required' }],
+        },
+      }),
+      makeNode('monitor', {
+        riskLevel: 'low',
+        relationships: {
+          preceded_by: [{ dossier: 'deploy', condition: 'suggested' }],
+        },
+      }),
+    ]);
+
+    const graph = buildGraph(nodes);
+    const plan = buildExecutionPlan(graph, 'deploy');
+
+    expect(plan.entryDossier).toBe('deploy');
+    expect(plan.totalDossiers).toBe(3);
+    expect(plan.phases).toHaveLength(3);
+    expect(plan.phases[0].dossiers[0].name).toBe('setup');
+    expect(plan.phases[1].dossiers[0].name).toBe('deploy');
+    expect(plan.phases[2].dossiers[0].name).toBe('monitor');
+    expect(plan.conflicts).toHaveLength(0);
+  });
+
+  it('should throw CycleError for cyclic graphs', () => {
+    const nodes = new Map<string, DossierNode>([
+      makeNode('a', {
+        relationships: { preceded_by: [{ dossier: 'b' }] },
+      }),
+      makeNode('b', {
+        relationships: { preceded_by: [{ dossier: 'a' }] },
+      }),
+    ]);
+
+    const graph = buildGraph(nodes);
+
+    expect(() => buildExecutionPlan(graph, 'a')).toThrow(CycleError);
+  });
+
+  it('should include conflicts in the plan', () => {
+    const nodes = new Map<string, DossierNode>([
+      makeNode('mysql', {
+        relationships: {
+          conflicts_with: [{ dossier: 'postgres', reason: 'Both set up primary DB' }],
+        },
+      }),
+      makeNode('postgres'),
+    ]);
+
+    const graph = buildGraph(nodes);
+    const plan = buildExecutionPlan(graph, 'mysql');
+
+    expect(plan.conflicts).toHaveLength(1);
+    expect(plan.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('should handle single dossier with no dependencies', () => {
+    const nodes = new Map<string, DossierNode>([makeNode('standalone', { riskLevel: 'low' })]);
+
+    const graph = buildGraph(nodes);
+    const plan = buildExecutionPlan(graph, 'standalone');
+
+    expect(plan.totalDossiers).toBe(1);
+    expect(plan.phases).toHaveLength(1);
+    expect(plan.phases[0].dossiers[0].name).toBe('standalone');
+    expect(plan.phases[0].dossiers[0].condition).toBe('required');
+  });
+
+  it('should mark entry dossier as required regardless of edge conditions', () => {
+    const nodes = new Map<string, DossierNode>([
+      makeNode('dep', {
+        relationships: {
+          followed_by: [{ dossier: 'entry', condition: 'suggested' }],
+        },
+      }),
+      makeNode('entry'),
+    ]);
+
+    const graph = buildGraph(nodes);
+    const plan = buildExecutionPlan(graph, 'entry');
+
+    const entryPhase = plan.phases.find((p) => p.dossiers.some((d) => d.name === 'entry'));
+    expect(entryPhase?.dossiers.find((d) => d.name === 'entry')?.condition).toBe('required');
+  });
+});

--- a/mcp-server/src/orchestration/__tests__/resolver.test.ts
+++ b/mcp-server/src/orchestration/__tests__/resolver.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DossierResolver, ResolveError } from '../resolver';
+
+// Mock the CLI wrapper
+vi.mock('../../utils/cli-wrapper', () => ({
+  CliNotFoundError: class extends Error {
+    name = 'CliNotFoundError';
+    constructor() {
+      super('ai-dossier CLI not found');
+    }
+  },
+  execCli: vi.fn(),
+}));
+
+// Mock the logger
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { execCli } from '../../utils/cli-wrapper';
+
+const mockExecCli = vi.mocked(execCli);
+
+describe('DossierResolver', () => {
+  let resolver: DossierResolver;
+
+  beforeEach(() => {
+    resolver = new DossierResolver('/test/project');
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('resolveFromPath', () => {
+    it('should resolve a dossier from a file path', async () => {
+      mockExecCli.mockResolvedValueOnce({
+        name: 'deploy-to-aws',
+        title: 'Deploy to AWS',
+        version: '1.0.0',
+        risk_level: 'high',
+        relationships: {
+          preceded_by: [{ dossier: 'setup-infra', condition: 'required' }],
+        },
+      });
+
+      const result = await resolver.resolveFromPath('/test/project/deploy.ds.md');
+
+      expect(result.name).toBe('deploy-to-aws');
+      expect(result.source).toBe('local');
+      expect(result.relationships?.preceded_by).toHaveLength(1);
+      expect(mockExecCli).toHaveBeenCalledWith('info', ['/test/project/deploy.ds.md', '--json']);
+    });
+
+    it('should use filename as name when metadata has no name', async () => {
+      mockExecCli.mockResolvedValueOnce({
+        title: 'My Dossier',
+        version: '1.0.0',
+      });
+
+      const result = await resolver.resolveFromPath('/test/project/my-dossier.ds.md');
+
+      expect(result.name).toBe('my-dossier');
+    });
+  });
+
+  describe('resolve', () => {
+    it('should resolve locally first', async () => {
+      // First call: list (local index)
+      mockExecCli.mockResolvedValueOnce([
+        { path: '/test/project/setup.ds.md', name: 'setup-infra' },
+      ]);
+      // Second call: info (get metadata)
+      mockExecCli.mockResolvedValueOnce({
+        name: 'setup-infra',
+        title: 'Setup Infrastructure',
+        risk_level: 'medium',
+      });
+
+      const result = await resolver.resolve('setup-infra');
+
+      expect(result.source).toBe('local');
+      expect(result.name).toBe('setup-infra');
+    });
+
+    it('should fall back to registry when not found locally', async () => {
+      // First call: list (empty local index)
+      mockExecCli.mockResolvedValueOnce([]);
+      // Second call: registry get
+      mockExecCli.mockResolvedValueOnce({
+        name: 'community-dossier',
+        title: 'Community Dossier',
+        version: '2.0.0',
+      });
+
+      const result = await resolver.resolve('community-dossier');
+
+      expect(result.source).toBe('registry');
+      expect(result.name).toBe('community-dossier');
+    });
+
+    it('should throw ResolveError when not found anywhere', async () => {
+      // First call: list (empty local index)
+      mockExecCli.mockResolvedValueOnce([]);
+      // Second call: registry get (fails)
+      mockExecCli.mockRejectedValueOnce(new Error('Not found'));
+
+      await expect(resolver.resolve('nonexistent')).rejects.toThrow(ResolveError);
+    });
+
+    it('should cache resolved dossiers', async () => {
+      // First call: list
+      mockExecCli.mockResolvedValueOnce([
+        { path: '/test/project/cached.ds.md', name: 'cached-dossier' },
+      ]);
+      // Second call: info
+      mockExecCli.mockResolvedValueOnce({
+        name: 'cached-dossier',
+        title: 'Cached',
+      });
+
+      const result1 = await resolver.resolve('cached-dossier');
+      const result2 = await resolver.resolve('cached-dossier');
+
+      expect(result1).toBe(result2); // Same reference
+      // info should only be called once (second resolve uses cache)
+      expect(mockExecCli).toHaveBeenCalledTimes(2); // list + info, no second pair
+    });
+  });
+
+  describe('resolveGraph', () => {
+    it('should recursively resolve dependencies', async () => {
+      const entry = {
+        name: 'deploy',
+        source: 'local' as const,
+        path: '/test/deploy.ds.md',
+        metadata: { risk_level: 'high' },
+        relationships: {
+          preceded_by: [{ dossier: 'setup', condition: 'required' as const }],
+        },
+      };
+
+      // list call (local index scan)
+      mockExecCli.mockResolvedValueOnce([{ path: '/test/setup.ds.md', name: 'setup' }]);
+      // info call for 'setup'
+      mockExecCli.mockResolvedValueOnce({
+        name: 'setup',
+        title: 'Setup',
+        risk_level: 'low',
+        relationships: {},
+      });
+
+      const nodes = await resolver.resolveGraph(entry);
+
+      expect(nodes.size).toBe(2);
+      expect(nodes.has('deploy')).toBe(true);
+      expect(nodes.has('setup')).toBe(true);
+      expect(nodes.get('deploy')?.riskLevel).toBe('high');
+      expect(nodes.get('setup')?.riskLevel).toBe('low');
+    });
+
+    it('should handle unresolvable references gracefully', async () => {
+      const entry = {
+        name: 'deploy',
+        source: 'local' as const,
+        metadata: {},
+        relationships: {
+          preceded_by: [{ dossier: 'missing', condition: 'optional' as const }],
+        },
+      };
+
+      // list call returns empty
+      mockExecCli.mockResolvedValueOnce([]);
+      // registry lookup fails
+      mockExecCli.mockRejectedValueOnce(new Error('Not found'));
+
+      const nodes = await resolver.resolveGraph(entry);
+
+      // Should still have the entry node, just skip the missing one
+      expect(nodes.size).toBe(1);
+      expect(nodes.has('deploy')).toBe(true);
+    });
+
+    it('should not revisit already-resolved nodes', async () => {
+      const entry = {
+        name: 'a',
+        source: 'local' as const,
+        metadata: {},
+        relationships: {
+          preceded_by: [{ dossier: 'b' }],
+          followed_by: [{ dossier: 'b' }], // same ref in two places
+        },
+      };
+
+      // list
+      mockExecCli.mockResolvedValueOnce([{ path: '/test/b.ds.md', name: 'b' }]);
+      // info for 'b'
+      mockExecCli.mockResolvedValueOnce({
+        name: 'b',
+        relationships: { preceded_by: [{ dossier: 'a' }] }, // refers back to a
+      });
+
+      const nodes = await resolver.resolveGraph(entry);
+
+      expect(nodes.size).toBe(2);
+    });
+  });
+});

--- a/mcp-server/src/orchestration/graph.ts
+++ b/mcp-server/src/orchestration/graph.ts
@@ -1,0 +1,274 @@
+/**
+ * DAG builder for dossier dependency graphs.
+ * Parses relationships (preceded_by, followed_by, conflicts_with, can_run_parallel_with)
+ * and produces an execution plan via topological sort.
+ */
+
+import type {
+  ConflictWarning,
+  DependencyGraph,
+  DossierNode,
+  ExecutionPhase,
+  ExecutionPlan,
+  GraphEdge,
+  PhaseEntry,
+} from './types';
+
+export class CycleError extends Error {
+  constructor(public readonly cycle: string[]) {
+    super(`Dependency cycle detected: ${cycle.join(' -> ')}`);
+    this.name = 'CycleError';
+  }
+}
+
+/**
+ * Build a dependency graph from a set of resolved dossier nodes.
+ */
+export function buildGraph(nodes: Map<string, DossierNode>): DependencyGraph {
+  const edges: GraphEdge[] = [];
+
+  for (const [name, node] of nodes) {
+    const rels = node.relationships;
+    if (!rels) continue;
+
+    // preceded_by: dependency must run BEFORE this node
+    // Edge direction: preceded -> this
+    if (rels.preceded_by) {
+      for (const dep of rels.preceded_by) {
+        if (nodes.has(dep.dossier)) {
+          edges.push({
+            from: dep.dossier,
+            to: name,
+            condition: dep.condition ?? 'required',
+            reason: dep.reason,
+          });
+        }
+      }
+    }
+
+    // followed_by: this node must run BEFORE the follower
+    // Edge direction: this -> follower
+    if (rels.followed_by) {
+      for (const dep of rels.followed_by) {
+        if (nodes.has(dep.dossier)) {
+          edges.push({
+            from: name,
+            to: dep.dossier,
+            condition: dep.condition ?? 'required',
+            reason: dep.purpose,
+          });
+        }
+      }
+    }
+  }
+
+  return { nodes, edges };
+}
+
+/**
+ * Detect cycles in the dependency graph using DFS coloring.
+ * Returns the cycle path if one exists, or null if the graph is acyclic.
+ */
+export function detectCycle(graph: DependencyGraph): string[] | null {
+  const WHITE = 0;
+  const GRAY = 1;
+  const BLACK = 2;
+
+  const color = new Map<string, number>();
+  const parent = new Map<string, string | null>();
+
+  // Build adjacency list
+  const adj = new Map<string, string[]>();
+  for (const name of graph.nodes.keys()) {
+    adj.set(name, []);
+    color.set(name, WHITE);
+  }
+  for (const edge of graph.edges) {
+    adj.get(edge.from)?.push(edge.to);
+  }
+
+  function dfs(node: string): string[] | null {
+    color.set(node, GRAY);
+
+    for (const neighbor of adj.get(node) ?? []) {
+      if (color.get(neighbor) === GRAY) {
+        // Found a cycle - reconstruct it
+        const cycle = [neighbor, node];
+        let current = node;
+        while (current !== neighbor) {
+          current = parent.get(current) ?? '';
+          if (current && current !== neighbor) {
+            cycle.push(current);
+          }
+        }
+        cycle.push(neighbor);
+        cycle.reverse();
+        return cycle;
+      }
+      if (color.get(neighbor) === WHITE) {
+        parent.set(neighbor, node);
+        const result = dfs(neighbor);
+        if (result) return result;
+      }
+    }
+
+    color.set(node, BLACK);
+    return null;
+  }
+
+  for (const node of graph.nodes.keys()) {
+    if (color.get(node) === WHITE) {
+      const cycle = dfs(node);
+      if (cycle) return cycle;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Topological sort using Kahn's algorithm.
+ * Returns phases where each phase contains dossiers that can run in parallel.
+ */
+export function topologicalSort(graph: DependencyGraph): string[][] {
+  // Build adjacency list and in-degree map
+  const adj = new Map<string, string[]>();
+  const inDegree = new Map<string, number>();
+
+  for (const name of graph.nodes.keys()) {
+    adj.set(name, []);
+    inDegree.set(name, 0);
+  }
+
+  for (const edge of graph.edges) {
+    adj.get(edge.from)?.push(edge.to);
+    inDegree.set(edge.to, (inDegree.get(edge.to) ?? 0) + 1);
+  }
+
+  // Start with nodes that have no incoming edges
+  const phases: string[][] = [];
+  let queue = [...graph.nodes.keys()].filter((n) => inDegree.get(n) === 0);
+
+  while (queue.length > 0) {
+    phases.push([...queue]);
+    const nextQueue: string[] = [];
+
+    for (const node of queue) {
+      for (const neighbor of adj.get(node) ?? []) {
+        const newDegree = (inDegree.get(neighbor) ?? 1) - 1;
+        inDegree.set(neighbor, newDegree);
+        if (newDegree === 0) {
+          nextQueue.push(neighbor);
+        }
+      }
+    }
+
+    queue = nextQueue;
+  }
+
+  return phases;
+}
+
+/**
+ * Detect conflicts between dossiers in the graph.
+ */
+export function detectConflicts(graph: DependencyGraph): ConflictWarning[] {
+  const conflicts: ConflictWarning[] = [];
+  const seen = new Set<string>();
+
+  for (const [name, node] of graph.nodes) {
+    if (!node.relationships?.conflicts_with) continue;
+
+    for (const conflict of node.relationships.conflicts_with) {
+      if (!graph.nodes.has(conflict.dossier)) continue;
+
+      // Avoid duplicate reports (A conflicts B = B conflicts A)
+      const key = [name, conflict.dossier].sort().join('::');
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      conflicts.push({
+        dossierA: name,
+        dossierB: conflict.dossier,
+        reason: conflict.reason,
+      });
+    }
+  }
+
+  return conflicts;
+}
+
+/**
+ * Build a complete execution plan from the dependency graph.
+ */
+export function buildExecutionPlan(graph: DependencyGraph, entryDossier: string): ExecutionPlan {
+  // Check for cycles
+  const cycle = detectCycle(graph);
+  if (cycle) {
+    throw new CycleError(cycle);
+  }
+
+  // Detect conflicts
+  const conflicts = detectConflicts(graph);
+
+  // Build the edge condition map for quick lookup
+  const edgeConditions = new Map<string, 'required' | 'optional' | 'suggested'>();
+  for (const edge of graph.edges) {
+    edgeConditions.set(`${edge.from}->${edge.to}`, edge.condition);
+  }
+
+  // Topological sort into phases
+  const sortedPhases = topologicalSort(graph);
+
+  // Build execution phases
+  const phases: ExecutionPhase[] = sortedPhases.map((phaseNodes, index) => {
+    const dossiers: PhaseEntry[] = phaseNodes.map((name) => {
+      const node = graph.nodes.get(name)!;
+
+      // Determine condition: entry dossier is always 'required',
+      // others inherit from edges pointing to them
+      let condition: 'required' | 'optional' | 'suggested' = 'required';
+      if (name !== entryDossier) {
+        for (const edge of graph.edges) {
+          if (edge.to === name) {
+            condition = edge.condition;
+            break;
+          }
+        }
+      }
+
+      return {
+        name,
+        source: node.source,
+        path: node.path,
+        condition,
+        riskLevel: node.riskLevel,
+      };
+    });
+
+    return { phase: index + 1, dossiers };
+  });
+
+  // Generate warnings
+  const warnings: string[] = [];
+
+  if (conflicts.length > 0) {
+    warnings.push(
+      `${conflicts.length} conflict(s) detected between dossiers in the execution graph`
+    );
+  }
+
+  // Warn about optional dependencies
+  const optionalCount = graph.edges.filter((e) => e.condition === 'optional').length;
+  if (optionalCount > 0) {
+    warnings.push(`${optionalCount} optional dependency(ies) included — these may be skipped`);
+  }
+
+  return {
+    entryDossier,
+    totalDossiers: graph.nodes.size,
+    phases,
+    conflicts,
+    warnings,
+  };
+}

--- a/mcp-server/src/orchestration/resolver.ts
+++ b/mcp-server/src/orchestration/resolver.ts
@@ -1,0 +1,248 @@
+/**
+ * Dossier reference resolver.
+ * Resolves dossier names to their metadata by:
+ *   1. Local file lookup (*.ds.md in project)
+ *   2. Registry lookup via `ai-dossier get --json <name>`
+ * Caches resolved dossiers for the lifetime of a resolution run.
+ */
+
+import { resolve } from 'node:path';
+import { CliNotFoundError, execCli } from '../utils/cli-wrapper';
+import { logger } from '../utils/logger';
+import type { DossierNode, DossierRelationships, ResolvedDossier } from './types';
+
+interface ListItem {
+  path: string;
+  name?: string;
+  title?: string;
+  version?: string;
+  risk_level?: string;
+  riskLevel?: string;
+  status?: string;
+  relationships?: DossierRelationships;
+  [key: string]: unknown;
+}
+
+interface InfoResult {
+  name?: string;
+  title?: string;
+  version?: string;
+  risk_level?: string;
+  riskLevel?: string;
+  status?: string;
+  relationships?: DossierRelationships;
+  [key: string]: unknown;
+}
+
+export class ResolveError extends Error {
+  constructor(
+    public readonly dossierName: string,
+    message: string
+  ) {
+    super(`Failed to resolve "${dossierName}": ${message}`);
+    this.name = 'ResolveError';
+  }
+}
+
+export class DossierResolver {
+  private cache = new Map<string, ResolvedDossier>();
+  private localIndex: Map<string, ListItem> | null = null;
+
+  constructor(private readonly basePath: string = process.cwd()) {}
+
+  /**
+   * Resolve a dossier reference by name.
+   * Tries local files first, then falls back to the registry.
+   */
+  async resolve(name: string): Promise<ResolvedDossier> {
+    const cached = this.cache.get(name);
+    if (cached) return cached;
+
+    // Try local resolution first
+    const local = await this.resolveLocal(name);
+    if (local) {
+      this.cache.set(name, local);
+      return local;
+    }
+
+    // Fall back to registry
+    const registry = await this.resolveFromRegistry(name);
+    if (registry) {
+      this.cache.set(name, registry);
+      return registry;
+    }
+
+    throw new ResolveError(name, 'Not found locally or in registry');
+  }
+
+  /**
+   * Resolve a dossier from a local file path (for the entry dossier).
+   */
+  async resolveFromPath(filePath: string): Promise<ResolvedDossier> {
+    const resolvedPath = resolve(filePath);
+
+    logger.info('Resolving dossier from path', { path: resolvedPath });
+
+    try {
+      const metadata = await execCli<InfoResult>('info', [resolvedPath, '--json']);
+      const name =
+        metadata.name || resolvedPath.split('/').pop()?.replace('.ds.md', '') || filePath;
+
+      const resolved: ResolvedDossier = {
+        name,
+        source: 'local',
+        path: resolvedPath,
+        metadata: metadata as Record<string, unknown>,
+        relationships: metadata.relationships,
+      };
+
+      this.cache.set(name, resolved);
+      return resolved;
+    } catch (error) {
+      if (error instanceof CliNotFoundError) {
+        throw new Error(error.message);
+      }
+      throw new ResolveError(filePath, error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  /**
+   * Recursively resolve all dossiers in the dependency graph
+   * starting from an entry dossier.
+   */
+  async resolveGraph(entryDossier: ResolvedDossier): Promise<Map<string, DossierNode>> {
+    const nodes = new Map<string, DossierNode>();
+    const queue: ResolvedDossier[] = [entryDossier];
+    const visited = new Set<string>();
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      if (visited.has(current.name)) continue;
+      visited.add(current.name);
+
+      nodes.set(current.name, {
+        name: current.name,
+        source: current.source,
+        path: current.path,
+        riskLevel:
+          (current.metadata.risk_level as string) ?? (current.metadata.riskLevel as string),
+        status: current.metadata.status as string,
+        relationships: current.relationships,
+      });
+
+      // Queue all referenced dossiers for resolution
+      const refs = this.collectReferences(current.relationships);
+      for (const ref of refs) {
+        if (visited.has(ref)) continue;
+        try {
+          const resolved = await this.resolve(ref);
+          queue.push(resolved);
+        } catch (error) {
+          logger.warn('Could not resolve referenced dossier', {
+            dossier: ref,
+            from: current.name,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+
+    return nodes;
+  }
+
+  private collectReferences(relationships?: DossierRelationships): string[] {
+    if (!relationships) return [];
+
+    const refs = new Set<string>();
+
+    for (const dep of relationships.preceded_by ?? []) {
+      refs.add(dep.dossier);
+    }
+    for (const dep of relationships.followed_by ?? []) {
+      refs.add(dep.dossier);
+    }
+    for (const dep of relationships.conflicts_with ?? []) {
+      refs.add(dep.dossier);
+    }
+    for (const name of relationships.can_run_parallel_with ?? []) {
+      refs.add(name);
+    }
+
+    return [...refs];
+  }
+
+  /**
+   * Build a local index of dossiers by scanning the base path.
+   */
+  private async buildLocalIndex(): Promise<Map<string, ListItem>> {
+    if (this.localIndex) return this.localIndex;
+
+    try {
+      const result = await execCli<ListItem[]>('list', [
+        this.basePath,
+        '--format',
+        'json',
+        '--recursive',
+      ]);
+
+      this.localIndex = new Map<string, ListItem>();
+      for (const item of result) {
+        // Index by name field if available, otherwise by filename
+        const name = item.name || item.path.split('/').pop()?.replace('.ds.md', '') || item.path;
+        this.localIndex.set(name, item);
+      }
+
+      return this.localIndex;
+    } catch {
+      this.localIndex = new Map();
+      return this.localIndex;
+    }
+  }
+
+  private async resolveLocal(name: string): Promise<ResolvedDossier | null> {
+    const index = await this.buildLocalIndex();
+    const item = index.get(name);
+    if (!item) return null;
+
+    logger.info('Resolved dossier locally', { name, path: item.path });
+
+    // Get full metadata including relationships
+    try {
+      const metadata = await execCli<InfoResult>('info', [item.path, '--json']);
+
+      return {
+        name,
+        source: 'local',
+        path: item.path,
+        metadata: metadata as Record<string, unknown>,
+        relationships: metadata.relationships,
+      };
+    } catch {
+      // Fallback to list item data
+      return {
+        name,
+        source: 'local',
+        path: item.path,
+        metadata: item as Record<string, unknown>,
+        relationships: item.relationships,
+      };
+    }
+  }
+
+  private async resolveFromRegistry(name: string): Promise<ResolvedDossier | null> {
+    logger.info('Attempting registry resolution', { name });
+
+    try {
+      const metadata = await execCli<InfoResult>('get', [name, '--json']);
+
+      return {
+        name,
+        source: 'registry',
+        metadata: metadata as Record<string, unknown>,
+        relationships: metadata.relationships,
+      };
+    } catch {
+      return null;
+    }
+  }
+}

--- a/mcp-server/src/orchestration/types.ts
+++ b/mcp-server/src/orchestration/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Types for the dependency graph resolver and execution planner.
+ */
+
+// --- Relationship types (matching dossier-schema.json) ---
+
+export interface PrecededByRelation {
+  dossier: string;
+  condition?: 'required' | 'optional' | 'suggested';
+  reason?: string;
+}
+
+export interface FollowedByRelation {
+  dossier: string;
+  condition?: 'required' | 'suggested';
+  purpose?: string;
+}
+
+export interface ConflictsWithRelation {
+  dossier: string;
+  reason: string;
+}
+
+export interface DossierRelationships {
+  preceded_by?: PrecededByRelation[];
+  followed_by?: FollowedByRelation[];
+  conflicts_with?: ConflictsWithRelation[];
+  can_run_parallel_with?: string[];
+  alternatives?: Array<{ dossier: string; when_to_use?: string }>;
+}
+
+// --- Graph types ---
+
+export interface DossierNode {
+  name: string;
+  source: 'local' | 'registry';
+  path?: string;
+  riskLevel?: string;
+  status?: string;
+  relationships?: DossierRelationships;
+}
+
+export interface GraphEdge {
+  from: string;
+  to: string;
+  condition: 'required' | 'optional' | 'suggested';
+  reason?: string;
+}
+
+export interface DependencyGraph {
+  nodes: Map<string, DossierNode>;
+  edges: GraphEdge[];
+}
+
+// --- Execution plan types ---
+
+export interface PhaseEntry {
+  name: string;
+  source: 'local' | 'registry';
+  path?: string;
+  condition: 'required' | 'optional' | 'suggested';
+  riskLevel?: string;
+}
+
+export interface ExecutionPhase {
+  phase: number;
+  dossiers: PhaseEntry[];
+}
+
+export interface ConflictWarning {
+  dossierA: string;
+  dossierB: string;
+  reason: string;
+}
+
+export interface ExecutionPlan {
+  entryDossier: string;
+  totalDossiers: number;
+  phases: ExecutionPhase[];
+  conflicts: ConflictWarning[];
+  warnings: string[];
+}
+
+// --- Resolver types ---
+
+export interface ResolvedDossier {
+  name: string;
+  source: 'local' | 'registry';
+  path?: string;
+  metadata: Record<string, unknown>;
+  relationships?: DossierRelationships;
+}

--- a/mcp-server/src/tools/__tests__/resolveGraph.test.ts
+++ b/mcp-server/src/tools/__tests__/resolveGraph.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveGraph } from '../resolveGraph';
+
+// Mock the resolver
+vi.mock('../../orchestration/resolver', () => {
+  const DossierResolver = vi.fn();
+  DossierResolver.prototype.resolve = vi.fn();
+  DossierResolver.prototype.resolveFromPath = vi.fn();
+  DossierResolver.prototype.resolveGraph = vi.fn();
+  return { DossierResolver, ResolveError: class extends Error {} };
+});
+
+// Mock the graph module
+vi.mock('../../orchestration/graph', () => ({
+  buildGraph: vi.fn(),
+  buildExecutionPlan: vi.fn(),
+  CycleError: class CycleError extends Error {
+    cycle: string[];
+    constructor(cycle: string[]) {
+      super(`Dependency cycle detected: ${cycle.join(' -> ')}`);
+      this.name = 'CycleError';
+      this.cycle = cycle;
+    }
+  },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { buildExecutionPlan, buildGraph, CycleError } from '../../orchestration/graph';
+import { DossierResolver } from '../../orchestration/resolver';
+
+const mockResolverInstance = () => {
+  const instance = new DossierResolver();
+  return instance;
+};
+
+describe('resolveGraph tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return error when dossier parameter is empty', async () => {
+    const result = await resolveGraph({ dossier: '' });
+
+    expect(result).toHaveProperty('error');
+    expect((result as any).error.type).toBe('unknown');
+    expect((result as any).error.message).toContain('required');
+  });
+
+  it('should use resolveFromPath for file paths', async () => {
+    const mockEntry = {
+      name: 'deploy',
+      source: 'local' as const,
+      path: '/test/deploy.ds.md',
+      metadata: {},
+      relationships: {},
+    };
+    const mockNodes = new Map([['deploy', { name: 'deploy', source: 'local' as const }]]);
+    const mockGraph = { nodes: mockNodes, edges: [] };
+    const mockPlan = {
+      entryDossier: 'deploy',
+      totalDossiers: 1,
+      phases: [
+        { phase: 1, dossiers: [{ name: 'deploy', source: 'local', condition: 'required' }] },
+      ],
+      conflicts: [],
+      warnings: [],
+    };
+
+    vi.mocked(DossierResolver.prototype.resolveFromPath).mockResolvedValue(mockEntry);
+    vi.mocked(DossierResolver.prototype.resolveGraph).mockResolvedValue(mockNodes);
+    vi.mocked(buildGraph).mockReturnValue(mockGraph);
+    vi.mocked(buildExecutionPlan).mockReturnValue(mockPlan);
+
+    const result = await resolveGraph({ dossier: './deploy.ds.md' });
+
+    expect(DossierResolver.prototype.resolveFromPath).toHaveBeenCalled();
+    expect(DossierResolver.prototype.resolve).not.toHaveBeenCalled();
+    expect(result).toHaveProperty('plan');
+    expect((result as any).plan.totalDossiers).toBe(1);
+  });
+
+  it('should use resolve for registry names', async () => {
+    const mockEntry = {
+      name: 'deploy',
+      source: 'registry' as const,
+      metadata: {},
+      relationships: {},
+    };
+    const mockNodes = new Map([['deploy', { name: 'deploy', source: 'registry' as const }]]);
+    const mockGraph = { nodes: mockNodes, edges: [] };
+    const mockPlan = {
+      entryDossier: 'deploy',
+      totalDossiers: 1,
+      phases: [
+        { phase: 1, dossiers: [{ name: 'deploy', source: 'registry', condition: 'required' }] },
+      ],
+      conflicts: [],
+      warnings: [],
+    };
+
+    vi.mocked(DossierResolver.prototype.resolve).mockResolvedValue(mockEntry);
+    vi.mocked(DossierResolver.prototype.resolveGraph).mockResolvedValue(mockNodes);
+    vi.mocked(buildGraph).mockReturnValue(mockGraph);
+    vi.mocked(buildExecutionPlan).mockReturnValue(mockPlan);
+
+    const result = await resolveGraph({ dossier: 'deploy-to-aws' });
+
+    expect(DossierResolver.prototype.resolve).toHaveBeenCalledWith('deploy-to-aws');
+    expect(DossierResolver.prototype.resolveFromPath).not.toHaveBeenCalled();
+    expect(result).toHaveProperty('plan');
+  });
+
+  it('should treat paths with slashes as file paths', async () => {
+    const mockEntry = {
+      name: 'deploy',
+      source: 'local' as const,
+      path: '/test/sub/deploy.ds.md',
+      metadata: {},
+    };
+    const mockNodes = new Map([['deploy', { name: 'deploy', source: 'local' as const }]]);
+
+    vi.mocked(DossierResolver.prototype.resolveFromPath).mockResolvedValue(mockEntry);
+    vi.mocked(DossierResolver.prototype.resolveGraph).mockResolvedValue(mockNodes);
+    vi.mocked(buildGraph).mockReturnValue({ nodes: mockNodes, edges: [] });
+    vi.mocked(buildExecutionPlan).mockReturnValue({
+      entryDossier: 'deploy',
+      totalDossiers: 1,
+      phases: [],
+      conflicts: [],
+      warnings: [],
+    });
+
+    await resolveGraph({ dossier: 'sub/deploy' });
+
+    expect(DossierResolver.prototype.resolveFromPath).toHaveBeenCalled();
+  });
+
+  it('should return cycle error with cycle path', async () => {
+    const mockEntry = {
+      name: 'a',
+      source: 'local' as const,
+      metadata: {},
+    };
+    const mockNodes = new Map([
+      ['a', { name: 'a', source: 'local' as const }],
+      ['b', { name: 'b', source: 'local' as const }],
+    ]);
+
+    vi.mocked(DossierResolver.prototype.resolve).mockResolvedValue(mockEntry);
+    vi.mocked(DossierResolver.prototype.resolveGraph).mockResolvedValue(mockNodes);
+    vi.mocked(buildGraph).mockReturnValue({ nodes: mockNodes, edges: [] });
+    vi.mocked(buildExecutionPlan).mockImplementation(() => {
+      throw new CycleError(['a', 'b', 'a']);
+    });
+
+    const result = await resolveGraph({ dossier: 'a' });
+
+    expect(result).toHaveProperty('error');
+    const err = (result as any).error;
+    expect(err.type).toBe('cycle');
+    expect(err.cycle).toEqual(['a', 'b', 'a']);
+    expect(err.message).toContain('cycle');
+  });
+
+  it('should return resolve error for other failures', async () => {
+    vi.mocked(DossierResolver.prototype.resolve).mockRejectedValue(new Error('Connection timeout'));
+
+    const result = await resolveGraph({ dossier: 'broken-dossier' });
+
+    expect(result).toHaveProperty('error');
+    const err = (result as any).error;
+    expect(err.type).toBe('resolve');
+    expect(err.message).toContain('Connection timeout');
+  });
+});

--- a/mcp-server/src/tools/resolveGraph.ts
+++ b/mcp-server/src/tools/resolveGraph.ts
@@ -1,0 +1,91 @@
+/**
+ * resolve_graph tool - Resolve dossier dependency graph into an execution plan.
+ * Reads relationships (preceded_by, followed_by, conflicts_with, can_run_parallel_with)
+ * and produces a DAG-based execution plan.
+ */
+
+import { resolve } from 'node:path';
+import { buildExecutionPlan, buildGraph, CycleError } from '../orchestration/graph';
+import { DossierResolver } from '../orchestration/resolver';
+import type { ExecutionPlan } from '../orchestration/types';
+import { logger } from '../utils/logger';
+
+export interface ResolveGraphInput {
+  dossier: string;
+}
+
+export interface ResolveGraphOutput {
+  plan: ExecutionPlan;
+}
+
+export interface ResolveGraphError {
+  error: {
+    type: 'cycle' | 'resolve' | 'unknown';
+    message: string;
+    cycle?: string[];
+  };
+}
+
+/**
+ * Resolve a dossier's dependency graph and produce an execution plan.
+ */
+export async function resolveGraph(
+  input: ResolveGraphInput
+): Promise<ResolveGraphOutput | ResolveGraphError> {
+  const { dossier: dossierRef } = input;
+
+  if (!dossierRef) {
+    return {
+      error: { type: 'unknown', message: 'dossier parameter is required' },
+    };
+  }
+
+  logger.info('Resolving dependency graph', { dossier: dossierRef });
+
+  const resolver = new DossierResolver();
+
+  try {
+    // Determine if input is a file path or a name
+    const isPath = dossierRef.includes('/') || dossierRef.endsWith('.ds.md');
+
+    // Resolve entry dossier
+    const entryDossier = isPath
+      ? await resolver.resolveFromPath(resolve(dossierRef))
+      : await resolver.resolve(dossierRef);
+
+    // Recursively resolve the full dependency graph
+    const nodes = await resolver.resolveGraph(entryDossier);
+
+    // Build the graph structure
+    const graph = buildGraph(nodes);
+
+    // Generate the execution plan
+    const plan = buildExecutionPlan(graph, entryDossier.name);
+
+    logger.info('Dependency graph resolved', {
+      entryDossier: entryDossier.name,
+      totalDossiers: plan.totalDossiers,
+      phases: plan.phases.length,
+      conflicts: plan.conflicts.length,
+    });
+
+    return { plan };
+  } catch (error) {
+    if (error instanceof CycleError) {
+      return {
+        error: {
+          type: 'cycle',
+          message: error.message,
+          cycle: error.cycle,
+        },
+      };
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error('Graph resolution failed', { dossier: dossierRef, error: message });
+
+    return {
+      error: { type: 'resolve', message },
+    };
+  }
+}

--- a/mcp-server/vitest.config.ts
+++ b/mcp-server/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "vitest": "^4.0.9"
       },
       "engines": {
-        "node": ">=24.0.0"
+        "node": ">=18.0.0"
       }
     },
     "mcp-server": {
@@ -56,7 +56,224 @@
       "devDependencies": {
         "@types/node": "^24.10.0",
         "tsx": "^4.20.6",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^3.1.1"
+      }
+    },
+    "mcp-server/node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "mcp-server/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "mcp-server/node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "mcp-server/node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "mcp-server/node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "mcp-server/node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "mcp-server/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "mcp-server/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "mcp-server/node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "mcp-server/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "mcp-server/node_modules/zod": {
@@ -2401,6 +2618,7 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2732,6 +2950,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2782,6 +3010,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/cli-cursor": {
@@ -2919,6 +3157,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/depd": {
@@ -3845,6 +4093,13 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4164,6 +4419,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4177,7 +4442,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4713,6 +4977,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/strnum": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
@@ -4769,10 +5046,30 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/tinyrainbow": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
       "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5380,7 +5677,6 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -5448,6 +5744,29 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vitest": {


### PR DESCRIPTION
## Summary
- Add orchestration layer that resolves dossier dependency graphs into execution plans
- New `resolve_graph` MCP tool reads `preceded_by`, `followed_by`, `conflicts_with`, and `can_run_parallel_with` relationships to produce a DAG-based execution plan
- Includes cycle detection, topological sort into parallel phases, and conflict detection
- Reference resolution supports local files (via `ai-dossier list/info`) and registry fallback (via `ai-dossier get`)

## New Files
- `mcp-server/src/orchestration/types.ts` — shared type definitions
- `mcp-server/src/orchestration/graph.ts` — DAG builder, cycle detection, topological sort
- `mcp-server/src/orchestration/resolver.ts` — dossier reference resolution (local + registry)
- `mcp-server/src/tools/resolveGraph.ts` — MCP tool exposing the resolver
- `mcp-server/vitest.config.ts` — test configuration (first tests for mcp-server)

## Test plan
- [x] 22 unit tests for graph operations (cycle detection, topological sort, parallel groups, conflict detection, execution plan)
- [x] 9 unit tests for resolver (local/registry resolution, caching, recursive graph resolution)
- [x] 6 unit tests for resolveGraph tool (input validation, path vs name detection, error responses)
- [ ] Manual testing with example dossiers that have relationships

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)