### PR TITLE
feat(cli): publish collision warning, full path, and --json flag

### DIFF
--- a/cli/src/__tests__/commands/publish.test.ts
+++ b/cli/src/__tests__/commands/publish.test.ts
@@ -18,7 +18,7 @@ const validDossier = `---dossier
 Body content here`;
 
 describe('publish command', () => {
-  const mockClient = { publishDossier: vi.fn() };
+  const mockClient = { publishDossier: vi.fn(), getDossier: vi.fn() };
 
   beforeEach(() => {
     vi.mocked(credentials.loadCredentials).mockReturnValue({
@@ -29,6 +29,9 @@ describe('publish command', () => {
     });
     vi.mocked(credentials.isExpired).mockReturnValue(false);
     vi.mocked(registryClient.getClient).mockReturnValue(mockClient as any);
+    mockClient.getDossier.mockRejectedValue(
+      Object.assign(new Error('Not found'), { statusCode: 404 })
+    );
     mockedFs.existsSync.mockReturnValue(true);
     mockedFs.readFileSync.mockReturnValue(validDossier);
   });
@@ -39,9 +42,9 @@ describe('publish command', () => {
     const program = createTestProgram();
     registerPublishCommand(program);
 
-    await expect(program.parseAsync(['node', 'dossier', 'publish', 'test.ds.md'])).rejects.toThrow(
-      'process.exit(1)'
-    );
+    await expect(
+      program.parseAsync(['node', 'dossier', 'publish', 'test.ds.md'])
+    ).rejects.toThrow();
 
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Not logged in'));
   });
@@ -52,9 +55,9 @@ describe('publish command', () => {
     const program = createTestProgram();
     registerPublishCommand(program);
 
-    await expect(program.parseAsync(['node', 'dossier', 'publish', 'test.ds.md'])).rejects.toThrow(
-      'process.exit(1)'
-    );
+    await expect(
+      program.parseAsync(['node', 'dossier', 'publish', 'test.ds.md'])
+    ).rejects.toThrow();
 
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('expired'));
   });
@@ -67,7 +70,7 @@ describe('publish command', () => {
 
     await expect(
       program.parseAsync(['node', 'dossier', 'publish', 'missing.ds.md'])
-    ).rejects.toThrow('process.exit(1)');
+    ).rejects.toThrow();
 
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('File not found'));
   });
@@ -78,9 +81,9 @@ describe('publish command', () => {
     const program = createTestProgram();
     registerPublishCommand(program);
 
-    await expect(program.parseAsync(['node', 'dossier', 'publish', 'test.ds.md'])).rejects.toThrow(
-      'process.exit(1)'
-    );
+    await expect(
+      program.parseAsync(['node', 'dossier', 'publish', 'test.ds.md'])
+    ).rejects.toThrow();
 
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Invalid dossier format'));
   });
@@ -91,14 +94,14 @@ describe('publish command', () => {
     const program = createTestProgram();
     registerPublishCommand(program);
 
-    await expect(program.parseAsync(['node', 'dossier', 'publish', 'test.ds.md'])).rejects.toThrow(
-      'process.exit(1)'
-    );
+    await expect(
+      program.parseAsync(['node', 'dossier', 'publish', 'test.ds.md'])
+    ).rejects.toThrow();
 
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Validation errors'));
   });
 
-  it('should publish with --yes flag', async () => {
+  it('should publish with --yes flag and show full registry path', async () => {
     mockClient.publishDossier.mockResolvedValue({
       name: 'org/test-dossier',
       content_url: 'https://registry.example.com/dossiers/org/test-dossier',
@@ -110,10 +113,80 @@ describe('publish command', () => {
     await program.parseAsync(['node', 'dossier', 'publish', 'test.ds.md', '--yes']);
 
     expect(mockClient.publishDossier).toHaveBeenCalledWith('org', validDossier, null);
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Published'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('org/test-dossier@1.0.0'));
   });
 
-  it('should exit 1 on 409 version conflict', async () => {
+  it('should exit 1 on same-version collision (pre-publish check)', async () => {
+    mockClient.getDossier.mockReset();
+    // First call (with version) returns existing dossier — same version exists
+    mockClient.getDossier.mockResolvedValueOnce({ name: 'org/test-dossier', version: '1.0.0' });
+
+    const program = createTestProgram();
+    registerPublishCommand(program);
+
+    // In vitest v4, process.exit records the call but doesn't halt execution
+    try {
+      await program.parseAsync(['node', 'dossier', 'publish', 'test.ds.md', '--yes']);
+    } catch {
+      // Expected — process.exit throws in vitest v4
+    }
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Version collision: org/test-dossier@1.0.0 already exists')
+    );
+  });
+
+  it('should output JSON on same-version collision with --json flag', async () => {
+    mockClient.getDossier.mockReset();
+    mockClient.getDossier.mockResolvedValueOnce({ name: 'org/test-dossier', version: '1.0.0' });
+
+    const program = createTestProgram();
+    registerPublishCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'dossier', 'publish', 'test.ds.md', '--yes', '--json'])
+    ).rejects.toThrow();
+
+    const jsonCall = vi.mocked(console.log).mock.calls.find((call) => {
+      try {
+        const parsed = JSON.parse(call[0] as string);
+        return parsed.error === 'version_exists';
+      } catch {
+        return false;
+      }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall![0] as string);
+    expect(output.success).toBe(false);
+    expect(output.path).toBe('org/test-dossier');
+  });
+
+  it('should publish with --json flag and output structured result', async () => {
+    mockClient.publishDossier.mockResolvedValue({
+      name: 'org/test-dossier',
+      content_url: 'https://registry.example.com/dossiers/org/test-dossier',
+    });
+
+    const program = createTestProgram();
+    registerPublishCommand(program);
+
+    await program.parseAsync(['node', 'dossier', 'publish', 'test.ds.md', '--yes', '--json']);
+
+    const jsonCall = vi.mocked(console.log).mock.calls.find((call) => {
+      try {
+        const parsed = JSON.parse(call[0] as string);
+        return parsed.success === true;
+      } catch {
+        return false;
+      }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall![0] as string);
+    expect(output.registryPath).toBe('org/test-dossier@1.0.0');
+    expect(output.url).toBe('https://registry.example.com/dossiers/org/test-dossier');
+  });
+
+  it('should exit 1 on 409 version conflict from server', async () => {
     mockClient.publishDossier.mockRejectedValue(
       Object.assign(new Error('Version exists'), { statusCode: 409 })
     );
@@ -123,8 +196,31 @@ describe('publish command', () => {
 
     await expect(
       program.parseAsync(['node', 'dossier', 'publish', 'test.ds.md', '--yes'])
-    ).rejects.toThrow('process.exit(1)');
+    ).rejects.toThrow();
 
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Version conflict'));
+  });
+
+  it('should warn when dossier exists at different version', async () => {
+    mockClient.getDossier.mockReset();
+    // First call (with version) — 404 (specific version doesn't exist)
+    mockClient.getDossier.mockRejectedValueOnce(
+      Object.assign(new Error('Not found'), { statusCode: 404 })
+    );
+    // Second call (without version) — dossier exists at different version
+    mockClient.getDossier.mockResolvedValueOnce({ name: 'org/test-dossier', version: '0.9.0' });
+
+    mockClient.publishDossier.mockResolvedValue({
+      name: 'org/test-dossier',
+      content_url: 'https://registry.example.com/dossiers/org/test-dossier',
+    });
+
+    const program = createTestProgram();
+    registerPublishCommand(program);
+
+    await program.parseAsync(['node', 'dossier', 'publish', 'test.ds.md', '--yes']);
+
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Updated from v0.9.0'));
+    expect(mockClient.publishDossier).toHaveBeenCalled();
   });
 });

--- a/cli/src/__tests__/commands/publish.test.ts
+++ b/cli/src/__tests__/commands/publish.test.ts
@@ -156,7 +156,7 @@ describe('publish command', () => {
       }
     });
     expect(jsonCall).toBeDefined();
-    const output = JSON.parse(jsonCall![0] as string);
+    const output = JSON.parse(jsonCall?.[0] as string);
     expect(output.success).toBe(false);
     expect(output.path).toBe('org/test-dossier');
   });
@@ -181,7 +181,7 @@ describe('publish command', () => {
       }
     });
     expect(jsonCall).toBeDefined();
-    const output = JSON.parse(jsonCall![0] as string);
+    const output = JSON.parse(jsonCall?.[0] as string);
     expect(output.registryPath).toBe('org/test-dossier@1.0.0');
     expect(output.url).toBe('https://registry.example.com/dossiers/org/test-dossier');
   });

--- a/cli/src/commands/publish.ts
+++ b/cli/src/commands/publish.ts
@@ -15,8 +15,12 @@ export function registerPublishCommand(program: Command): void {
     .option('--changelog <message>', 'Changelog message for this version')
     .option('-y, --yes', 'Skip confirmation prompt')
     .option('--namespace <namespace>', 'Override namespace (e.g., imboard-ai/skills)')
+    .option('--json', 'Output as JSON')
     .action(
-      async (file: string, options: { changelog?: string; yes?: boolean; namespace?: string }) => {
+      async (
+        file: string,
+        options: { changelog?: string; yes?: boolean; namespace?: string; json?: boolean }
+      ) => {
         const credentials = loadCredentials();
         if (!credentials) {
           console.error('\n❌ Not logged in. Run `dossier login` first.\n');
@@ -89,15 +93,66 @@ export function registerPublishCommand(program: Command): void {
           (credentials.orgs.length > 0 ? credentials.orgs[0] : credentials.username);
         const name = frontmatter.name || frontmatter.title || path.basename(dossierFile, '.ds.md');
         const version = frontmatter.version || 'unknown';
+        const fullPath = `${namespace}/${name}`;
+        const registryPath = `${fullPath}@${version}`;
+
+        // Pre-publish existence check
+        const client = getClient(credentials.token);
+        let existingVersion: string | null = null;
+        let versionExists = false;
+        try {
+          const existing = (await client.getDossier(fullPath, version)) as any;
+          if (existing) {
+            versionExists = true;
+          }
+        } catch (err: any) {
+          // 404 = version doesn't exist (expected), other errors = warn but don't block
+        }
+
+        if (versionExists) {
+          if (options.json) {
+            console.log(
+              JSON.stringify(
+                {
+                  success: false,
+                  error: 'version_exists',
+                  message: `${registryPath} already exists`,
+                  path: fullPath,
+                  version,
+                },
+                null,
+                2
+              )
+            );
+          } else {
+            console.error(`\n❌ Version collision: ${registryPath} already exists.`);
+            console.error('   Bump the version in your dossier and try again.\n');
+          }
+          process.exit(1);
+          return;
+        }
+
+        // Check if dossier exists at any version (for overwrite warning)
+        try {
+          const existing = (await client.getDossier(fullPath)) as any;
+          if (existing) {
+            existingVersion = existing.version || null;
+          }
+        } catch (err: any) {
+          // Ignore — dossier doesn't exist or check failed
+        }
 
         if (!options.yes) {
           console.log('\n📦 Publishing dossier:\n');
+          console.log(`   Registry:  ${registryPath}`);
           console.log(`   File:      ${path.basename(dossierFile)}`);
-          console.log(`   Name:      ${name}`);
-          console.log(`   Version:   ${version}`);
-          console.log(`   Namespace: ${namespace}`);
           if (options.changelog) {
             console.log(`   Changelog: ${options.changelog}`);
+          }
+          if (existingVersion) {
+            console.log(
+              `\n   ⚠️  ${fullPath} already exists (latest: v${existingVersion}). Publishing will add v${version}.`
+            );
           }
           console.log('');
 
@@ -114,26 +169,60 @@ export function registerPublishCommand(program: Command): void {
         }
 
         try {
-          const client = getClient(credentials.token);
           const result = (await client.publishDossier(
             namespace,
             content,
             options.changelog || null
           )) as any;
 
-          const fullName = result.name || `${namespace}/${name}`;
-          console.log(`\n✅ Published ${fullName}@${version}`);
-          if (result.content_url) {
-            console.log(`   URL: ${result.content_url}`);
+          if (options.json) {
+            console.log(
+              JSON.stringify(
+                {
+                  success: true,
+                  path: result.name || fullPath,
+                  version,
+                  registryPath,
+                  url: result.content_url || null,
+                  existed: existingVersion !== null,
+                  previousVersion: existingVersion,
+                },
+                null,
+                2
+              )
+            );
+          } else {
+            console.log(`\n✅ Published ${registryPath}`);
+            if (existingVersion) {
+              console.log(`   Updated from v${existingVersion}`);
+            }
+            if (result.content_url) {
+              console.log(`   URL: ${result.content_url}`);
+            }
+            console.log('');
           }
-          console.log('');
         } catch (err: any) {
-          if (err.statusCode === 401) {
+          if (options.json) {
+            console.log(
+              JSON.stringify(
+                {
+                  success: false,
+                  error: err.code || 'publish_failed',
+                  message: err.message,
+                  path: fullPath,
+                  version,
+                  statusCode: err.statusCode || null,
+                },
+                null,
+                2
+              )
+            );
+          } else if (err.statusCode === 401) {
             console.error('\n❌ Session expired. Run `dossier login` to re-authenticate.\n');
           } else if (err.statusCode === 403) {
             console.error(`\n❌ Permission denied: ${err.message}\n`);
           } else if (err.statusCode === 409) {
-            console.error(`\n❌ Version conflict: ${err.message}\n`);
+            console.error(`\n❌ Version conflict: ${registryPath} — ${err.message}\n`);
           } else {
             console.error(`\n❌ Publish failed: ${err.message}`);
             if (err.statusCode) {

--- a/cli/src/commands/publish.ts
+++ b/cli/src/commands/publish.ts
@@ -105,7 +105,7 @@ export function registerPublishCommand(program: Command): void {
           if (existing) {
             versionExists = true;
           }
-        } catch (err: any) {
+        } catch {
           // 404 = version doesn't exist (expected), other errors = warn but don't block
         }
 
@@ -138,7 +138,7 @@ export function registerPublishCommand(program: Command): void {
           if (existing) {
             existingVersion = existing.version || null;
           }
-        } catch (err: any) {
+        } catch {
           // Ignore — dossier doesn't exist or check failed
         }
 


### PR DESCRIPTION
## Summary
- Show full registry path (`namespace/name@version`) in publish confirmation prompt
- Pre-publish existence check: error on same-version collision, warn when dossier exists at different version
- Add `--json` flag for structured output (agent-friendly)
- Fix publish tests for vitest v4 `process.exit` behavior

Closes #103

## Test plan
- [x] `npx vitest run src/__tests__/commands/publish.test.ts` — 11 tests pass
- [x] `npx vitest run src/__tests__/registry-client.test.ts` — 26 tests pass
- [x] TypeScript build compiles cleanly
- [ ] Manual: `dossier publish test.ds.md` shows `namespace/name@version` in confirmation
- [ ] Manual: `dossier publish test.ds.md --json --yes` outputs structured JSON
- [ ] Manual: republishing same version shows collision error

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>