### PR TITLE
fix(core): add engines field for Node.js >=18 requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -181,7 +181,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -2758,6 +2757,7 @@
       "integrity": "sha512-6HV2HHl9aRJ09TlYj/WAQxaa797Ezb5u0LpgabthlASAUAWKgw/W1DSPX7t848mMZmIUvzZgnUHGIylAoYHP0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.9",
         "fflate": "^0.8.2",
@@ -5677,6 +5677,7 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -5953,6 +5954,9 @@
         "@vitest/ui": "^4.0.9",
         "typescript": "^5.9.3",
         "vitest": "^4.0.9"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,9 @@
   "bugs": {
     "url": "https://github.com/imboard-ai/ai-dossier/issues"
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary
- Adds `"engines": { "node": ">=18.0.0" }` to `packages/core/package.json` to match the CLI package
- The `README.md` already exists with package-specific docs (installation, API usage, examples)

Closes #96

## Test plan
- [x] Core package builds successfully (`tsc --noEmit`)
- [x] All 91 core tests pass
- [x] `package.json` is valid JSON with correct `engines` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)