### PR TITLE
feat(mcp-server): cross-dossier output mapping (inputs.from_dossiers)

### DIFF
--- a/mcp-server/src/orchestration/__tests__/outputMapper.test.ts
+++ b/mcp-server/src/orchestration/__tests__/outputMapper.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { FromDossierInput, OutputConfiguration } from '../outputMapper';
+import { OutputMapper } from '../outputMapper';
+
+describe('OutputMapper', () => {
+  let mapper: OutputMapper;
+
+  beforeEach(() => {
+    mapper = new OutputMapper();
+  });
+
+  describe('collectOutput / getOutputs', () => {
+    it('should store and retrieve a collected output', () => {
+      mapper.collectOutput('setup-infra', 'cluster_arn', 'arn:aws:ecs:us-east-1:123:cluster/prod');
+
+      const outputs = mapper.getOutputs('setup-infra');
+      expect(outputs).toHaveLength(1);
+      expect(outputs[0]).toEqual({
+        key: 'cluster_arn',
+        value: 'arn:aws:ecs:us-east-1:123:cluster/prod',
+        export_as: undefined,
+      });
+    });
+
+    it('should store export_as metadata alongside the value', () => {
+      mapper.collectOutput('setup-infra', 'cluster_arn', 'arn:aws:ecs:...', 'env_var');
+
+      const outputs = mapper.getOutputs('setup-infra');
+      expect(outputs[0].export_as).toBe('env_var');
+    });
+
+    it('should store multiple outputs for the same dossier', () => {
+      mapper.collectOutput('setup-infra', 'cluster_arn', 'arn:...');
+      mapper.collectOutput('setup-infra', 'region', 'us-east-1');
+
+      expect(mapper.getOutputs('setup-infra')).toHaveLength(2);
+    });
+
+    it('should overwrite an output with the same key', () => {
+      mapper.collectOutput('setup-infra', 'cluster_arn', 'old-value');
+      mapper.collectOutput('setup-infra', 'cluster_arn', 'new-value');
+
+      const outputs = mapper.getOutputs('setup-infra');
+      expect(outputs).toHaveLength(1);
+      expect(outputs[0].value).toBe('new-value');
+    });
+
+    it('should return an empty array for unknown dossiers', () => {
+      expect(mapper.getOutputs('nonexistent')).toEqual([]);
+    });
+  });
+
+  describe('resolveInputs', () => {
+    beforeEach(() => {
+      mapper.collectOutput(
+        'setup-infra',
+        'cluster_arn',
+        'arn:aws:ecs:us-east-1:123:cluster/prod',
+        'env_var'
+      );
+      mapper.collectOutput('setup-infra', 'region', 'us-east-1');
+      mapper.collectOutput('build-image', 'image_uri', 'ecr.amazonaws.com/app:latest');
+    });
+
+    it('should resolve inputs that have matching collected outputs', () => {
+      const fromDossiers: FromDossierInput[] = [
+        { source_dossier: 'setup-infra', output_name: 'cluster_arn', usage: 'Target ECS cluster' },
+      ];
+
+      const resolved = mapper.resolveInputs(fromDossiers);
+
+      expect(resolved).toHaveLength(1);
+      expect(resolved[0]).toEqual({
+        source_dossier: 'setup-infra',
+        output_name: 'cluster_arn',
+        value: 'arn:aws:ecs:us-east-1:123:cluster/prod',
+        export_as: 'env_var',
+        usage: 'Target ECS cluster',
+      });
+    });
+
+    it('should resolve inputs from multiple source dossiers', () => {
+      const fromDossiers: FromDossierInput[] = [
+        { source_dossier: 'setup-infra', output_name: 'cluster_arn' },
+        { source_dossier: 'build-image', output_name: 'image_uri' },
+      ];
+
+      const resolved = mapper.resolveInputs(fromDossiers);
+
+      expect(resolved).toHaveLength(2);
+      expect(resolved.map((r) => r.output_name)).toEqual(['cluster_arn', 'image_uri']);
+    });
+
+    it('should skip inputs whose source dossier has not reported outputs', () => {
+      const fromDossiers: FromDossierInput[] = [
+        { source_dossier: 'not-yet-run', output_name: 'some_value' },
+      ];
+
+      const resolved = mapper.resolveInputs(fromDossiers);
+      expect(resolved).toHaveLength(0);
+    });
+
+    it('should skip inputs whose output key does not exist in the source', () => {
+      const fromDossiers: FromDossierInput[] = [
+        { source_dossier: 'setup-infra', output_name: 'nonexistent_key' },
+      ];
+
+      const resolved = mapper.resolveInputs(fromDossiers);
+      expect(resolved).toHaveLength(0);
+    });
+
+    it('should return an empty array for an empty from_dossiers list', () => {
+      expect(mapper.resolveInputs([])).toEqual([]);
+    });
+  });
+
+  describe('generateContextString', () => {
+    beforeEach(() => {
+      mapper.collectOutput(
+        'setup-infra',
+        'cluster_arn',
+        'arn:aws:ecs:us-east-1:123:cluster/prod',
+        'env_var'
+      );
+      mapper.collectOutput('build-image', 'image_uri', 'ecr.amazonaws.com/app:latest');
+    });
+
+    it('should generate a context string for resolved inputs', () => {
+      const fromDossiers: FromDossierInput[] = [
+        { source_dossier: 'setup-infra', output_name: 'cluster_arn', usage: 'Target ECS cluster' },
+      ];
+
+      const context = mapper.generateContextString(fromDossiers);
+
+      expect(context).not.toBeNull();
+      expect(context).toContain('The following values are available from previous steps:');
+      expect(context).toContain('cluster_arn = arn:aws:ecs:us-east-1:123:cluster/prod');
+      expect(context).toContain('[env_var]');
+      expect(context).toContain('from setup-infra');
+      expect(context).toContain('Target ECS cluster');
+    });
+
+    it('should include multiple resolved inputs in the context string', () => {
+      const fromDossiers: FromDossierInput[] = [
+        { source_dossier: 'setup-infra', output_name: 'cluster_arn' },
+        { source_dossier: 'build-image', output_name: 'image_uri' },
+      ];
+
+      const context = mapper.generateContextString(fromDossiers);
+
+      expect(context).toContain('cluster_arn');
+      expect(context).toContain('image_uri');
+    });
+
+    it('should omit export_as tag when not set', () => {
+      const fromDossiers: FromDossierInput[] = [
+        { source_dossier: 'build-image', output_name: 'image_uri' },
+      ];
+
+      const context = mapper.generateContextString(fromDossiers);
+
+      expect(context).not.toContain('[');
+    });
+
+    it('should return null when no inputs can be resolved', () => {
+      const fromDossiers: FromDossierInput[] = [
+        { source_dossier: 'not-yet-run', output_name: 'some_value' },
+      ];
+
+      expect(mapper.generateContextString(fromDossiers)).toBeNull();
+    });
+
+    it('should return null for an empty from_dossiers list', () => {
+      expect(mapper.generateContextString([])).toBeNull();
+    });
+  });
+
+  describe('validateInputs', () => {
+    const sourceOutputs: Map<string, OutputConfiguration[]> = new Map([
+      [
+        'setup-infra',
+        [
+          { key: 'cluster_arn', description: 'ECS cluster ARN', export_as: 'env_var' },
+          { key: 'region', description: 'AWS region' },
+        ],
+      ],
+    ]);
+
+    it('should return no warnings when all inputs are satisfied', () => {
+      const fromDossiers: FromDossierInput[] = [
+        { source_dossier: 'setup-infra', output_name: 'cluster_arn' },
+        { source_dossier: 'setup-infra', output_name: 'region' },
+      ];
+
+      const warnings = mapper.validateInputs('deploy-app', fromDossiers, sourceOutputs);
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('should warn when the source dossier is not in the execution graph', () => {
+      const fromDossiers: FromDossierInput[] = [
+        { source_dossier: 'not-in-graph', output_name: 'some_value' },
+      ];
+
+      const warnings = mapper.validateInputs('deploy-app', fromDossiers, sourceOutputs);
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].source_dossier).toBe('not-in-graph');
+      expect(warnings[0].dossier).toBe('deploy-app');
+      expect(warnings[0].message).toContain('not in the execution graph');
+    });
+
+    it('should warn when the source dossier does not declare the required output', () => {
+      const fromDossiers: FromDossierInput[] = [
+        { source_dossier: 'setup-infra', output_name: 'undeclared_output' },
+      ];
+
+      const warnings = mapper.validateInputs('deploy-app', fromDossiers, sourceOutputs);
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].output_name).toBe('undeclared_output');
+      expect(warnings[0].message).toContain('does not declare an output named "undeclared_output"');
+    });
+
+    it('should return multiple warnings for multiple missing inputs', () => {
+      const fromDossiers: FromDossierInput[] = [
+        { source_dossier: 'not-in-graph', output_name: 'foo' },
+        { source_dossier: 'setup-infra', output_name: 'missing_key' },
+      ];
+
+      const warnings = mapper.validateInputs('deploy-app', fromDossiers, sourceOutputs);
+      expect(warnings).toHaveLength(2);
+    });
+
+    it('should return no warnings for an empty from_dossiers list', () => {
+      expect(mapper.validateInputs('deploy-app', [], sourceOutputs)).toHaveLength(0);
+    });
+  });
+
+  describe('clear', () => {
+    it('should remove all stored outputs', () => {
+      mapper.collectOutput('setup-infra', 'cluster_arn', 'some-arn');
+      mapper.collectOutput('build-image', 'image_uri', 'some-uri');
+
+      mapper.clear();
+
+      expect(mapper.getOutputs('setup-infra')).toHaveLength(0);
+      expect(mapper.getOutputs('build-image')).toHaveLength(0);
+    });
+  });
+});

--- a/mcp-server/src/orchestration/outputMapper.ts
+++ b/mcp-server/src/orchestration/outputMapper.ts
@@ -1,0 +1,183 @@
+/**
+ * Cross-dossier output mapper.
+ * Connects dossier outputs to downstream dossier inputs, enabling automatic
+ * data flow between steps in a journey.
+ *
+ * Schema fields consumed:
+ *   inputs.from_dossiers  — declares what this dossier expects from prior steps
+ *   outputs.configuration — declares what this dossier produces for later steps
+ */
+
+// --- Types matching dossier schema ---
+
+export interface FromDossierInput {
+  source_dossier: string;
+  output_name: string;
+  usage?: string;
+}
+
+export interface OutputConfiguration {
+  key: string;
+  description: string;
+  consumed_by?: string[];
+  export_as?: string;
+}
+
+// --- Internal / result types ---
+
+export interface CollectedOutput {
+  key: string;
+  value: string;
+  export_as?: string;
+}
+
+export interface ResolvedInput {
+  source_dossier: string;
+  output_name: string;
+  value: string;
+  export_as?: string;
+  usage?: string;
+}
+
+export interface MappingValidationWarning {
+  dossier: string;
+  source_dossier: string;
+  output_name: string;
+  message: string;
+}
+
+// --- OutputMapper class ---
+
+/**
+ * Stores outputs collected from completed dossier steps and resolves them
+ * into the inputs of subsequent steps.
+ *
+ * Lifecycle per journey session:
+ *   1. Call collectOutput() each time a step reports an output value.
+ *   2. Call resolveInputs() / generateContextString() to inject values into
+ *      the next step's dossier prompt.
+ *   3. Call validateInputs() at graph-resolution time to surface missing outputs
+ *      before execution begins.
+ *   4. Call clear() to reset between journey sessions.
+ */
+export class OutputMapper {
+  /** dossier name → (output key → collected output) */
+  private readonly store = new Map<string, Map<string, CollectedOutput>>();
+
+  /**
+   * Store an output value reported by a completed dossier step.
+   * Called when the LLM invokes the step_complete tool.
+   */
+  collectOutput(dossier: string, key: string, value: string, export_as?: string): void {
+    if (!this.store.has(dossier)) {
+      this.store.set(dossier, new Map());
+    }
+    this.store.get(dossier)?.set(key, { key, value, export_as });
+  }
+
+  /**
+   * Return all collected outputs for a specific dossier.
+   */
+  getOutputs(dossier: string): CollectedOutput[] {
+    const map = this.store.get(dossier);
+    return map ? [...map.values()] : [];
+  }
+
+  /**
+   * Resolve a dossier's from_dossiers inputs against previously collected
+   * outputs. Inputs whose source value has not yet been collected are silently
+   * skipped (the caller decides whether that is an error).
+   */
+  resolveInputs(fromDossiers: FromDossierInput[]): ResolvedInput[] {
+    const resolved: ResolvedInput[] = [];
+
+    for (const input of fromDossiers) {
+      const output = this.store.get(input.source_dossier)?.get(input.output_name);
+      if (output === undefined) continue;
+
+      resolved.push({
+        source_dossier: input.source_dossier,
+        output_name: input.output_name,
+        value: output.value,
+        export_as: output.export_as,
+        usage: input.usage,
+      });
+    }
+
+    return resolved;
+  }
+
+  /**
+   * Generate an LLM-readable context string listing all resolved input values.
+   * Returns null when no inputs could be resolved (e.g. first step in a journey).
+   *
+   * Example output:
+   *   The following values are available from previous steps:
+   *   - `cluster_arn = arn:aws:ecs:us-east-1:123:cluster/prod` [env_var] (from setup-infra) — Target ECS cluster
+   */
+  generateContextString(fromDossiers: FromDossierInput[]): string | null {
+    const resolved = this.resolveInputs(fromDossiers);
+    if (resolved.length === 0) return null;
+
+    const lines = ['The following values are available from previous steps:'];
+    for (const r of resolved) {
+      const exportTag = r.export_as ? ` [${r.export_as}]` : '';
+      const usageNote = r.usage ? ` — ${r.usage}` : '';
+      lines.push(
+        `- \`${r.output_name} = ${r.value}\`${exportTag} (from ${r.source_dossier})${usageNote}`
+      );
+    }
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Validate that a dossier's from_dossiers inputs have matching output
+   * declarations in their source dossiers. Run this at graph-resolution time,
+   * before any step executes.
+   *
+   * @param dossier        - name of the dossier being validated
+   * @param fromDossiers   - its inputs.from_dossiers declarations
+   * @param sourceOutputs  - map of dossier name → declared outputs.configuration
+   * @returns warnings for missing or mismatched declarations (empty = all good)
+   */
+  validateInputs(
+    dossier: string,
+    fromDossiers: FromDossierInput[],
+    sourceOutputs: Map<string, OutputConfiguration[]>
+  ): MappingValidationWarning[] {
+    const warnings: MappingValidationWarning[] = [];
+
+    for (const input of fromDossiers) {
+      const outputs = sourceOutputs.get(input.source_dossier);
+
+      if (!outputs) {
+        warnings.push({
+          dossier,
+          source_dossier: input.source_dossier,
+          output_name: input.output_name,
+          message: `Source dossier "${input.source_dossier}" is not in the execution graph or declares no outputs`,
+        });
+        continue;
+      }
+
+      if (!outputs.some((o) => o.key === input.output_name)) {
+        warnings.push({
+          dossier,
+          source_dossier: input.source_dossier,
+          output_name: input.output_name,
+          message: `Source dossier "${input.source_dossier}" does not declare an output named "${input.output_name}"`,
+        });
+      }
+    }
+
+    return warnings;
+  }
+
+  /**
+   * Clear all stored outputs. Call between journey sessions.
+   */
+  clear(): void {
+    this.store.clear();
+  }
+}


### PR DESCRIPTION
## Summary

- Implements `orchestration/outputMapper.ts` — connects dossier outputs to downstream dossier inputs, enabling automatic data flow between journey steps
- `OutputMapper` class stores outputs per session, resolves `inputs.from_dossiers` declarations, generates LLM-readable context injection, and validates mappings at graph-resolution time
- 21 unit tests covering all behaviours (collect/resolve/generate/validate/clear)

Closes #72

## Test plan

- [x] `npm test` in `mcp-server/` — 100 tests pass (21 new)
- [x] `tsc --noEmit` — no TypeScript errors
- [x] `biome check` — clean on new files

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>