### PR TITLE
feat(cli): add --agent flag for agent discovery

### DIFF
--- a/cli/src/__tests__/agent-flag.test.ts
+++ b/cli/src/__tests__/agent-flag.test.ts
@@ -1,0 +1,38 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const cliPath = path.resolve(__dirname, '../../src/cli.ts');
+
+function runCli(args: string[]): string {
+  return execFileSync('npx', ['ts-node', cliPath, ...args], {
+    encoding: 'utf-8',
+    timeout: 15000,
+  }).trim();
+}
+
+describe('--agent flag', () => {
+  it('should output valid JSON capability manifest', () => {
+    const output = runCli(['--agent']);
+    const manifest = JSON.parse(output);
+
+    expect(manifest.agent_protocol).toBe('1.0');
+    expect(manifest.cli).toBe('ai-dossier');
+    expect(manifest.version).toMatch(/^\d+\.\d+\.\d+/);
+    expect(manifest.discovery_command).toBe('ai-dossier commands');
+    expect(manifest.capabilities).toEqual({
+      json_output: '--json',
+      skip_prompts: '-y / --yes',
+      non_tty_safe: true,
+      machine_errors: true,
+    });
+    expect(manifest.quick_start).toBeInstanceOf(Array);
+    expect(manifest.quick_start.length).toBeGreaterThan(0);
+  });
+
+  it('should include agent hint in --help output', () => {
+    const output = runCli(['--help']);
+    expect(output).toContain('ai-dossier --agent');
+    expect(output).toContain('Agent-friendly');
+  });
+});

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -42,7 +42,12 @@ import { registerWhoamiCommand } from './commands/whoami';
 program
   .name('ai-dossier')
   .description('CLI tool for creating, verifying, and executing dossiers')
-  .version(pkg.version);
+  .version(pkg.version)
+  .option('--agent', 'Output machine-readable capability manifest for agent discovery')
+  .addHelpText(
+    'after',
+    '\nAgent-friendly: Run `ai-dossier --agent` for machine-readable capabilities.'
+  );
 
 // Register all commands
 registerVerifyCommand(program);
@@ -73,6 +78,30 @@ registerFormatCommand(program);
 registerFromFileCommand(program);
 registerGetCommand(program);
 registerCommandsCommand(program);
+
+// Handle --agent flag before normal parsing
+if (process.argv.includes('--agent')) {
+  const manifest = {
+    agent_protocol: '1.0',
+    cli: 'ai-dossier',
+    version: pkg.version,
+    discovery_command: 'ai-dossier commands',
+    capabilities: {
+      json_output: '--json',
+      skip_prompts: '-y / --yes',
+      non_tty_safe: true,
+      machine_errors: true,
+    },
+    quick_start: [
+      'ai-dossier commands                    # discover all commands and flags',
+      'ai-dossier whoami --json               # check auth status',
+      'ai-dossier search <query> --json       # find dossiers',
+      'ai-dossier list --json --source registry  # list all registry dossiers',
+    ],
+  };
+  console.log(JSON.stringify(manifest, null, 2));
+  process.exit(0);
+}
 
 // Parse and execute
 program.parse(process.argv);


### PR DESCRIPTION
## Summary

- Adds `--agent` flag that outputs a JSON capability manifest (protocol version, CLI version, capabilities, quick_start examples)
- Adds agent-friendly hint at the bottom of `--help` output
- Adds integration tests for both behaviors

Closes #131

## Test plan

- [x] `ai-dossier --agent` outputs valid JSON with all required fields
- [x] `ai-dossier --help` includes the agent-friendly hint line
- [x] Existing tests unaffected (pre-existing failures unchanged)
- [x] Biome lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)