### PR TITLE
feat(mcp): batch verification for dossier graphs

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -24,6 +24,7 @@ import { type ReadDossierInput, readDossier } from './tools/readDossier.js';
 import { type ResolveGraphInput, resolveGraph } from './tools/resolveGraph.js';
 import { type SearchDossiersInput, searchDossiers } from './tools/searchDossiers.js';
 import { type VerifyDossierInput, verifyDossier } from './tools/verifyDossier.js';
+import { type VerifyGraphInput, verifyGraph } from './tools/verifyGraph.js';
 import { logger } from './utils/logger.js';
 import { createToolResponse } from './utils/response.js';
 
@@ -129,6 +130,25 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           required: ['dossier'],
         },
       },
+      {
+        name: 'verify_graph',
+        description:
+          'Batch security verification for a dossier dependency graph. Verifies all dossiers in a resolved graph and returns an aggregate security report with per-dossier breakdown and overall recommendation.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            graph_id: {
+              type: 'string',
+              description: 'ID of a previously resolved graph (from resolve_graph)',
+            },
+            dossier: {
+              type: 'string',
+              description:
+                'Path to dossier file (.ds.md) or registry name. Resolves and verifies in one shot.',
+            },
+          },
+        },
+      },
     ],
   };
 });
@@ -163,6 +183,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case 'resolve_graph': {
         const result = await resolveGraph(args as unknown as ResolveGraphInput);
+        return createToolResponse(result);
+      }
+
+      case 'verify_graph': {
+        const result = await verifyGraph(args as unknown as VerifyGraphInput);
         return createToolResponse(result);
       }
 

--- a/mcp-server/src/tools/__tests__/resolveGraph.test.ts
+++ b/mcp-server/src/tools/__tests__/resolveGraph.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ExecutionPlan } from '../../orchestration/types';
 import { resolveGraph } from '../resolveGraph';
 
 // Mock the resolver
@@ -22,6 +23,11 @@ vi.mock('../../orchestration/graph', () => ({
       this.cycle = cycle;
     }
   },
+}));
+
+vi.mock('../../utils/graphStore', () => ({
+  generateGraphId: vi.fn(() => 'test-graph-id'),
+  storeGraph: vi.fn(),
 }));
 
 vi.mock('../../utils/logger', () => ({
@@ -63,11 +69,14 @@ describe('resolveGraph tool', () => {
     };
     const mockNodes = new Map([['deploy', { name: 'deploy', source: 'local' as const }]]);
     const mockGraph = { nodes: mockNodes, edges: [] };
-    const mockPlan = {
+    const mockPlan: ExecutionPlan = {
       entryDossier: 'deploy',
       totalDossiers: 1,
       phases: [
-        { phase: 1, dossiers: [{ name: 'deploy', source: 'local', condition: 'required' }] },
+        {
+          phase: 1,
+          dossiers: [{ name: 'deploy', source: 'local' as const, condition: 'required' as const }],
+        },
       ],
       conflicts: [],
       warnings: [],
@@ -95,11 +104,16 @@ describe('resolveGraph tool', () => {
     };
     const mockNodes = new Map([['deploy', { name: 'deploy', source: 'registry' as const }]]);
     const mockGraph = { nodes: mockNodes, edges: [] };
-    const mockPlan = {
+    const mockPlan: ExecutionPlan = {
       entryDossier: 'deploy',
       totalDossiers: 1,
       phases: [
-        { phase: 1, dossiers: [{ name: 'deploy', source: 'registry', condition: 'required' }] },
+        {
+          phase: 1,
+          dossiers: [
+            { name: 'deploy', source: 'registry' as const, condition: 'required' as const },
+          ],
+        },
       ],
       conflicts: [],
       warnings: [],

--- a/mcp-server/src/tools/__tests__/verifyGraph.test.ts
+++ b/mcp-server/src/tools/__tests__/verifyGraph.test.ts
@@ -1,0 +1,348 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ExecutionPlan } from '../../orchestration/types';
+import type { VerifyDossierOutput } from '../verifyDossier';
+import { type VerifyGraphError, type VerifyGraphOutput, verifyGraph } from '../verifyGraph';
+
+vi.mock('../../utils/cli-wrapper', () => ({
+  execCli: vi.fn(),
+  CliNotFoundError: class CliNotFoundError extends Error {
+    constructor() {
+      super('ai-dossier CLI not found');
+      this.name = 'CliNotFoundError';
+    }
+  },
+}));
+
+vi.mock('../../utils/graphStore', () => ({
+  getGraph: vi.fn(),
+  generateGraphId: vi.fn(() => 'test-graph-id'),
+  storeGraph: vi.fn(),
+}));
+
+vi.mock('../../orchestration/resolver', () => {
+  const DossierResolver = vi.fn();
+  DossierResolver.prototype.resolve = vi.fn();
+  DossierResolver.prototype.resolveFromPath = vi.fn();
+  DossierResolver.prototype.resolveGraph = vi.fn();
+  return { DossierResolver };
+});
+
+vi.mock('../../orchestration/graph', () => ({
+  buildGraph: vi.fn(),
+  buildExecutionPlan: vi.fn(),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { buildExecutionPlan, buildGraph } from '../../orchestration/graph';
+import { DossierResolver } from '../../orchestration/resolver';
+import { CliNotFoundError, execCli } from '../../utils/cli-wrapper';
+import { getGraph } from '../../utils/graphStore';
+
+function makePlan(
+  entries: Array<{ name: string; source: 'local' | 'registry'; path?: string; riskLevel?: string }>
+): ExecutionPlan {
+  return {
+    entryDossier: entries[0]?.name ?? 'unknown',
+    totalDossiers: entries.length,
+    phases: [
+      {
+        phase: 1,
+        dossiers: entries.map((e) => ({
+          name: e.name,
+          source: e.source,
+          path: e.path,
+          condition: 'required' as const,
+          riskLevel: e.riskLevel,
+        })),
+      },
+    ],
+    conflicts: [],
+    warnings: [],
+  };
+}
+
+function passedResult(): VerifyDossierOutput {
+  return {
+    passed: true,
+    stages: [
+      { stage: 1, name: 'Integrity Check', passed: true },
+      { stage: 2, name: 'Authenticity Check', passed: true },
+    ],
+  };
+}
+
+function failedIntegrity(): VerifyDossierOutput {
+  return {
+    passed: false,
+    stages: [
+      { stage: 1, name: 'Integrity Check', passed: false },
+      { stage: 2, name: 'Authenticity Check', skipped: true },
+    ],
+  };
+}
+
+function failedAuthenticity(): VerifyDossierOutput {
+  return {
+    passed: false,
+    stages: [
+      { stage: 1, name: 'Integrity Check', passed: true },
+      { stage: 2, name: 'Authenticity Check', passed: false },
+    ],
+  };
+}
+
+describe('verifyGraph tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return error when neither graph_id nor dossier is provided', async () => {
+    const result = await verifyGraph({});
+    expect(result).toHaveProperty('error');
+    expect((result as VerifyGraphError).error.type).toBe('validation');
+  });
+
+  it('should return error when graph_id is not found', async () => {
+    vi.mocked(getGraph).mockReturnValue(undefined);
+
+    const result = await verifyGraph({ graph_id: 'nonexistent' });
+    expect(result).toHaveProperty('error');
+    expect((result as VerifyGraphError).error.type).toBe('not_found');
+  });
+
+  it('should verify all dossiers from a stored graph', async () => {
+    const plan = makePlan([
+      { name: 'setup-infra', source: 'local', path: '/tmp/setup.ds.md', riskLevel: 'low' },
+      { name: 'deploy-app', source: 'local', path: '/tmp/deploy.ds.md', riskLevel: 'low' },
+    ]);
+
+    vi.mocked(getGraph).mockReturnValue(plan);
+    vi.mocked(execCli).mockResolvedValue(passedResult());
+
+    const result = (await verifyGraph({ graph_id: 'test-id' })) as VerifyGraphOutput;
+
+    expect(result.overall_recommendation).toBe('ALLOW');
+    expect(result.dossiers).toHaveLength(2);
+    expect(result.blockers).toHaveLength(0);
+    expect(execCli).toHaveBeenCalledTimes(2);
+  });
+
+  it('should run verifications in parallel', async () => {
+    const plan = makePlan([
+      { name: 'a', source: 'local', path: '/a.ds.md' },
+      { name: 'b', source: 'local', path: '/b.ds.md' },
+      { name: 'c', source: 'local', path: '/c.ds.md' },
+    ]);
+
+    vi.mocked(getGraph).mockReturnValue(plan);
+
+    const callOrder: string[] = [];
+    vi.mocked(execCli).mockImplementation((_cmd, args) => {
+      callOrder.push(args[0]);
+      return Promise.resolve(passedResult());
+    });
+
+    await verifyGraph({ graph_id: 'test-id' });
+
+    // All three were called (Promise.all means parallel)
+    expect(callOrder).toHaveLength(3);
+    expect(callOrder).toContain('/a.ds.md');
+    expect(callOrder).toContain('/b.ds.md');
+    expect(callOrder).toContain('/c.ds.md');
+  });
+
+  it('should BLOCK when any dossier fails integrity', async () => {
+    const plan = makePlan([
+      { name: 'good', source: 'local', path: '/good.ds.md', riskLevel: 'low' },
+      { name: 'bad', source: 'local', path: '/bad.ds.md', riskLevel: 'low' },
+    ]);
+
+    vi.mocked(getGraph).mockReturnValue(plan);
+    vi.mocked(execCli)
+      .mockResolvedValueOnce(passedResult())
+      .mockResolvedValueOnce(failedIntegrity());
+
+    const result = (await verifyGraph({ graph_id: 'test-id' })) as VerifyGraphOutput;
+
+    expect(result.overall_recommendation).toBe('BLOCK');
+    expect(result.blockers).toContain('bad');
+    expect(result.dossiers[1].recommendation).toBe('BLOCK');
+  });
+
+  it('should WARN when authenticity fails but integrity passes', async () => {
+    const plan = makePlan([
+      { name: 'unsigned', source: 'local', path: '/unsigned.ds.md', riskLevel: 'low' },
+    ]);
+
+    vi.mocked(getGraph).mockReturnValue(plan);
+    vi.mocked(execCli).mockResolvedValue(failedAuthenticity());
+
+    const result = (await verifyGraph({ graph_id: 'test-id' })) as VerifyGraphOutput;
+
+    expect(result.overall_recommendation).toBe('WARN');
+    expect(result.blockers).toHaveLength(0);
+    expect(result.dossiers[0].recommendation).toBe('WARN');
+  });
+
+  it('should WARN for high-risk dossiers even when verification passes', async () => {
+    const plan = makePlan([
+      { name: 'risky', source: 'local', path: '/risky.ds.md', riskLevel: 'high' },
+    ]);
+
+    vi.mocked(getGraph).mockReturnValue(plan);
+    vi.mocked(execCli).mockResolvedValue(passedResult());
+
+    const result = (await verifyGraph({ graph_id: 'test-id' })) as VerifyGraphOutput;
+
+    expect(result.overall_recommendation).toBe('WARN');
+    expect(result.dossiers[0].recommendation).toBe('WARN');
+    expect(result.dossiers[0].passed).toBe(true);
+  });
+
+  it('should aggregate worst-case recommendation', async () => {
+    const plan = makePlan([
+      { name: 'allow', source: 'local', path: '/allow.ds.md', riskLevel: 'low' },
+      { name: 'warn', source: 'local', path: '/warn.ds.md', riskLevel: 'high' },
+    ]);
+
+    vi.mocked(getGraph).mockReturnValue(plan);
+    vi.mocked(execCli).mockResolvedValue(passedResult());
+
+    const result = (await verifyGraph({ graph_id: 'test-id' })) as VerifyGraphOutput;
+
+    // One ALLOW + one WARN = overall WARN
+    expect(result.overall_recommendation).toBe('WARN');
+  });
+
+  it('should resolve and verify when dossier parameter is used', async () => {
+    const mockEntry = {
+      name: 'deploy',
+      source: 'local' as const,
+      path: '/test/deploy.ds.md',
+      metadata: {},
+      relationships: {},
+    };
+    const mockNodes = new Map([
+      ['deploy', { name: 'deploy', source: 'local' as const, path: '/test/deploy.ds.md' }],
+    ]);
+    const mockGraph = { nodes: mockNodes, edges: [] };
+    const mockPlan = makePlan([
+      { name: 'deploy', source: 'local', path: '/test/deploy.ds.md', riskLevel: 'low' },
+    ]);
+
+    vi.mocked(DossierResolver.prototype.resolveFromPath).mockResolvedValue(mockEntry);
+    vi.mocked(DossierResolver.prototype.resolveGraph).mockResolvedValue(mockNodes);
+    vi.mocked(buildGraph).mockReturnValue(mockGraph);
+    vi.mocked(buildExecutionPlan).mockReturnValue(mockPlan);
+    vi.mocked(execCli).mockResolvedValue(passedResult());
+
+    const result = (await verifyGraph({ dossier: './deploy.ds.md' })) as VerifyGraphOutput;
+
+    expect(result.overall_recommendation).toBe('ALLOW');
+    expect(result.dossiers).toHaveLength(1);
+    expect(DossierResolver.prototype.resolveFromPath).toHaveBeenCalled();
+  });
+
+  it('should return resolve error when inline resolution fails', async () => {
+    vi.mocked(DossierResolver.prototype.resolve).mockRejectedValue(
+      new Error('Registry unavailable')
+    );
+
+    const result = await verifyGraph({ dossier: 'nonexistent-dossier' });
+
+    expect(result).toHaveProperty('error');
+    expect((result as VerifyGraphError).error.type).toBe('resolve');
+    expect((result as VerifyGraphError).error.message).toContain('Registry unavailable');
+  });
+
+  it('should BLOCK when CLI is not found', async () => {
+    const plan = makePlan([{ name: 'test', source: 'local', path: '/test.ds.md' }]);
+
+    vi.mocked(getGraph).mockReturnValue(plan);
+    vi.mocked(execCli).mockRejectedValue(new CliNotFoundError());
+
+    const result = (await verifyGraph({ graph_id: 'test-id' })) as VerifyGraphOutput;
+
+    expect(result.overall_recommendation).toBe('BLOCK');
+    expect(result.dossiers[0].recommendation).toBe('BLOCK');
+    expect(result.dossiers[0].error).toBeDefined();
+  });
+
+  it('should use name when path is not available', async () => {
+    const plan = makePlan([{ name: 'org/deploy-app', source: 'registry' }]);
+
+    vi.mocked(getGraph).mockReturnValue(plan);
+    vi.mocked(execCli).mockResolvedValue(passedResult());
+
+    await verifyGraph({ graph_id: 'test-id' });
+
+    expect(execCli).toHaveBeenCalledWith('verify', ['org/deploy-app', '--json']);
+  });
+
+  it('should deduplicate dossiers across phases', async () => {
+    const plan: ExecutionPlan = {
+      entryDossier: 'a',
+      totalDossiers: 2,
+      phases: [
+        { phase: 1, dossiers: [{ name: 'a', source: 'local', condition: 'required' }] },
+        { phase: 2, dossiers: [{ name: 'a', source: 'local', condition: 'required' }] },
+      ],
+      conflicts: [],
+      warnings: [],
+    };
+
+    vi.mocked(getGraph).mockReturnValue(plan);
+    vi.mocked(execCli).mockResolvedValue(passedResult());
+
+    const result = (await verifyGraph({ graph_id: 'test-id' })) as VerifyGraphOutput;
+
+    // Should verify 'a' only once
+    expect(execCli).toHaveBeenCalledTimes(1);
+    expect(result.dossiers).toHaveLength(1);
+  });
+
+  it('should produce a readable summary', async () => {
+    const plan = makePlan([
+      { name: 'a', source: 'local', path: '/a.ds.md', riskLevel: 'low' },
+      { name: 'b', source: 'local', path: '/b.ds.md', riskLevel: 'low' },
+      { name: 'c', source: 'local', path: '/c.ds.md', riskLevel: 'low' },
+    ]);
+
+    vi.mocked(getGraph).mockReturnValue(plan);
+    vi.mocked(execCli)
+      .mockResolvedValueOnce(passedResult())
+      .mockResolvedValueOnce(passedResult())
+      .mockResolvedValueOnce(failedIntegrity());
+
+    const result = (await verifyGraph({ graph_id: 'test-id' })) as VerifyGraphOutput;
+
+    expect(result.summary).toContain('3 dossiers verified');
+    expect(result.summary).toContain('2 passed');
+    expect(result.summary).toContain('1 blocked');
+  });
+
+  it('should prefer graph_id over dossier when both are provided', async () => {
+    const plan = makePlan([
+      { name: 'from-store', source: 'local', path: '/store.ds.md', riskLevel: 'low' },
+    ]);
+
+    vi.mocked(getGraph).mockReturnValue(plan);
+    vi.mocked(execCli).mockResolvedValue(passedResult());
+
+    const result = (await verifyGraph({
+      graph_id: 'test-id',
+      dossier: './other.ds.md',
+    })) as VerifyGraphOutput;
+
+    expect(result.dossiers[0].name).toBe('from-store');
+    expect(DossierResolver.prototype.resolve).not.toHaveBeenCalled();
+    expect(DossierResolver.prototype.resolveFromPath).not.toHaveBeenCalled();
+  });
+});

--- a/mcp-server/src/tools/resolveGraph.ts
+++ b/mcp-server/src/tools/resolveGraph.ts
@@ -8,6 +8,7 @@ import { resolve } from 'node:path';
 import { buildExecutionPlan, buildGraph, CycleError } from '../orchestration/graph';
 import { DossierResolver } from '../orchestration/resolver';
 import type { ExecutionPlan } from '../orchestration/types';
+import { generateGraphId, storeGraph } from '../utils/graphStore';
 import { logger } from '../utils/logger';
 
 export interface ResolveGraphInput {
@@ -15,6 +16,7 @@ export interface ResolveGraphInput {
 }
 
 export interface ResolveGraphOutput {
+  graph_id: string;
   plan: ExecutionPlan;
 }
 
@@ -62,14 +64,18 @@ export async function resolveGraph(
     // Generate the execution plan
     const plan = buildExecutionPlan(graph, entryDossier.name);
 
+    const graphId = generateGraphId();
+    storeGraph(graphId, plan);
+
     logger.info('Dependency graph resolved', {
       entryDossier: entryDossier.name,
       totalDossiers: plan.totalDossiers,
       phases: plan.phases.length,
       conflicts: plan.conflicts.length,
+      graphId,
     });
 
-    return { plan };
+    return { graph_id: graphId, plan };
   } catch (error) {
     if (error instanceof CycleError) {
       return {

--- a/mcp-server/src/tools/verifyGraph.ts
+++ b/mcp-server/src/tools/verifyGraph.ts
@@ -1,0 +1,215 @@
+/**
+ * verify_graph tool - Batch verification for dossier dependency graphs.
+ * Verifies all dossiers in a resolved graph and returns an aggregate security report.
+ */
+
+import { resolve } from 'node:path';
+import { buildExecutionPlan, buildGraph } from '../orchestration/graph';
+import { DossierResolver } from '../orchestration/resolver';
+import type { ExecutionPlan, PhaseEntry } from '../orchestration/types';
+import { CliNotFoundError, execCli } from '../utils/cli-wrapper';
+import { getGraph } from '../utils/graphStore';
+import { logger } from '../utils/logger';
+import type { VerifyDossierOutput } from './verifyDossier';
+
+export interface VerifyGraphInput {
+  graph_id?: string;
+  dossier?: string;
+}
+
+export type Recommendation = 'ALLOW' | 'WARN' | 'BLOCK';
+
+export interface DossierVerificationResult {
+  name: string;
+  recommendation: Recommendation;
+  risk: string;
+  passed: boolean;
+  error?: string;
+}
+
+export interface VerifyGraphOutput {
+  overall_recommendation: Recommendation;
+  summary: string;
+  blockers: string[];
+  dossiers: DossierVerificationResult[];
+}
+
+export interface VerifyGraphError {
+  error: {
+    type: 'validation' | 'resolve' | 'not_found';
+    message: string;
+  };
+}
+
+/**
+ * Extract all unique dossiers from an execution plan.
+ */
+function extractDossiers(plan: ExecutionPlan): PhaseEntry[] {
+  const seen = new Set<string>();
+  const dossiers: PhaseEntry[] = [];
+  for (const phase of plan.phases) {
+    for (const entry of phase.dossiers) {
+      if (!seen.has(entry.name)) {
+        seen.add(entry.name);
+        dossiers.push(entry);
+      }
+    }
+  }
+  return dossiers;
+}
+
+/**
+ * Determine recommendation based on verification result and risk level.
+ */
+function getRecommendation(result: VerifyDossierOutput, riskLevel: string): Recommendation {
+  if (!result.passed) {
+    // Check if integrity stage specifically failed (stage 1 is typically integrity/checksum)
+    const integrityFailed = result.stages.some(
+      (s) =>
+        s.passed === false &&
+        (s.name.toLowerCase().includes('integrity') || s.name.toLowerCase().includes('checksum'))
+    );
+    if (integrityFailed) return 'BLOCK';
+    return 'WARN';
+  }
+  // Even if verification passed, high risk dossiers get a WARN
+  if (riskLevel === 'critical' || riskLevel === 'high') return 'WARN';
+  return 'ALLOW';
+}
+
+/**
+ * Compute the worst-case recommendation across all results.
+ */
+function worstCase(recommendations: Recommendation[]): Recommendation {
+  if (recommendations.includes('BLOCK')) return 'BLOCK';
+  if (recommendations.includes('WARN')) return 'WARN';
+  return 'ALLOW';
+}
+
+/**
+ * Verify a single dossier entry, returning its verification result.
+ */
+async function verifySingleDossier(entry: PhaseEntry): Promise<DossierVerificationResult> {
+  const identifier = entry.path ?? entry.name;
+  try {
+    const result = await execCli<VerifyDossierOutput>('verify', [identifier, '--json']);
+    const risk = entry.riskLevel ?? 'unknown';
+    const recommendation = getRecommendation(result, risk);
+    return {
+      name: entry.name,
+      recommendation,
+      risk,
+      passed: result.passed,
+    };
+  } catch (error) {
+    if (error instanceof CliNotFoundError) {
+      return {
+        name: entry.name,
+        recommendation: 'BLOCK',
+        risk: entry.riskLevel ?? 'unknown',
+        passed: false,
+        error: error.message,
+      };
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      name: entry.name,
+      recommendation: 'BLOCK',
+      risk: entry.riskLevel ?? 'unknown',
+      passed: false,
+      error: message,
+    };
+  }
+}
+
+/**
+ * Resolve a dossier reference into an execution plan (same logic as resolveGraph tool).
+ */
+async function resolvePlan(dossierRef: string): Promise<ExecutionPlan> {
+  const resolver = new DossierResolver();
+  const isPath = dossierRef.includes('/') || dossierRef.endsWith('.ds.md');
+  const entryDossier = isPath
+    ? await resolver.resolveFromPath(resolve(dossierRef))
+    : await resolver.resolve(dossierRef);
+  const nodes = await resolver.resolveGraph(entryDossier);
+  const graph = buildGraph(nodes);
+  return buildExecutionPlan(graph, entryDossier.name);
+}
+
+/**
+ * Verify all dossiers in a dependency graph and return an aggregate security report.
+ */
+export async function verifyGraph(
+  input: VerifyGraphInput
+): Promise<VerifyGraphOutput | VerifyGraphError> {
+  const { graph_id, dossier } = input;
+
+  if (!graph_id && !dossier) {
+    return {
+      error: {
+        type: 'validation',
+        message: 'Either graph_id or dossier parameter is required',
+      },
+    };
+  }
+
+  let plan: ExecutionPlan;
+
+  if (graph_id) {
+    const stored = getGraph(graph_id);
+    if (!stored) {
+      return {
+        error: {
+          type: 'not_found',
+          message: `No graph found with id: ${graph_id}`,
+        },
+      };
+    }
+    plan = stored;
+    logger.info('Verifying graph from store', { graphId: graph_id });
+  } else {
+    logger.info('Resolving and verifying graph', { dossier });
+    try {
+      plan = await resolvePlan(dossier!);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error('Graph resolution failed during verify', { dossier, error: message });
+      return {
+        error: { type: 'resolve', message },
+      };
+    }
+  }
+
+  const entries = extractDossiers(plan);
+
+  logger.info('Starting batch verification', { totalDossiers: entries.length });
+
+  // Verify all dossiers in parallel
+  const results = await Promise.all(entries.map(verifySingleDossier));
+
+  const blockers = results.filter((r) => r.recommendation === 'BLOCK').map((r) => r.name);
+  const overall = worstCase(results.map((r) => r.recommendation));
+
+  const counts = { ALLOW: 0, WARN: 0, BLOCK: 0 };
+  for (const r of results) counts[r.recommendation]++;
+
+  const parts: string[] = [`${results.length} dossiers verified`];
+  if (counts.ALLOW > 0) parts.push(`${counts.ALLOW} passed`);
+  if (counts.WARN > 0) parts.push(`${counts.WARN} warnings`);
+  if (counts.BLOCK > 0) parts.push(`${counts.BLOCK} blocked`);
+
+  const output: VerifyGraphOutput = {
+    overall_recommendation: overall,
+    summary: parts.join(', '),
+    blockers,
+    dossiers: results,
+  };
+
+  logger.info('Batch verification complete', {
+    overall,
+    total: results.length,
+    blockers: blockers.length,
+  });
+
+  return output;
+}

--- a/mcp-server/src/utils/graphStore.ts
+++ b/mcp-server/src/utils/graphStore.ts
@@ -1,0 +1,21 @@
+/**
+ * In-memory store for resolved execution plans.
+ * Allows verify_graph to reference a previously resolved graph by ID.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { ExecutionPlan } from '../orchestration/types';
+
+const store = new Map<string, ExecutionPlan>();
+
+export function generateGraphId(): string {
+  return randomUUID();
+}
+
+export function storeGraph(id: string, plan: ExecutionPlan): void {
+  store.set(id, plan);
+}
+
+export function getGraph(id: string): ExecutionPlan | undefined {
+  return store.get(id);
+}


### PR DESCRIPTION
## Summary
- Add `verify_graph` MCP tool that verifies all dossiers in a resolved dependency graph and returns an aggregate security report
- Add in-memory graph store so `resolve_graph` results can be referenced by `graph_id`
- Fix pre-existing TS type errors in `resolveGraph.test.ts`

## Details
- **Input**: `graph_id` (from prior `resolve_graph`) OR `dossier` (resolve + verify in one shot)
- **Parallel verification**: All dossiers verified concurrently via `Promise.all`
- **Aggregate recommendation**: Worst-case across all dossiers (BLOCK > WARN > ALLOW)
- **Blockers**: Any dossier failing integrity check blocks the entire journey
- **Per-dossier breakdown**: name, recommendation, risk level, pass/fail status

Closes #71

## Test plan
- [x] 15 unit tests covering all acceptance criteria
- [x] Validation errors (missing params, unknown graph_id)
- [x] Both input modes (graph_id and dossier)
- [x] Parallel verification behavior
- [x] BLOCK on integrity failure
- [x] WARN on authenticity failure / high-risk dossiers
- [x] Worst-case aggregation
- [x] Deduplication across phases
- [x] CLI-not-found error handling
- [x] Summary formatting
- [x] TypeScript build passes
- [x] All 52 tests pass (including existing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)