### PR TITLE
feat(cli): add --json output to publish, remove, and whoami

### DIFF
--- a/cli/src/__tests__/commands/publish.test.ts
+++ b/cli/src/__tests__/commands/publish.test.ts
@@ -147,7 +147,7 @@ describe('publish command', () => {
     const jsonCall = vi.mocked(console.log).mock.calls.find((call) => {
       try {
         const parsed = JSON.parse(call[0] as string);
-        return parsed.success === true;
+        return parsed.published === true;
       } catch {
         return false;
       }
@@ -193,15 +193,15 @@ describe('publish command', () => {
     const jsonCall = vi.mocked(console.log).mock.calls.find((call) => {
       try {
         const parsed = JSON.parse(call[0] as string);
-        return parsed.error === 'version_exists';
+        return parsed.code === 'version_exists';
       } catch {
         return false;
       }
     });
     expect(jsonCall).toBeDefined();
     const output = JSON.parse(jsonCall?.[0] as string);
-    expect(output.success).toBe(false);
-    expect(output.path).toBe('org/test-dossier');
+    expect(output.published).toBe(false);
+    expect(output.name).toBe('org/test-dossier');
   });
 
   it('should publish with --json flag and output structured result', async () => {
@@ -218,15 +218,16 @@ describe('publish command', () => {
     const jsonCall = vi.mocked(console.log).mock.calls.find((call) => {
       try {
         const parsed = JSON.parse(call[0] as string);
-        return parsed.success === true;
+        return parsed.published === true;
       } catch {
         return false;
       }
     });
     expect(jsonCall).toBeDefined();
     const output = JSON.parse(jsonCall?.[0] as string);
-    expect(output.registryPath).toBe('org/test-dossier@1.0.0');
-    expect(output.url).toBe('https://registry.example.com/dossiers/org/test-dossier');
+    expect(output.name).toBe('org/test-dossier');
+    expect(output.version).toBe('1.0.0');
+    expect(output.content_url).toBe('https://registry.example.com/dossiers/org/test-dossier');
   });
 
   it('should exit 1 on 409 version conflict from server', async () => {

--- a/cli/src/__tests__/commands/remove.test.ts
+++ b/cli/src/__tests__/commands/remove.test.ts
@@ -76,7 +76,7 @@ describe('remove command', () => {
     const jsonCall = vi.mocked(console.log).mock.calls.find((call) => {
       try {
         const parsed = JSON.parse(call[0] as string);
-        return parsed.success === true;
+        return parsed.removed === true;
       } catch {
         return false;
       }
@@ -90,7 +90,7 @@ describe('remove command', () => {
 
   it('should output JSON error on remove failure with --json flag', async () => {
     mockClient.removeDossier.mockRejectedValue(
-      Object.assign(new Error('Not found'), { statusCode: 404 })
+      Object.assign(new Error('Not found'), { statusCode: 404, code: 'not_found' })
     );
 
     const program = createTestProgram();
@@ -103,15 +103,15 @@ describe('remove command', () => {
     const jsonCall = vi.mocked(console.log).mock.calls.find((call) => {
       try {
         const parsed = JSON.parse(call[0] as string);
-        return parsed.success === false;
+        return parsed.removed === false;
       } catch {
         return false;
       }
     });
     expect(jsonCall).toBeDefined();
     const output = JSON.parse(jsonCall?.[0] as string);
-    expect(output.success).toBe(false);
-    expect(output.statusCode).toBe(404);
+    expect(output.error).toBe('Not found');
+    expect(output.code).toBe('not_found');
   });
 
   it('should remove specific version with --yes', async () => {

--- a/cli/src/__tests__/commands/whoami.test.ts
+++ b/cli/src/__tests__/commands/whoami.test.ts
@@ -34,7 +34,7 @@ describe('whoami command', () => {
     registerWhoamiCommand(program);
 
     await expect(program.parseAsync(['node', 'dossier', 'whoami'])).rejects.toThrow(
-      'process.exit(1)'
+      /process\.exit/
     );
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Not logged in'));
   });
@@ -52,9 +52,60 @@ describe('whoami command', () => {
     registerWhoamiCommand(program);
 
     await expect(program.parseAsync(['node', 'dossier', 'whoami'])).rejects.toThrow(
-      'process.exit(1)'
+      /process\.exit/
     );
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('expired'));
+  });
+
+  it('should output JSON when logged in with --json flag', async () => {
+    vi.mocked(credentials.loadCredentials).mockReturnValue({
+      token: 'tok',
+      username: 'testuser',
+      orgs: ['org1', 'org2'],
+      expiresAt: null,
+    });
+    vi.mocked(credentials.isExpired).mockReturnValue(false);
+
+    const program = createTestProgram();
+    registerWhoamiCommand(program);
+    await program.parseAsync(['node', 'dossier', 'whoami', '--json']);
+
+    const jsonCall = vi.mocked(console.log).mock.calls.find((call) => {
+      try {
+        const parsed = JSON.parse(call[0] as string);
+        return parsed.logged_in === true;
+      } catch {
+        return false;
+      }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall?.[0] as string);
+    expect(output.username).toBe('testuser');
+    expect(output.orgs).toEqual(['org1', 'org2']);
+  });
+
+  it('should output JSON when not logged in with --json flag', async () => {
+    vi.mocked(credentials.loadCredentials).mockReturnValue(null);
+
+    const program = createTestProgram();
+    registerWhoamiCommand(program);
+
+    await expect(program.parseAsync(['node', 'dossier', 'whoami', '--json'])).rejects.toThrow(
+      /process\.exit/
+    );
+
+    const jsonCall = vi.mocked(console.log).mock.calls.find((call) => {
+      try {
+        const parsed = JSON.parse(call[0] as string);
+        return parsed.logged_in === false;
+      } catch {
+        return false;
+      }
+    });
+    expect(jsonCall).toBeDefined();
+    const output = JSON.parse(jsonCall?.[0] as string);
+    expect(output.error).toBe('Not logged in');
+    expect(output.code).toBe('not_logged_in');
   });
 
   it('should not show orgs when empty', async () => {

--- a/cli/src/commands/publish.ts
+++ b/cli/src/commands/publish.ts
@@ -23,11 +23,31 @@ export function registerPublishCommand(program: Command): void {
       ) => {
         const credentials = loadCredentials();
         if (!credentials) {
-          console.error('\n❌ Not logged in. Run `dossier login` first.\n');
+          if (options.json) {
+            console.log(
+              JSON.stringify(
+                { published: false, error: 'Not logged in', code: 'not_logged_in' },
+                null,
+                2
+              )
+            );
+          } else {
+            console.error('\n❌ Not logged in. Run `dossier login` first.\n');
+          }
           process.exit(1);
         }
         if (isExpired(credentials)) {
-          console.error('\n❌ Credentials expired. Run `dossier login` to re-authenticate.\n');
+          if (options.json) {
+            console.log(
+              JSON.stringify(
+                { published: false, error: 'Credentials expired', code: 'expired' },
+                null,
+                2
+              )
+            );
+          } else {
+            console.error('\n❌ Credentials expired. Run `dossier login` to re-authenticate.\n');
+          }
           process.exit(1);
         }
 
@@ -100,10 +120,10 @@ export function registerPublishCommand(program: Command): void {
             console.log(
               JSON.stringify(
                 {
-                  success: false,
-                  error: 'version_exists',
-                  message: `${registryPath} already exists`,
-                  path: fullPath,
+                  published: false,
+                  error: `${registryPath} already exists`,
+                  code: 'version_exists',
+                  name: fullPath,
                   version,
                 },
                 null,
@@ -168,13 +188,10 @@ export function registerPublishCommand(program: Command): void {
             console.log(
               JSON.stringify(
                 {
-                  success: true,
-                  path: result.name || fullPath,
+                  published: true,
+                  name: result.name || fullPath,
                   version,
-                  registryPath,
-                  url: result.content_url || null,
-                  existed: existingVersion !== null,
-                  previousVersion: existingVersion,
+                  content_url: result.content_url || null,
                   verification: {
                     verify_command: verifyCommand,
                     cdn_delay_seconds: cdnDelaySeconds,
@@ -201,12 +218,9 @@ export function registerPublishCommand(program: Command): void {
             console.log(
               JSON.stringify(
                 {
-                  success: false,
-                  error: err.code || 'publish_failed',
-                  message: err.message,
-                  path: fullPath,
-                  version,
-                  statusCode: err.statusCode || null,
+                  published: false,
+                  error: err.message,
+                  code: err.code || 'publish_failed',
                 },
                 null,
                 2

--- a/cli/src/commands/remove.ts
+++ b/cli/src/commands/remove.ts
@@ -13,11 +13,31 @@ export function registerRemoveCommand(program: Command): void {
     .action(async (name: string, options: { yes?: boolean; json?: boolean }) => {
       const credentials = loadCredentials();
       if (!credentials) {
-        console.error('\n❌ Not logged in. Run `dossier login` first.\n');
+        if (options.json) {
+          console.log(
+            JSON.stringify(
+              { removed: false, error: 'Not logged in', code: 'not_logged_in' },
+              null,
+              2
+            )
+          );
+        } else {
+          console.error('\n❌ Not logged in. Run `dossier login` first.\n');
+        }
         process.exit(1);
       }
       if (isExpired(credentials)) {
-        console.error('\n❌ Credentials expired. Run `dossier login` to re-authenticate.\n');
+        if (options.json) {
+          console.log(
+            JSON.stringify(
+              { removed: false, error: 'Credentials expired', code: 'expired' },
+              null,
+              2
+            )
+          );
+        } else {
+          console.error('\n❌ Credentials expired. Run `dossier login` to re-authenticate.\n');
+        }
         process.exit(1);
       }
 
@@ -54,10 +74,8 @@ export function registerRemoveCommand(program: Command): void {
           console.log(
             JSON.stringify(
               {
-                success: true,
-                name: dossierName,
-                version: version || null,
-                target,
+                removed: true,
+                name: target,
                 verification: {
                   verify_command: verifyCommand,
                   cdn_delay_seconds: cdnDelaySeconds,
@@ -78,12 +96,9 @@ export function registerRemoveCommand(program: Command): void {
           console.log(
             JSON.stringify(
               {
-                success: false,
-                error: err.code || 'remove_failed',
-                message: err.message,
-                name: dossierName,
-                version: version || null,
-                statusCode: err.statusCode || null,
+                removed: false,
+                error: err.message,
+                code: err.code || 'remove_failed',
               },
               null,
               2

--- a/cli/src/commands/whoami.ts
+++ b/cli/src/commands/whoami.ts
@@ -5,24 +5,59 @@ export function registerWhoamiCommand(program: Command): void {
   program
     .command('whoami')
     .description('Show current registry user')
-    .action(() => {
+    .option('--json', 'Output as JSON')
+    .action((options: { json?: boolean }) => {
       const credentials = loadCredentials();
       if (!credentials) {
-        console.log('\nℹ️  Not logged in');
-        console.log('   Run `dossier login` to authenticate\n');
+        if (options.json) {
+          console.log(
+            JSON.stringify(
+              { logged_in: false, error: 'Not logged in', code: 'not_logged_in' },
+              null,
+              2
+            )
+          );
+        } else {
+          console.log('\nℹ️  Not logged in');
+          console.log('   Run `dossier login` to authenticate\n');
+        }
         process.exit(1);
       }
 
       if (isExpired(credentials)) {
-        console.log('\n⚠️  Credentials expired');
-        console.log('   Run `dossier login` to re-authenticate\n');
+        if (options.json) {
+          console.log(
+            JSON.stringify(
+              { logged_in: false, error: 'Credentials expired', code: 'expired' },
+              null,
+              2
+            )
+          );
+        } else {
+          console.log('\n⚠️  Credentials expired');
+          console.log('   Run `dossier login` to re-authenticate\n');
+        }
         process.exit(1);
       }
 
-      console.log(`\n👤 ${credentials.username}`);
-      if (credentials.orgs.length > 0) {
-        console.log(`   Organizations: ${credentials.orgs.join(', ')}`);
+      if (options.json) {
+        console.log(
+          JSON.stringify(
+            {
+              logged_in: true,
+              username: credentials.username,
+              orgs: credentials.orgs,
+            },
+            null,
+            2
+          )
+        );
+      } else {
+        console.log(`\n👤 ${credentials.username}`);
+        if (credentials.orgs.length > 0) {
+          console.log(`   Organizations: ${credentials.orgs.join(', ')}`);
+        }
+        console.log('');
       }
-      console.log('');
     });
 }


### PR DESCRIPTION
## Summary
- Add `--json` flag to `remove` and `whoami` commands for agent-parseable output
- Align `publish --json` output fields to match acceptance criteria (`published`, `name`, `content_url`)
- Add JSON error output for auth failures (not logged in, expired) across all three commands
- Fix pre-existing vitest v4 `process.exit` assertion mismatches in remove/whoami tests

Closes #105

## Test plan
- [x] All 25 tests pass (publish: 11, remove: 8, whoami: 6)
- `publish --json -y` outputs `{ "published": true, "name": "...", "version": "...", "content_url": "..." }`
- `remove --json -y` outputs `{ "removed": true, "name": "..." }`
- `whoami --json` outputs `{ "logged_in": true, "username": "...", "orgs": [...] }`
- On failure, JSON includes `{ "error": "...", "code": "..." }`

Co-Authored-By: Claude <noreply@anthropic.com>