### PR TITLE
fix(core): stop silently swallowing errors in crypto verification paths

### DIFF
--- a/cli/bin/dossier-verify
+++ b/cli/bin/dossier-verify
@@ -193,18 +193,9 @@ async function checkSignature(body, frontmatter) {
   // key_id is easier to manage in trusted-keys.txt file
   const isTrusted = trustedKeys.has(signature.key_id) || trustedKeys.has(signature.public_key);
 
-  try {
-    const isValid = await verifySignature(body, signature);
+  const result = await verifySignature(body, signature);
 
-    if (!isValid) {
-      return {
-        present: true,
-        verified: false,
-        trusted: isTrusted,
-        message: 'Signature verification FAILED',
-      };
-    }
-
+  if (result.valid) {
     return {
       present: true,
       verified: true,
@@ -213,14 +204,23 @@ async function checkSignature(body, frontmatter) {
         ? `Verified signature from trusted source: ${trustedKeys.get(signature.key_id) || trustedKeys.get(signature.public_key)}`
         : 'Valid signature but key is not in trusted list',
     };
-  } catch (err) {
+  }
+
+  if (result.error) {
     return {
       present: true,
       verified: false,
       trusted: false,
-      message: `Verification error: ${err.message}`,
+      message: `Verification error: ${result.error}`,
     };
   }
+
+  return {
+    present: true,
+    verified: false,
+    trusted: isTrusted,
+    message: 'Signature verification FAILED',
+  };
 }
 
 // Assess risk

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -114,14 +114,22 @@ ${options.template !== DEFAULT_CREATE_TEMPLATE ? `- **Template reference**: ${op
           const result = spawnSync('claude', [tmpFile], { stdio: 'inherit' });
           try {
             fs.unlinkSync(tmpFile);
-          } catch {}
+          } catch (cleanupErr) {
+            process.stderr.write(
+              `Warning: failed to clean up temp file ${tmpFile}: ${(cleanupErr as Error).message}\n`
+            );
+          }
           if (result.status !== 0) {
             throw { status: result.status, message: `claude exited with code ${result.status}` };
           }
         } catch (execError) {
           try {
             fs.unlinkSync(tmpFile);
-          } catch {}
+          } catch (cleanupErr) {
+            process.stderr.write(
+              `Warning: failed to clean up temp file ${tmpFile}: ${(cleanupErr as Error).message}\n`
+            );
+          }
           throw execError;
         }
 

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -129,8 +129,10 @@ export function registerRunCommand(program: Command): void {
         try {
           const parsed = parseDossierContent(content);
           fm = parsed.frontmatter;
-        } catch {
-          // Non-fatal: metadata display is best-effort
+        } catch (err) {
+          process.stderr.write(
+            `Warning: failed to parse dossier metadata: ${(err as Error).message}\n`
+          );
         }
 
         if (fm && (fm.title || fm.risk_level || fm.objective)) {
@@ -145,8 +147,10 @@ export function registerRunCommand(program: Command): void {
           }
           log('');
         }
-      } catch {
-        // Non-fatal
+      } catch (err) {
+        process.stderr.write(
+          `Warning: failed to read dossier summary: ${(err as Error).message}\n`
+        );
       }
 
       // Nested session detection
@@ -199,7 +203,11 @@ export function registerRunCommand(program: Command): void {
         if (tmpUrlFile)
           try {
             fs.unlinkSync(tmpUrlFile);
-          } catch {}
+          } catch (err) {
+            process.stderr.write(
+              `Warning: failed to clean up temp file ${tmpUrlFile}: ${(err as Error).message}\n`
+            );
+          }
       };
 
       if (options.dryRun) {

--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -231,7 +231,11 @@ export function downloadUrlToTempFile(url: string): string {
   if (!fs.existsSync(tmpFile) || fs.statSync(tmpFile).size === 0) {
     try {
       fs.unlinkSync(tmpFile);
-    } catch {}
+    } catch (err) {
+      process.stderr.write(
+        `Warning: failed to clean up temp file ${tmpFile}: ${(err as Error).message}\n`
+      );
+    }
     throw new Error(`Downloaded file is empty: ${resolvedUrl}`);
   }
   return tmpFile;
@@ -332,8 +336,8 @@ export function findDossierFilesLocal(dir: string, recursive = false): string[] 
         results.push(fullPath);
       }
     }
-  } catch {
-    // Silently skip directories we can't read
+  } catch (err) {
+    process.stderr.write(`Warning: cannot read directory ${dir}: ${(err as Error).message}\n`);
   }
 
   return results;

--- a/packages/core/src/__tests__/kms.test.ts
+++ b/packages/core/src/__tests__/kms.test.ts
@@ -106,14 +106,14 @@ describe('KmsVerifier', () => {
     expect(verifier.supports('RSA')).toBe(false);
   });
 
-  it('should return false when key_id is missing', async () => {
+  it('should return invalid when key_id is missing', async () => {
     const result = await verifier.verify('content', {
       algorithm: 'ECDSA-SHA-256',
       signature: 'sig',
       public_key: 'pk',
       signed_at: new Date().toISOString(),
     });
-    expect(result).toBe(false);
+    expect(result).toEqual({ valid: false });
   });
 
   it('should verify a valid signature', async () => {
@@ -127,7 +127,7 @@ describe('KmsVerifier', () => {
       signed_at: new Date().toISOString(),
     });
 
-    expect(result).toBe(true);
+    expect(result).toEqual({ valid: true });
   });
 
   it('should reject an invalid signature', async () => {
@@ -141,10 +141,10 @@ describe('KmsVerifier', () => {
       signed_at: new Date().toISOString(),
     });
 
-    expect(result).toBe(false);
+    expect(result).toEqual({ valid: false });
   });
 
-  it('should return false on KMS errors', async () => {
+  it('should return error on KMS errors', async () => {
     vi.mocked(KMSClient.prototype.send).mockRejectedValueOnce(new Error('KMS unavailable'));
 
     const result = await verifier.verify('content', {
@@ -155,7 +155,8 @@ describe('KmsVerifier', () => {
       signed_at: new Date().toISOString(),
     });
 
-    expect(result).toBe(false);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('KMS unavailable');
   });
 
   it('should extract region from ARN', async () => {
@@ -195,6 +196,6 @@ describe('KmsVerifier', () => {
       signed_at: new Date().toISOString(),
     });
 
-    expect(result).toBe(true);
+    expect(result).toEqual({ valid: true });
   });
 });

--- a/packages/core/src/__tests__/signature.test.ts
+++ b/packages/core/src/__tests__/signature.test.ts
@@ -240,7 +240,7 @@ describe('verifyWithEd25519', () => {
     // Verify signature
     const result = verifyWithEd25519(content, signatureBase64, publicKeyPem);
 
-    expect(result).toBe(true);
+    expect(result).toEqual({ valid: true });
   });
 
   it('should reject tampered content', () => {
@@ -255,7 +255,7 @@ describe('verifyWithEd25519', () => {
 
     const result = verifyWithEd25519(tamperedContent, signatureBase64, publicKeyPem);
 
-    expect(result).toBe(false);
+    expect(result).toEqual({ valid: false });
   });
 
   it('should reject wrong public key', () => {
@@ -270,26 +270,28 @@ describe('verifyWithEd25519', () => {
 
     const result = verifyWithEd25519(content, signatureBase64, publicKeyPem2);
 
-    expect(result).toBe(false);
+    expect(result).toEqual({ valid: false });
   });
 
-  it('should handle invalid PEM format', () => {
+  it('should return error for invalid PEM format', () => {
     const content = 'Test content';
     const signature = 'dGVzdA==';
     const invalidPem = 'not-a-valid-pem';
 
     const result = verifyWithEd25519(content, signature, invalidPem);
 
-    expect(result).toBe(false);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
   });
 
-  it('should handle invalid signature base64', () => {
+  it('should reject invalid signature base64', () => {
     const { publicKey } = generateKeyPairSync('ed25519');
     const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }) as string;
 
     const result = verifyWithEd25519('content', 'invalid!!!base64', publicKeyPem);
 
-    expect(result).toBe(false);
+    // Buffer.from silently ignores invalid base64 chars, so this is a genuine verification failure
+    expect(result.valid).toBe(false);
   });
 
   it('should work with multiline content', () => {
@@ -306,7 +308,7 @@ With special chars: 你好 🎉`;
 
     const result = verifyWithEd25519(content, signatureBase64, publicKeyPem);
 
-    expect(result).toBe(true);
+    expect(result).toEqual({ valid: true });
   });
 
   it('should detect whitespace changes', () => {
@@ -321,7 +323,7 @@ With special chars: 你好 🎉`;
 
     const result = verifyWithEd25519(modifiedContent, signatureBase64, publicKeyPem);
 
-    expect(result).toBe(false);
+    expect(result).toEqual({ valid: false });
   });
 });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,7 @@ export {
   Signer,
   Verifier,
   VerifierRegistry,
+  VerifyResult,
 } from './signers';
 // Type exports
 export * from './types';

--- a/packages/core/src/signature.ts
+++ b/packages/core/src/signature.ts
@@ -9,7 +9,7 @@ import { createPublicKey, verify } from 'node:crypto';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { KMSClient, SigningAlgorithmSpec, VerifyCommand } from '@aws-sdk/client-kms';
-import type { SignatureResult } from './signers';
+import type { SignatureResult, VerifyResult } from './signers';
 import { getVerifierRegistry } from './signers';
 import { sha256Hash } from './utils/crypto';
 import { readFileIfExists } from './utils/fs';
@@ -45,8 +45,10 @@ export function loadTrustedKeys(filePath?: string): Map<string, string> {
         keys.set(publicKey, keyId);
       }
     }
-  } catch (_err) {
-    // Silently handle errors - consumers can check the returned Map size
+  } catch (err) {
+    process.stderr.write(
+      `Warning: error parsing trusted keys file ${keysPath}: ${(err as Error).message}\n`
+    );
   }
 
   return keys;
@@ -57,8 +59,13 @@ export function loadTrustedKeys(filePath?: string): Map<string, string> {
  * @param content - The content to verify
  * @param signature - Base64-encoded signature
  * @param publicKey - PEM-format Ed25519 public key
+ * @returns VerifyResult with valid flag and optional error
  */
-export function verifyWithEd25519(content: string, signature: string, publicKey: string): boolean {
+export function verifyWithEd25519(
+  content: string,
+  signature: string,
+  publicKey: string
+): VerifyResult {
   try {
     const signatureBuffer = Buffer.from(signature, 'base64');
     const contentBuffer = Buffer.from(content, 'utf8');
@@ -71,21 +78,23 @@ export function verifyWithEd25519(content: string, signature: string, publicKey:
     });
 
     // Verify Ed25519 signature (algorithm is null for Ed25519)
-    return verify(null, contentBuffer, publicKeyObject, signatureBuffer);
-  } catch (_err) {
-    return false;
+    const valid = verify(null, contentBuffer, publicKeyObject, signatureBuffer);
+    return { valid };
+  } catch (err) {
+    return { valid: false, error: (err as Error).message };
   }
 }
 
 /**
  * Verify signature using AWS KMS (ECDSA-SHA-256)
+ * @returns VerifyResult with valid flag and optional error
  */
 export async function verifyWithKms(
   content: string,
   signature: string,
   keyId: string,
   region = 'us-east-1'
-): Promise<boolean> {
+): Promise<VerifyResult> {
   const client = new KMSClient({ region });
 
   // Calculate SHA256 digest of content (must match signing process)
@@ -103,9 +112,9 @@ export async function verifyWithKms(
 
   try {
     const response = await client.send(command);
-    return response.SignatureValid === true;
-  } catch (_err) {
-    return false;
+    return { valid: response.SignatureValid === true };
+  } catch (err) {
+    return { valid: false, error: (err as Error).message };
   }
 }
 
@@ -114,12 +123,12 @@ export async function verifyWithKms(
  * This is a convenience function that encapsulates registry lookup
  * @param content - The content to verify
  * @param signature - Signature result object containing algorithm and signature data
- * @returns Promise<boolean> - true if signature is valid, false otherwise
+ * @returns VerifyResult with valid flag and optional error
  */
 export async function verifySignature(
   content: string,
   signature: SignatureResult
-): Promise<boolean> {
+): Promise<VerifyResult> {
   const verifierRegistry = getVerifierRegistry();
   const verifier = verifierRegistry.get(signature.algorithm);
   return await verifier.verify(content, signature);

--- a/packages/core/src/signers/ed25519.ts
+++ b/packages/core/src/signers/ed25519.ts
@@ -5,7 +5,7 @@
 import type { KeyObject } from 'node:crypto';
 import { createPrivateKey, createPublicKey, sign, verify } from 'node:crypto';
 import { readFileSync } from 'node:fs';
-import type { SignatureResult, Signer, Verifier } from './index';
+import type { SignatureResult, Signer, Verifier, VerifyResult } from './index';
 
 export class Ed25519Signer implements Signer {
   readonly algorithm = 'ed25519';
@@ -51,7 +51,7 @@ export class Ed25519Verifier implements Verifier {
     return algorithm === 'ed25519';
   }
 
-  async verify(content: string, signature: SignatureResult): Promise<boolean> {
+  async verify(content: string, signature: SignatureResult): Promise<VerifyResult> {
     try {
       const signatureBuffer = Buffer.from(signature.signature, 'base64');
       const contentBuffer = Buffer.from(content, 'utf8');
@@ -64,9 +64,10 @@ export class Ed25519Verifier implements Verifier {
       });
 
       // Verify Ed25519 signature
-      return verify(null, contentBuffer, publicKeyObject, signatureBuffer);
-    } catch (_err) {
-      return false;
+      const valid = verify(null, contentBuffer, publicKeyObject, signatureBuffer);
+      return { valid };
+    } catch (err) {
+      return { valid: false, error: (err as Error).message };
     }
   }
 }

--- a/packages/core/src/signers/index.ts
+++ b/packages/core/src/signers/index.ts
@@ -28,11 +28,17 @@ export interface Signer {
   readonly algorithm: string;
 }
 
+export interface VerifyResult {
+  valid: boolean;
+  /** Present when valid is false due to an error (not a genuine verification failure) */
+  error?: string;
+}
+
 export interface Verifier {
   /**
    * Verify a signature
    */
-  verify(content: string, signature: SignatureResult): Promise<boolean>;
+  verify(content: string, signature: SignatureResult): Promise<VerifyResult>;
 
   /**
    * Check if this verifier supports the given algorithm

--- a/packages/core/src/signers/kms.ts
+++ b/packages/core/src/signers/kms.ts
@@ -10,7 +10,7 @@ import {
   VerifyCommand,
 } from '@aws-sdk/client-kms';
 import { sha256Hash } from '../utils/crypto';
-import type { SignatureResult, Signer, Verifier } from './index';
+import type { SignatureResult, Signer, Verifier, VerifyResult } from './index';
 
 export class KmsSigner implements Signer {
   readonly algorithm = 'ECDSA-SHA-256';
@@ -85,9 +85,9 @@ export class KmsVerifier implements Verifier {
     return algorithm === 'ECDSA-SHA-256';
   }
 
-  async verify(content: string, signature: SignatureResult): Promise<boolean> {
+  async verify(content: string, signature: SignatureResult): Promise<VerifyResult> {
     if (!signature.key_id) {
-      return false;
+      return { valid: false };
     }
 
     try {
@@ -108,9 +108,9 @@ export class KmsVerifier implements Verifier {
       });
 
       const response = await client.send(command);
-      return response.SignatureValid === true;
-    } catch (_err) {
-      return false;
+      return { valid: response.SignatureValid === true };
+    } catch (err) {
+      return { valid: false, error: (err as Error).message };
     }
   }
 

--- a/tools/verify-dossier.ts
+++ b/tools/verify-dossier.ts
@@ -153,27 +153,25 @@ async function verifyDossier(dossierFile: string, trustedKeysFile: string): Prom
     }
 
     // Verify signature
-    try {
-      const isValid = await verifySignature(body, sig);
+    const sigResult = await verifySignature(body, sig);
 
-      if (isValid) {
-        if (result.authenticity.isTrusted) {
-          result.authenticity.status = 'verified';
-          result.authenticity.message = `Verified signature from trusted source: ${result.authenticity.trustedAs}`;
-        } else {
-          result.authenticity.status = 'signed_unknown';
-          result.authenticity.message = `Valid signature but key is not in trusted list`;
-        }
+    if (sigResult.valid) {
+      if (result.authenticity.isTrusted) {
+        result.authenticity.status = 'verified';
+        result.authenticity.message = `Verified signature from trusted source: ${result.authenticity.trustedAs}`;
       } else {
-        result.authenticity.status = 'invalid';
-        result.authenticity.message = 'SIGNATURE VERIFICATION FAILED';
-        result.errors.push('Signature verification FAILED - do not execute!');
-        result.recommendation = 'BLOCK';
+        result.authenticity.status = 'signed_unknown';
+        result.authenticity.message = `Valid signature but key is not in trusted list`;
       }
-    } catch (err) {
+    } else if (sigResult.error) {
       result.authenticity.status = 'error';
-      result.authenticity.message = `Verification error: ${(err as Error).message}`;
-      result.errors.push(`Signature verification error: ${(err as Error).message}`);
+      result.authenticity.message = `Verification error: ${sigResult.error}`;
+      result.errors.push(`Signature verification error: ${sigResult.error}`);
+    } else {
+      result.authenticity.status = 'invalid';
+      result.authenticity.message = 'SIGNATURE VERIFICATION FAILED';
+      result.errors.push('Signature verification FAILED - do not execute!');
+      result.recommendation = 'BLOCK';
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #83

- Introduces `VerifyResult` type (`{ valid: boolean; error?: string }`) to differentiate genuine verification failures from transient errors (network outage, access denied, etc.)
- Updates `Verifier` interface, `Ed25519Verifier`, `KmsVerifier`, `verifyWithEd25519`, `verifyWithKms`, and `verifySignature` to return `VerifyResult`
- Updates consumers (`cli/bin/dossier-verify`, `tools/verify-dossier.ts`) to surface error vs invalid distinction
- Adds stderr logging to CLI empty `catch {}` blocks (temp file cleanup, directory reads, metadata parsing, trusted keys parsing)
- Updates tests to match new return types

## Impact

A KMS network outage during verification now returns `{ valid: false, error: "KMS unavailable" }` instead of just `{ valid: false }`, so consumers can distinguish "signature is forged" from "we couldn't reach KMS."

## Test plan

- [x] Core tests pass (111/111)
- [x] dossier-verify CLI tests pass (28/28)
- [x] MCP server tests pass (74/74)
- [x] Pre-existing CLI test failures unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)