### PR TITLE
docs: document .ds.md/.dsw.md extensions and ---dossier delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
 
 **Status**: v1.0 protocol | 15+ production examples | Active development
 
+> **File conventions**: Dossiers use `.ds.md` (immutable instructions) and `.dsw.md` (mutable working files). Frontmatter uses `---dossier` (JSON) instead of `---` (YAML) to avoid parser conflicts. [Learn more](docs/explanation/faq.md#what-do-the-dsmd-and-dswmd-file-extensions-mean)
+
 ---
 
 ## Try it Now

--- a/docs/explanation/faq.md
+++ b/docs/explanation/faq.md
@@ -5,7 +5,7 @@
 - [Dossiers vs. Alternatives](#dossiers-vs-alternatives)
 - [Protocol & Governance](#protocol--governance)
 - [Security & Trust](#security--trust)
-- [Technical Concerns](#technical-concerns)
+- [Technical Concerns](#technical-concerns) (file extensions, `---dossier` delimiter, determinism)
 - [Practical Usage](#practical-usage)
 
 ---
@@ -886,6 +886,33 @@ signature:
 ---
 
 ## Technical Concerns
+
+### What do the `.ds.md` and `.dsw.md` file extensions mean?
+
+Dossier files use two extensions:
+
+| Extension | Purpose | Mutable? | Verified? |
+|-----------|---------|----------|-----------|
+| `.ds.md` | **Dossier** — immutable instructions | No | Yes (checksums + signatures) |
+| `.dsw.md` | **Working file** — mutable execution state | Yes | No |
+
+**`.ds.md` (Dossier files)** contain the instructions, metadata, and validation criteria. They are checksummed and optionally signed. Their content should not change during execution.
+
+**`.dsw.md` (Working files)** track execution state: progress, context gathered, decisions made, and action logs. They are mutable and intentionally outside the security boundary. See the [working files example](../../examples/working-files/) for the full pattern.
+
+**Why not just `.md`?** The `.ds.md` extension makes dossiers discoverable by tooling (CLI, MCP server, IDE plugins) without needing to parse every markdown file in a project.
+
+### Why does the frontmatter use `---dossier` instead of `---`?
+
+Standard YAML frontmatter uses `---` as its delimiter. Dossier frontmatter uses `---dossier` intentionally:
+
+1. **Disambiguation** — Tools like Jekyll, Hugo, and VS Code treat `---` as YAML frontmatter. Since dossier frontmatter contains **JSON** (not YAML), using `---` would cause parsing errors or incorrect syntax highlighting in many editors.
+2. **Explicit identification** — `---dossier` signals to parsers that this block is a dossier metadata block, not generic frontmatter. This enables fast detection without reading the full file.
+3. **Coexistence** — A project can have both standard frontmatter files and dossier files without conflicts.
+
+**Tradeoff**: Some markdown previewers won't render the frontmatter as hidden metadata — they'll show it as text. This is expected. The frontmatter is meant for tooling (CLI, MCP server, registries), not for human reading in a previewer.
+
+If your editor shows the JSON block as visible text, that's normal behavior and does not affect execution.
 
 ### LLMs are non-deterministic. How can I rely on dossiers for production?
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,6 +14,14 @@ Instead of writing brittle scripts that break on edge cases, you write clear ins
 
 > **❓ First time here?** See [FAQ.md](../explanation/faq.md) for common questions like "Why not just use AGENTS.md?", "Who controls this protocol?", and detailed comparisons with alternatives.
 
+### File extensions & frontmatter at a glance
+
+- **`.ds.md`** — Dossier files (immutable instructions, checksummed)
+- **`.dsw.md`** — Working files (mutable execution state, not verified)
+- **`---dossier`** — Custom frontmatter delimiter (contains JSON metadata, not YAML). Uses `---dossier` instead of `---` to avoid conflicts with standard YAML frontmatter parsers. If your markdown previewer shows the JSON block as text, that's expected.
+
+See the [FAQ](../explanation/faq.md#what-do-the-dsmd-and-dswmd-file-extensions-mean) for details.
+
 ---
 
 ## Choose Your Path


### PR DESCRIPTION
## Summary
- Add FAQ entries explaining `.ds.md` vs `.dsw.md` file extensions and why frontmatter uses `---dossier` instead of `---`
- Add "File extensions & frontmatter at a glance" section to the Quick Start guide
- Add a brief callout in the README "At a Glance" section with a link to the FAQ

Closes #97

## Test plan
- [ ] Verify FAQ anchor links work (`#what-do-the-dsmd-and-dswmd-file-extensions-mean`)
- [ ] Verify Quick Start link to FAQ resolves correctly
- [ ] Verify README link to FAQ resolves correctly
- [ ] Review rendered markdown for formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)