### PR TITLE
Add MCP server engines, homepage, and bugs fields to package.json

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -22,6 +22,18 @@
   ],
   "author": "Yuval Dimnik <yuval.dimnik@gmail.com>",
   "license": "Elastic-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/imboard-ai/ai-dossier.git",
+    "directory": "mcp-server"
+  },
+  "homepage": "https://github.com/imboard-ai/ai-dossier#readme",
+  "bugs": {
+    "url": "https://github.com/imboard-ai/ai-dossier/issues"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "type": "commonjs",
   "files": [
     "dist/"


### PR DESCRIPTION
## Summary
- Adds `engines` field (`node >= 18.0.0`) to match CLI package
- Adds `homepage` and `bugs` fields for npm discoverability
- Adds `repository` field with `directory: "mcp-server"` for monorepo linking

Closes #98

## Test plan
- [x] All 37 MCP server tests pass
- [x] `package.json` validates correctly (lint-staged/biome passed on commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)