### PR TITLE
refactor(mcp): extract shared path validation utility

### DIFF
--- a/mcp-server/src/tools/listDossiers.ts
+++ b/mcp-server/src/tools/listDossiers.ts
@@ -3,9 +3,9 @@
  * Thin wrapper around `ai-dossier list --format json [path]`
  */
 
-import { resolve } from 'node:path';
 import { CliNotFoundError, execCli } from '../utils/cli-wrapper';
 import { logger } from '../utils/logger';
+import { validatePathWithinCwd } from '../utils/paths';
 
 export interface ListDossiersInput {
   path?: string;
@@ -36,12 +36,7 @@ export async function listDossiers(input: ListDossiersInput): Promise<ListDossie
   const searchPath = input.path || process.cwd();
   const recursive = input.recursive !== false;
 
-  // Validate path stays within the current working directory
-  const resolvedPath = resolve(searchPath);
-  const cwd = process.cwd();
-  if (!resolvedPath.startsWith(`${cwd}/`) && resolvedPath !== cwd) {
-    throw new Error(`Access denied: path "${searchPath}" is outside the working directory`);
-  }
+  const resolvedPath = validatePathWithinCwd(searchPath);
 
   logger.info('Scanning for dossiers via CLI', { searchPath, recursive });
 

--- a/mcp-server/src/tools/readDossier.ts
+++ b/mcp-server/src/tools/readDossier.ts
@@ -4,10 +4,10 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { parseDossierContent } from '@ai-dossier/core';
 import { CliNotFoundError, execCli } from '../utils/cli-wrapper';
 import { logger } from '../utils/logger';
+import { validatePathWithinCwd } from '../utils/paths';
 
 export interface ReadDossierInput {
   path: string;
@@ -24,12 +24,7 @@ export interface ReadDossierOutput {
 export async function readDossier(input: ReadDossierInput): Promise<ReadDossierOutput> {
   const { path: dossierPath } = input;
 
-  // Validate path stays within the current working directory
-  const resolvedPath = resolve(dossierPath);
-  const cwd = process.cwd();
-  if (!resolvedPath.startsWith(`${cwd}/`) && resolvedPath !== cwd) {
-    throw new Error(`Access denied: path "${dossierPath}" is outside the working directory`);
-  }
+  const resolvedPath = validatePathWithinCwd(dossierPath);
 
   logger.info('Reading dossier via CLI', { dossierFile: dossierPath });
 

--- a/mcp-server/src/utils/__tests__/paths.test.ts
+++ b/mcp-server/src/utils/__tests__/paths.test.ts
@@ -1,0 +1,28 @@
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { validatePathWithinCwd } from '../paths';
+
+describe('validatePathWithinCwd', () => {
+  it('should return resolved path for paths within cwd', () => {
+    const result = validatePathWithinCwd('.');
+    expect(result).toBe(process.cwd());
+  });
+
+  it('should return resolved path for subdirectories', () => {
+    const result = validatePathWithinCwd('src');
+    expect(result).toBe(resolve('src'));
+  });
+
+  it('should reject paths outside cwd', () => {
+    expect(() => validatePathWithinCwd('/etc/passwd')).toThrow('Access denied');
+  });
+
+  it('should reject parent directory traversal', () => {
+    expect(() => validatePathWithinCwd('../../etc/passwd')).toThrow('Access denied');
+  });
+
+  it('should allow cwd itself', () => {
+    const result = validatePathWithinCwd(process.cwd());
+    expect(result).toBe(process.cwd());
+  });
+});

--- a/mcp-server/src/utils/paths.ts
+++ b/mcp-server/src/utils/paths.ts
@@ -1,0 +1,16 @@
+import { resolve } from 'node:path';
+
+/**
+ * Validate that a path stays within the current working directory.
+ * Throws if the resolved path is outside cwd.
+ *
+ * @returns The resolved absolute path
+ */
+export function validatePathWithinCwd(inputPath: string): string {
+  const resolvedPath = resolve(inputPath);
+  const cwd = process.cwd();
+  if (!resolvedPath.startsWith(`${cwd}/`) && resolvedPath !== cwd) {
+    throw new Error(`Access denied: path "${inputPath}" is outside the working directory`);
+  }
+  return resolvedPath;
+}


### PR DESCRIPTION
## Summary
- Extract duplicated path-within-cwd validation from `readDossier` and `listDossiers` into a shared `validatePathWithinCwd()` utility in `mcp-server/src/utils/paths.ts`
- Add 5 tests covering: cwd itself, subdirectories, absolute outside paths, parent traversal
- Both tools now import the shared utility instead of inline validation

Closes #66

## Test plan
- [x] `mcp-server` path validation tests: 5 pass
- [x] `listDossiers` tests: 7 pass (path rejection still works)
- [x] `readDossier` tests: 4 pass (path rejection still works)
- [x] `verifyDossier` tests: 4 pass (unaffected)

Co-Authored-By: Claude <noreply@anthropic.com>