### PR TITLE
fix(cli): detect non-TTY stdin and fail gracefully instead of hanging

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -42,6 +42,32 @@ chmod +x bin/dossier-verify
 
 ---
 
+## Authentication
+
+### Interactive (Browser OAuth)
+
+```bash
+dossier login
+```
+
+### Non-Interactive (CI/CD, Agents)
+
+Set the `DOSSIER_REGISTRY_TOKEN` environment variable:
+
+```bash
+export DOSSIER_REGISTRY_TOKEN=<your-token>
+
+# Optional: set user/org context
+export DOSSIER_REGISTRY_USER=<username>
+export DOSSIER_REGISTRY_ORGS=org1,org2
+```
+
+When `DOSSIER_REGISTRY_TOKEN` is set, it takes precedence over stored credentials. This is recommended for CI/CD pipelines, Docker containers, and AI agent contexts where interactive login is not possible.
+
+Commands that require confirmation (`publish`, `remove`, `cache clean`) will fail with a clear error in non-interactive sessions. Use `-y`/`--yes` to skip confirmation prompts.
+
+---
+
 ## Usage
 
 ### Basic Verification

--- a/cli/src/__tests__/commands/publish.test.ts
+++ b/cli/src/__tests__/commands/publish.test.ts
@@ -101,6 +101,25 @@ describe('publish command', () => {
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Validation errors'));
   });
 
+  it('should exit 1 in non-TTY without --yes', async () => {
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+
+    const program = createTestProgram();
+    registerPublishCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'dossier', 'publish', 'test.ds.md'])
+    ).rejects.toThrow();
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Non-interactive session'));
+
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: originalIsTTY,
+      configurable: true,
+    });
+  });
+
   it('should publish with --yes flag and show full registry path', async () => {
     mockClient.publishDossier.mockResolvedValue({
       name: 'org/test-dossier',

--- a/cli/src/__tests__/commands/remove.test.ts
+++ b/cli/src/__tests__/commands/remove.test.ts
@@ -51,6 +51,23 @@ describe('remove command', () => {
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('expired'));
   });
 
+  it('should exit 1 in non-TTY without --yes', async () => {
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+
+    const program = createTestProgram();
+    registerRemoveCommand(program);
+
+    await expect(program.parseAsync(['node', 'dossier', 'remove', 'my-dossier'])).rejects.toThrow();
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Non-interactive session'));
+
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: originalIsTTY,
+      configurable: true,
+    });
+  });
+
   it('should remove with --yes flag and show CDN warning', async () => {
     mockClient.removeDossier.mockResolvedValue({});
 

--- a/cli/src/__tests__/credentials.test.ts
+++ b/cli/src/__tests__/credentials.test.ts
@@ -118,6 +118,62 @@ describe('credentials', () => {
       expect(creds?.orgs).toEqual([]);
     });
 
+    it('should return credentials from DOSSIER_REGISTRY_TOKEN env var', () => {
+      const saved = {
+        token: process.env.DOSSIER_REGISTRY_TOKEN,
+        user: process.env.DOSSIER_REGISTRY_USER,
+        orgs: process.env.DOSSIER_REGISTRY_ORGS,
+      };
+
+      process.env.DOSSIER_REGISTRY_TOKEN = 'env-token';
+      process.env.DOSSIER_REGISTRY_USER = 'env-user';
+      process.env.DOSSIER_REGISTRY_ORGS = 'org1,org2';
+
+      try {
+        const creds = loadCredentials();
+        expect(creds).toEqual({
+          token: 'env-token',
+          username: 'env-user',
+          orgs: ['org1', 'org2'],
+          expiresAt: null,
+        });
+        // Env var should take precedence — file should not be read
+        expect(mockedFs.readFileSync).not.toHaveBeenCalled();
+      } finally {
+        if (saved.token === undefined) delete process.env.DOSSIER_REGISTRY_TOKEN;
+        else process.env.DOSSIER_REGISTRY_TOKEN = saved.token;
+        if (saved.user === undefined) delete process.env.DOSSIER_REGISTRY_USER;
+        else process.env.DOSSIER_REGISTRY_USER = saved.user;
+        if (saved.orgs === undefined) delete process.env.DOSSIER_REGISTRY_ORGS;
+        else process.env.DOSSIER_REGISTRY_ORGS = saved.orgs;
+      }
+    });
+
+    it('should use default username when only DOSSIER_REGISTRY_TOKEN is set', () => {
+      const saved = {
+        token: process.env.DOSSIER_REGISTRY_TOKEN,
+        user: process.env.DOSSIER_REGISTRY_USER,
+        orgs: process.env.DOSSIER_REGISTRY_ORGS,
+      };
+
+      process.env.DOSSIER_REGISTRY_TOKEN = 'env-token';
+      delete process.env.DOSSIER_REGISTRY_USER;
+      delete process.env.DOSSIER_REGISTRY_ORGS;
+
+      try {
+        const creds = loadCredentials();
+        expect(creds?.username).toBe('token-auth');
+        expect(creds?.orgs).toEqual([]);
+      } finally {
+        if (saved.token === undefined) delete process.env.DOSSIER_REGISTRY_TOKEN;
+        else process.env.DOSSIER_REGISTRY_TOKEN = saved.token;
+        if (saved.user === undefined) delete process.env.DOSSIER_REGISTRY_USER;
+        else process.env.DOSSIER_REGISTRY_USER = saved.user;
+        if (saved.orgs === undefined) delete process.env.DOSSIER_REGISTRY_ORGS;
+        else process.env.DOSSIER_REGISTRY_ORGS = saved.orgs;
+      }
+    });
+
     it('should warn and fix insecure permissions', () => {
       mockedFs.statSync.mockReturnValue({ mode: 0o100644 } as any);
       mockedFs.readFileSync.mockReturnValue(

--- a/cli/src/commands/cache.ts
+++ b/cli/src/commands/cache.ts
@@ -121,6 +121,12 @@ export function registerCacheCommand(program: Command): void {
 
       async function confirm(msg: string): Promise<boolean> {
         if (options.yes) return true;
+        if (!process.stdin.isTTY) {
+          console.error(
+            '\n❌ Non-interactive session detected. Use -y/--yes to skip confirmation.\n'
+          );
+          process.exit(1);
+        }
         const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
         const answer = await new Promise<string>((resolve) => {
           rl.question(`${msg} (y/N) `, resolve);

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -8,6 +8,13 @@ export function registerLoginCommand(program: Command): void {
     .command('login')
     .description('Authenticate with the dossier registry via GitHub')
     .action(async () => {
+      if (!process.stdin.isTTY) {
+        console.error('\n❌ Non-interactive session detected. Cannot run OAuth flow.');
+        console.error('   Set the DOSSIER_REGISTRY_TOKEN environment variable instead:\n');
+        console.error('   export DOSSIER_REGISTRY_TOKEN=<your-token>\n');
+        process.exit(1);
+      }
+
       try {
         const registryUrl = getRegistryUrl();
         const result = await runOAuthFlow(registryUrl);

--- a/cli/src/commands/publish.ts
+++ b/cli/src/commands/publish.ts
@@ -129,6 +129,13 @@ export function registerPublishCommand(program: Command): void {
         }
 
         if (!options.yes) {
+          if (!process.stdin.isTTY) {
+            console.error(
+              '\n❌ Non-interactive session detected. Use -y/--yes to skip confirmation.\n'
+            );
+            process.exit(1);
+          }
+
           console.log('\n📦 Publishing dossier:\n');
           console.log(`   Registry:  ${registryPath}`);
           console.log(`   File:      ${path.basename(dossierFile)}`);

--- a/cli/src/commands/remove.ts
+++ b/cli/src/commands/remove.ts
@@ -25,6 +25,13 @@ export function registerRemoveCommand(program: Command): void {
       const target = version ? `${dossierName}@${version}` : dossierName;
 
       if (!options.yes) {
+        if (!process.stdin.isTTY) {
+          console.error(
+            '\n❌ Non-interactive session detected. Use -y/--yes to skip confirmation.\n'
+          );
+          process.exit(1);
+        }
+
         const msg = version
           ? `Are you sure you want to remove version '${version}' of '${dossierName}'?`
           : `Are you sure you want to remove '${dossierName}' and ALL its versions?`;

--- a/cli/src/credentials.ts
+++ b/cli/src/credentials.ts
@@ -40,9 +40,20 @@ function saveCredentials(credentials: Credentials): void {
 }
 
 /**
- * Load credentials from file.
+ * Load credentials from file or DOSSIER_REGISTRY_TOKEN env var.
+ * The env var takes precedence when set.
  */
 function loadCredentials(): Credentials | null {
+  const envToken = process.env.DOSSIER_REGISTRY_TOKEN;
+  if (envToken) {
+    return {
+      token: envToken,
+      username: process.env.DOSSIER_REGISTRY_USER || 'token-auth',
+      orgs: process.env.DOSSIER_REGISTRY_ORGS ? process.env.DOSSIER_REGISTRY_ORGS.split(',') : [],
+      expiresAt: null,
+    };
+  }
+
   if (!fs.existsSync(CREDENTIALS_FILE)) {
     return null;
   }


### PR DESCRIPTION
## Summary

- **publish, remove, cache clean**: Exit with clear error when stdin is not a TTY and `--yes` is not provided, preventing indefinite hangs in agent/CI contexts
- **login**: Detect non-interactive session and suggest `DOSSIER_REGISTRY_TOKEN` env var
- **credentials**: Support `DOSSIER_REGISTRY_TOKEN` env var (with optional `DOSSIER_REGISTRY_USER`, `DOSSIER_REGISTRY_ORGS`) for non-interactive auth — takes precedence over stored credentials
- **README**: Document token-based authentication for CI/CD and agents

Closes #107

## Test plan

- [x] publish exits with "Non-interactive session" error in non-TTY without `--yes` (new test)
- [x] remove exits with "Non-interactive session" error in non-TTY without `--yes` (new test)
- [x] `DOSSIER_REGISTRY_TOKEN` env var returns valid credentials (new test)
- [x] Default username `token-auth` when only token env var is set (new test)
- [x] All 42 affected tests pass (publish: 14, remove: 9, credentials: 19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)