### PR TITLE
feat(mcp): e2e journey tests, orchestration prompts & resources

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -1,0 +1,305 @@
+# Dossier Orchestration Reference
+
+**Version**: 1.0
+**Status**: Stable
+
+This document is a complete reference for the MCP orchestration tools that enable multi-dossier journey execution.
+
+---
+
+## Tool Reference
+
+### `resolve_graph`
+
+Resolves a dossier's dependency graph into an ordered execution plan. Reads `relationships` fields and builds a DAG with topological ordering.
+
+**Input:**
+```json
+{ "dossier": "path/to/entry.ds.md" }
+```
+or
+```json
+{ "dossier": "registry-org/registry-name" }
+```
+
+**Output (success):**
+```json
+{
+  "graph_id": "abc123",
+  "plan": {
+    "entryDossier": "setup-project",
+    "totalDossiers": 3,
+    "phases": [
+      {
+        "phase": 1,
+        "dossiers": [{ "name": "setup-project", "source": "local", "condition": "required" }]
+      },
+      {
+        "phase": 2,
+        "dossiers": [{ "name": "install-deps", "source": "local", "condition": "required" }]
+      }
+    ],
+    "conflicts": [],
+    "warnings": []
+  }
+}
+```
+
+**Output (error):**
+```json
+{
+  "error": {
+    "type": "cycle",
+    "message": "Dependency cycle detected: a -> b -> a",
+    "cycle": ["a", "b", "a"]
+  }
+}
+```
+
+Error types: `cycle` | `resolve` | `unknown`
+
+---
+
+### `verify_graph`
+
+Batch-verifies all dossiers in a resolved graph. Can also resolve + verify in one call.
+
+**Input (from stored graph):**
+```json
+{ "graph_id": "abc123" }
+```
+
+**Input (inline resolve + verify):**
+```json
+{ "dossier": "path/to/entry.ds.md" }
+```
+
+**Output:**
+```json
+{
+  "overall_recommendation": "ALLOW",
+  "summary": "3 dossiers verified: 3 passed, 0 blocked",
+  "dossiers": [
+    {
+      "name": "setup-project",
+      "passed": true,
+      "recommendation": "ALLOW",
+      "stages": [
+        { "stage": 1, "name": "Integrity Check", "passed": true },
+        { "stage": 2, "name": "Authenticity Check", "passed": true }
+      ]
+    }
+  ],
+  "blockers": []
+}
+```
+
+**Recommendations:** `ALLOW` | `WARN` | `BLOCK`
+- `ALLOW` — all verifications passed, low risk
+- `WARN` — unsigned dossiers or high-risk operations (user should review)
+- `BLOCK` — integrity failure, do not execute
+
+---
+
+### `start_journey`
+
+Creates a journey session and returns the first step's content.
+
+**Input:**
+```json
+{ "graph_id": "abc123" }
+```
+
+**Output:**
+```json
+{
+  "journey_id": "journey-uuid",
+  "total_steps": 3,
+  "step": {
+    "index": 0,
+    "dossier": "setup-project",
+    "body": "# Setup Project\n\n## Steps\n...",
+    "context": ""
+  }
+}
+```
+
+The `body` contains the dossier's instruction markdown. Execute these instructions, then call `step_complete`.
+
+---
+
+### `step_complete`
+
+Marks the current step as complete or failed, advances to the next step.
+
+**Input:**
+```json
+{
+  "journey_id": "journey-uuid",
+  "status": "completed",
+  "outputs": { "project_path": "/tmp/myapp" }
+}
+```
+
+**Output (more steps):**
+```json
+{
+  "status": "running",
+  "step": {
+    "index": 1,
+    "dossier": "install-deps",
+    "body": "# Install Dependencies\n...",
+    "context": "Available from previous steps: project_path=/tmp/myapp (from setup-project)"
+  }
+}
+```
+
+**Output (journey complete):**
+```json
+{
+  "status": "completed",
+  "summary": {
+    "journey_id": "journey-uuid",
+    "status": "completed",
+    "total_steps": 3,
+    "completed_steps": 3,
+    "failed_steps": 0,
+    "outputs": { "setup-project": { "project_path": "/tmp/myapp" } },
+    "started_at": "2026-01-01T00:00:00.000Z",
+    "completed_at": "2026-01-01T00:05:00.000Z"
+  }
+}
+```
+
+**Output (step failed):**
+```json
+{
+  "status": "failed",
+  "summary": { ... }
+}
+```
+
+**`status` values:** `completed` | `failed`
+
+---
+
+### `get_journey_status`
+
+Returns the current state of a journey without advancing it.
+
+**Input:**
+```json
+{ "journey_id": "journey-uuid" }
+```
+
+**Output:**
+```json
+{
+  "summary": {
+    "journey_id": "journey-uuid",
+    "status": "running",
+    "total_steps": 3,
+    "completed_steps": 1,
+    "failed_steps": 0,
+    "outputs": {}
+  },
+  "current_step": {
+    "index": 1,
+    "dossier": "install-deps",
+    "status": "running",
+    "context": "Available from previous steps: project_path=/tmp/myapp (from setup-project)"
+  },
+  "steps": [
+    { "index": 0, "dossier": "setup-project", "status": "completed" },
+    { "index": 1, "dossier": "install-deps", "status": "running" },
+    { "index": 2, "dossier": "run-tests", "status": "pending" }
+  ]
+}
+```
+
+---
+
+### `cancel_journey`
+
+Cancels an active journey and returns a summary of what completed.
+
+**Input:**
+```json
+{
+  "journey_id": "journey-uuid",
+  "reason": "User requested cancellation"
+}
+```
+
+**Output:**
+```json
+{
+  "summary": {
+    "journey_id": "journey-uuid",
+    "status": "cancelled",
+    "total_steps": 3,
+    "completed_steps": 1,
+    "failed_steps": 0,
+    "cancel_reason": "User requested cancellation"
+  }
+}
+```
+
+---
+
+## Example Interaction Sequences
+
+### Happy Path (3-step journey)
+
+```
+LLM: resolve_graph({ dossier: "examples/journey/setup-project.ds.md" })
+MCP: { graph_id: "g1", plan: { totalDossiers: 3, phases: [...] } }
+
+LLM: verify_graph({ graph_id: "g1" })
+MCP: { overall_recommendation: "ALLOW", ... }
+
+LLM: [shows user: "3-step journey, all ALLOW. Proceed?"]
+
+LLM: start_journey({ graph_id: "g1" })
+MCP: { journey_id: "j1", step: { index: 0, dossier: "setup-project", body: "..." } }
+
+LLM: [executes step 0 body]
+LLM: step_complete({ journey_id: "j1", status: "completed", outputs: { project_path: "/tmp/app" } })
+MCP: { status: "running", step: { index: 1, dossier: "install-deps", context: "project_path=/tmp/app..." } }
+
+LLM: [executes step 1 body using context]
+LLM: step_complete({ journey_id: "j1", status: "completed", outputs: { deps_installed: true } })
+MCP: { status: "running", step: { index: 2, dossier: "run-tests", context: "..." } }
+
+LLM: [executes step 2 body]
+LLM: step_complete({ journey_id: "j1", status: "completed" })
+MCP: { status: "completed", summary: { completed_steps: 3, failed_steps: 0 } }
+```
+
+### Mid-Journey Cancellation
+
+```
+LLM: start_journey({ graph_id: "g1" })
+MCP: { journey_id: "j1", step: { index: 0, ... } }
+
+LLM: step_complete({ journey_id: "j1", status: "completed" })
+MCP: { status: "running", step: { index: 1, ... } }
+
+LLM: [user asks to stop]
+LLM: cancel_journey({ journey_id: "j1", reason: "User cancelled" })
+MCP: { summary: { status: "cancelled", completed_steps: 1 } }
+```
+
+---
+
+## Error States and Recovery
+
+| Error | Cause | Recovery |
+|-------|-------|----------|
+| `resolve error: cycle detected` | Circular `preceded_by` chain | Fix the dossier relationships |
+| `verify_graph: BLOCK` | Checksum mismatch | Re-download or re-sign the dossier |
+| `verify_graph: WARN` | Unsigned dossiers | Review content manually, confirm with user |
+| `start_journey: not_found` | `graph_id` expired | Call `resolve_graph` again |
+| `step_complete: invalid_state` | Journey already finished | Use `get_journey_status` to check |
+| `step_complete: not_found` | Wrong `journey_id` | Use `get_journey_status` to confirm |
+| Step fails during execution | Runtime error in step | Call `step_complete` with `status: "failed"` |

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,0 +1,115 @@
+# Dossier Execution Protocol
+
+**Version**: 2.0
+**Status**: Stable
+
+---
+
+## Overview
+
+This protocol defines how to execute dossiers safely and effectively, including both single-dossier and multi-dossier journey execution.
+
+---
+
+## Single-Dossier Execution
+
+Use this flow when a dossier has **no `relationships` fields** (or only `suggested` relationships):
+
+1. **VERIFY** — Run `verify_dossier` to check integrity and signature
+   - If verification fails → STOP and report the issue
+   - If signature is untrusted → ask user whether to proceed
+
+2. **READ** — Use `read_dossier` to get the dossier content
+
+3. **EXECUTE** — Follow the dossier body instructions
+   - Respect `risk_level` warnings
+   - Ask for confirmation before destructive operations
+   - Report progress as you complete each step
+
+4. **REPORT** — Summarize what was accomplished
+
+---
+
+## Multi-Dossier Journey Execution
+
+Use this flow when a dossier has **`relationships.preceded_by` or `relationships.followed_by`** entries with `condition: "required"`.
+
+### Decision Tree
+
+```
+Does the dossier have relationships.preceded_by or followed_by (required)?
+├── YES → Use journey execution (resolve_graph → verify_graph → start_journey → step_complete)
+└── NO  → Use single-dossier execution (verify_dossier → read_dossier)
+```
+
+### Journey Flow
+
+```
+1. resolve_graph({ dossier: "path/to/entry.ds.md" })
+   → Returns: { graph_id, plan: { phases, totalDossiers, conflicts } }
+
+2. verify_graph({ graph_id })
+   → Returns: { overall_recommendation, dossiers: [...], blockers }
+   → If BLOCK → STOP, report integrity failure
+   → If WARN  → Present warning to user, ask to proceed
+   → If ALLOW → Continue
+
+3. [Present journey plan to user]:
+   "This will execute N steps: step1 → step2 → step3
+    Overall risk: [risk_level]. Proceed?"
+
+4. start_journey({ graph_id })
+   → Returns: { journey_id, step: { index, dossier, body, context }, total_steps }
+
+5. [Execute step body, collect outputs]
+   step_complete({ journey_id, status: "completed", outputs: { key: "value" } })
+   → If status: "running" → repeat step 5 with new step
+   → If status: "completed" → journey done, show summary
+   → If status: "failed"   → step failed, show summary
+
+6. [On failure]: Diagnose the issue and decide whether to retry or cancel
+   cancel_journey({ journey_id, reason: "..." })
+```
+
+### Output Mapping
+
+When `step_complete` advances to the next step, it injects a `context` string containing outputs from all previous steps:
+
+```
+Available from previous steps: project_path=/tmp/myapp (from setup-project), deps_installed=true (from install-deps)
+```
+
+Use these values when executing the current step. They represent outputs declared in each dossier's `outputs` section.
+
+### Checking Journey State
+
+Use `get_journey_status({ journey_id })` at any point to inspect:
+- `summary.status` — current journey status
+- `steps` — per-step status (pending/running/completed/failed)
+- `current_step` — index and dossier of the running step
+
+---
+
+## Risk Level Handling
+
+| Risk Level | Required Action |
+|------------|-----------------|
+| `low`      | Proceed directly |
+| `medium`   | Inform user, proceed |
+| `high`     | Explicit user confirmation required |
+| `critical` | Strong warning + explicit confirmation |
+
+For journeys, use the **aggregate risk** from `verify_graph` to determine the overall risk level before starting.
+
+---
+
+## Error Handling
+
+| Situation | Action |
+|-----------|--------|
+| `verify_dossier` fails | Stop, report checksum/signature failure |
+| `verify_graph` returns BLOCK | Stop, list blockers |
+| `verify_graph` returns WARN | Inform user, ask to proceed |
+| `step_complete` returns failed | Show summary, ask user to diagnose |
+| `resolve_graph` returns cycle error | Report the cycle path, ask user to fix |
+| Journey not found | Check journey_id is correct |

--- a/examples/journey/install-deps.ds.md
+++ b/examples/journey/install-deps.ds.md
@@ -1,0 +1,89 @@
+---dossier
+{
+  "dossier_schema_version": "1.0.0",
+  "name": "install-deps",
+  "title": "Install Dependencies",
+  "version": "1.0.0",
+  "status": "Stable",
+  "objective": "Install project dependencies into the project directory",
+  "category": [
+    "development"
+  ],
+  "tags": [
+    "setup",
+    "dependencies",
+    "example",
+    "journey"
+  ],
+  "risk_level": "low",
+  "risk_factors": [
+    "network_access",
+    "modifies_files"
+  ],
+  "requires_approval": false,
+  "relationships": {
+    "preceded_by": [
+      {
+        "dossier": "setup-project",
+        "condition": "required",
+        "reason": "Project directory must exist before installing dependencies"
+      }
+    ]
+  },
+  "inputs": {
+    "from_dossiers": [
+      {
+        "source_dossier": "setup-project",
+        "output_name": "project_path",
+        "usage": "Directory where dependencies will be installed"
+      }
+    ]
+  },
+  "outputs": {
+    "configuration": [
+      {
+        "name": "deps_installed",
+        "description": "Boolean indicating whether dependencies were successfully installed",
+        "consumed_by": [
+          "run-tests"
+        ]
+      }
+    ]
+  },
+  "checksum": {
+    "algorithm": "sha256",
+    "hash": "51ac61694bc91229f15d5d6923325e8186d28ba0b27c11d6e4b34c69f4cb8221"
+  }
+}
+---
+
+# Install Dependencies
+
+## Objective
+
+Install project dependencies into the project directory created by `setup-project`.
+
+## Inputs
+
+- `project_path` (from `setup-project`): The project directory to install dependencies into
+
+## Steps
+
+1. Navigate to the project directory:
+   ```bash
+   cd "$project_path"
+   ```
+
+2. Create a minimal `package.json` if not present and install dependencies:
+   ```bash
+   npm install --save-dev typescript 2>/dev/null || echo "npm not required for this example"
+   ```
+
+3. Confirm installation succeeded:
+   ```bash
+   echo "Dependencies installed in $project_path"
+   ```
+
+## Output
+
+- `deps_installed`: `true` if installation completed without errors

--- a/examples/journey/run-tests.ds.md
+++ b/examples/journey/run-tests.ds.md
@@ -1,0 +1,57 @@
+---dossier
+{
+  "dossier_schema_version": "1.0.0",
+  "name": "run-tests",
+  "title": "Run Tests",
+  "version": "1.0.0",
+  "status": "Stable",
+  "objective": "Run the project test suite and report results",
+  "category": [
+    "development"
+  ],
+  "tags": [
+    "testing",
+    "ci",
+    "example",
+    "journey"
+  ],
+  "risk_level": "low",
+  "risk_factors": [
+    "executes_external_code"
+  ],
+  "requires_approval": false,
+  "relationships": {
+    "preceded_by": [
+      {
+        "dossier": "install-deps",
+        "condition": "required",
+        "reason": "Dependencies must be installed before running tests"
+      }
+    ]
+  },
+  "checksum": {
+    "algorithm": "sha256",
+    "hash": "b003b51ca4cdfd728bf8e5c523f797d0de2a45cb12c917037bb7957b04acbc1b"
+  }
+}
+---
+
+# Run Tests
+
+## Objective
+
+Run the project test suite and verify all tests pass.
+
+## Steps
+
+1. Run the test suite:
+   ```bash
+   cd "$project_path"
+   npm test 2>/dev/null || echo "No test suite configured — example journey complete"
+   ```
+
+2. Report the test results to the user.
+
+## Notes
+
+This is the final step in the example journey. After completion, the journey will be marked as complete.

--- a/examples/journey/setup-project.ds.md
+++ b/examples/journey/setup-project.ds.md
@@ -1,0 +1,70 @@
+---dossier
+{
+  "dossier_schema_version": "1.0.0",
+  "name": "setup-project",
+  "title": "Setup Project",
+  "version": "1.0.0",
+  "status": "Stable",
+  "objective": "Initialize a new project directory with basic structure",
+  "category": [
+    "development"
+  ],
+  "tags": [
+    "setup",
+    "project",
+    "example",
+    "journey"
+  ],
+  "risk_level": "low",
+  "risk_factors": [
+    "modifies_files"
+  ],
+  "requires_approval": false,
+  "outputs": {
+    "configuration": [
+      {
+        "name": "project_path",
+        "description": "Absolute path to the created project directory",
+        "consumed_by": [
+          "install-deps"
+        ]
+      }
+    ]
+  },
+  "checksum": {
+    "algorithm": "sha256",
+    "hash": "65b4498bae9b227841796a1c72108215d08acc3970c3e2e9c7830d175bbabbf7"
+  }
+}
+---
+
+# Setup Project
+
+## Objective
+
+Initialize a new project directory with a basic file structure.
+
+## Steps
+
+1. Create a project directory under `/tmp/`:
+   ```bash
+   PROJECT_PATH="/tmp/example-project-$(date +%s)"
+   mkdir -p "$PROJECT_PATH"
+   ```
+
+2. Create a basic `package.json`:
+   ```bash
+   cat > "$PROJECT_PATH/package.json" <<'EOF'
+   {
+     "name": "example-project",
+     "version": "1.0.0",
+     "description": "Example project for journey testing"
+   }
+   EOF
+   ```
+
+3. Note the project path — it will be passed to the next step as `project_path`.
+
+## Output
+
+- `project_path`: the absolute path to the created directory (e.g., `/tmp/example-project-1234567890`)

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -17,6 +17,7 @@ import {
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { getConceptResource } from './resources/concept.js';
+import { getOrchestrationResource } from './resources/orchestration.js';
 import { getProtocolResource } from './resources/protocol.js';
 import { getSecurityResource } from './resources/security.js';
 import { type CancelJourneyInput, cancelJourney } from './tools/cancelJourney.js';
@@ -322,6 +323,13 @@ server.setRequestHandler(ListResourcesRequestSchema, async () => {
         description: 'Introduction to dossiers - what they are and why to use them',
         mimeType: 'text/markdown',
       },
+      {
+        uri: 'dossier://orchestration',
+        name: 'Orchestration Reference',
+        description:
+          'Complete reference for multi-dossier journey tools: resolve_graph, verify_graph, start_journey, step_complete, get_journey_status, cancel_journey',
+        mimeType: 'text/markdown',
+      },
     ],
   };
 });
@@ -346,6 +354,10 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
 
       case 'dossier://concept':
         content = getConceptResource();
+        break;
+
+      case 'dossier://orchestration':
+        content = getOrchestrationResource();
         break;
 
       default:
@@ -375,11 +387,24 @@ server.setRequestHandler(ListPromptsRequestSchema, async () => {
     prompts: [
       {
         name: 'execute-dossier',
-        description: 'Run a dossier with verification and protocol',
+        description:
+          'Run a dossier with verification and protocol. Automatically chooses single-dossier or multi-dossier journey flow based on relationships.',
         arguments: [
           {
             name: 'dossier_path',
             description: 'Path or URL to the dossier file',
+            required: true,
+          },
+        ],
+      },
+      {
+        name: 'execute-journey',
+        description:
+          'Guide the LLM through a multi-step dossier journey: resolve, verify, present plan, execute steps in order, collect outputs.',
+        arguments: [
+          {
+            name: 'graph_id',
+            description: 'ID of a previously resolved graph (from resolve_graph)',
             required: true,
           },
         ],
@@ -429,20 +454,93 @@ server.setRequestHandler(GetPromptRequestSchema, async (request) => {
               type: 'text',
               text: `Execute the dossier at: ${dossierPath}
 
-Follow the Dossier Execution Protocol:
+## Decision: Single or Multi-Dossier?
 
-1. **VERIFY** - Run \`dossier verify ${dossierPath}\` to check integrity and signature
-   - If verification fails, STOP and report the issue
-   - If signature is from untrusted source, ask user whether to proceed
+First, read the dossier metadata to check for relationships:
+- Use \`read_dossier({ path: "${dossierPath}" })\` and inspect the \`metadata.relationships\` field.
 
-2. **READ** - Use the read_dossier tool to get the dossier content
+**If the dossier has \`relationships.preceded_by\` or \`relationships.followed_by\` with \`condition: "required"\`:**
+→ Use the **journey flow** (multi-dossier):
+1. \`resolve_graph({ dossier: "${dossierPath}" })\` — build execution plan
+2. \`verify_graph({ graph_id })\` — batch-verify all dossiers
+   - BLOCK → STOP, report integrity failure
+   - WARN → inform user, ask to proceed
+3. Present the journey plan to the user: steps, risk, estimated duration
+4. \`start_journey({ graph_id })\` — begin execution, get first step
+5. Execute each step's body, then call \`step_complete({ journey_id, status: "completed", outputs: {...} })\`
+6. Repeat until journey status is "completed" or "failed"
+7. Report the journey summary
 
-3. **EXECUTE** - Follow the instructions in the dossier body
-   - Respect any risk_level warnings
+**Otherwise (no required relationships):**
+→ Use the **single-dossier flow**:
+1. \`verify_dossier({ path: "${dossierPath}" })\` — check integrity and signature
+   - If verification fails → STOP and report the issue
+   - If signature is untrusted → ask user whether to proceed
+2. \`read_dossier({ path: "${dossierPath}" })\` — get dossier content
+3. Execute the dossier body instructions
+   - Respect \`risk_level\` warnings
    - Ask for confirmation before destructive operations
    - Report progress as you complete each step
+4. Summarize what was accomplished`,
+            },
+          },
+        ],
+      };
+    }
 
-4. **REPORT** - Summarize what was accomplished`,
+    case 'execute-journey': {
+      const graphId = args?.graph_id as string;
+      if (!graphId) {
+        throw new Error('graph_id argument is required');
+      }
+      return {
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: `Execute the multi-dossier journey for graph: ${graphId}
+
+## Journey Execution Steps
+
+1. **Verify the graph** (if not already done):
+   \`verify_graph({ graph_id: "${graphId}" })\`
+   - BLOCK → STOP, list the blockers to the user
+   - WARN → inform the user of unsigned/high-risk dossiers, ask to proceed
+   - ALLOW → continue
+
+2. **Present the journey plan** to the user:
+   - List each step: "Step 1: setup-project → Step 2: install-deps → Step 3: run-tests"
+   - Show aggregate risk level
+   - Ask: "Ready to proceed?"
+
+3. **Start the journey**:
+   \`start_journey({ graph_id: "${graphId}" })\`
+   → Returns \`{ journey_id, step: { index, dossier, body, context } }\`
+
+4. **For each step**:
+   a. Show the user: "Executing step [index+1]/[total]: [dossier]"
+   b. Execute the step body instructions
+   c. Collect any outputs declared in the dossier (e.g., \`project_path\`, \`cluster_arn\`)
+   d. Call: \`step_complete({ journey_id, status: "completed", outputs: { key: value } })\`
+   e. If \`status: "running"\` → repeat with next step
+   f. If \`status: "completed"\` → journey done, show summary
+   g. If \`status: "failed"\` → show failure summary, diagnose with user
+
+5. **On step failure**:
+   - Diagnose what went wrong
+   - Ask user: retry manually and call step_complete again, or cancel?
+   - To cancel: \`cancel_journey({ journey_id, reason: "..." })\`
+
+6. **Report** the journey summary:
+   - Steps completed, failed, total duration
+   - All collected outputs
+   - Next recommended actions (from dossier relationships)
+
+## Tips
+- Use \`get_journey_status({ journey_id })\` to inspect state at any point
+- The \`context\` field in each step contains outputs from previous steps — use them
+- Never skip calling \`step_complete\` even if a step has no outputs`,
             },
           },
         ],

--- a/mcp-server/src/resources/orchestration.ts
+++ b/mcp-server/src/resources/orchestration.ts
@@ -1,0 +1,9 @@
+/**
+ * dossier://orchestration resource
+ * Provides the orchestration tool reference to LLM context
+ */
+
+import { createResourceLoader } from '../utils/resourceLoader';
+
+/** Get ORCHESTRATION.md content */
+export const getOrchestrationResource = createResourceLoader('ORCHESTRATION.md', 'orchestration');

--- a/mcp-server/src/tools/__tests__/journey.test.ts
+++ b/mcp-server/src/tools/__tests__/journey.test.ts
@@ -1,0 +1,339 @@
+/**
+ * End-to-end integration tests for the MCP journey session tools.
+ * Tests the full orchestration flow: start → step → complete/cancel/fail.
+ *
+ * These tests exercise the session management layer directly, using
+ * mocked file I/O and graph store to keep tests fast and hermetic.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock file system reads so tests don't depend on real dossier files
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(() => '# Step Body\n\nStep instructions go here.'),
+}));
+
+// Mock core parser
+vi.mock('@ai-dossier/core', () => ({
+  parseDossierContent: vi.fn((raw: string) => ({ body: raw })),
+}));
+
+// Mock logger
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import type { ExecutionPlan } from '../../orchestration/types';
+import { storeGraph } from '../../utils/graphStore';
+import { cancelJourney } from '../cancelJourney';
+import { getJourneyStatus } from '../getJourneyStatus';
+import { startJourney } from '../startJourney';
+import { stepComplete } from '../stepComplete';
+
+/** Build a minimal execution plan for N sequential steps */
+function makePlan(names: string[]): ExecutionPlan {
+  return {
+    entryDossier: names[0],
+    totalDossiers: names.length,
+    phases: names.map((name, i) => ({
+      phase: i + 1,
+      dossiers: [
+        {
+          name,
+          source: 'local' as const,
+          path: `/tmp/${name}.ds.md`,
+          condition: 'required' as const,
+        },
+      ],
+    })),
+    conflicts: [],
+    warnings: [],
+  };
+}
+
+/** Store a plan and return its graph_id */
+function storePlan(graphId: string, plan: ExecutionPlan): string {
+  storeGraph(graphId, plan);
+  return graphId;
+}
+
+describe('Journey session — happy path (3 steps)', () => {
+  const graphId = 'test-graph-happy';
+
+  beforeEach(() => {
+    storePlan(graphId, makePlan(['setup-project', 'install-deps', 'run-tests']));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('start_journey returns first step and journey_id', async () => {
+    const result = await startJourney({ graph_id: graphId });
+
+    expect(result).not.toHaveProperty('error');
+    const out = result as Awaited<ReturnType<typeof startJourney>> & {
+      journey_id: string;
+      total_steps: number;
+      step: { index: number; dossier: string };
+    };
+    expect(out.journey_id).toBeTruthy();
+    expect(out.total_steps).toBe(3);
+    expect(out.step.index).toBe(0);
+    expect(out.step.dossier).toBe('setup-project');
+  });
+
+  it('step_complete advances to step 2 and injects outputs as context', async () => {
+    const start = (await startJourney({ graph_id: graphId })) as any;
+    const journeyId = start.journey_id;
+
+    const result = (await stepComplete({
+      journey_id: journeyId,
+      status: 'completed',
+      outputs: { project_path: '/tmp/myapp' },
+    })) as any;
+
+    expect(result.status).toBe('running');
+    expect(result.step.index).toBe(1);
+    expect(result.step.dossier).toBe('install-deps');
+    expect(result.step.context).toContain('project_path=/tmp/myapp');
+    expect(result.step.context).toContain('setup-project');
+  });
+
+  it('step_complete advances through all steps and returns completed summary', async () => {
+    const start = (await startJourney({ graph_id: graphId })) as any;
+    const journeyId = start.journey_id;
+
+    await stepComplete({
+      journey_id: journeyId,
+      status: 'completed',
+      outputs: { project_path: '/tmp/myapp' },
+    });
+
+    await stepComplete({
+      journey_id: journeyId,
+      status: 'completed',
+      outputs: { deps_installed: true },
+    });
+
+    const result = (await stepComplete({
+      journey_id: journeyId,
+      status: 'completed',
+    })) as any;
+
+    expect(result.status).toBe('completed');
+    expect(result.summary.total_steps).toBe(3);
+    expect(result.summary.completed_steps).toBe(3);
+    expect(result.summary.failed_steps).toBe(0);
+    expect(result.summary.outputs['setup-project'].project_path).toBe('/tmp/myapp');
+  });
+
+  it('get_journey_status reflects progress after each step', async () => {
+    const start = (await startJourney({ graph_id: graphId })) as any;
+    const journeyId = start.journey_id;
+
+    await stepComplete({ journey_id: journeyId, status: 'completed' });
+
+    const status = getJourneyStatus({ journey_id: journeyId }) as any;
+
+    expect(status.summary.status).toBe('running');
+    expect(status.summary.completed_steps).toBe(1);
+    expect(status.current_step?.index).toBe(1);
+    expect(status.steps).toHaveLength(3);
+    expect(status.steps[0].status).toBe('completed');
+    expect(status.steps[1].status).toBe('running');
+    expect(status.steps[2].status).toBe('pending');
+  });
+
+  it('get_journey_status shows completed after full journey', async () => {
+    const start = (await startJourney({ graph_id: graphId })) as any;
+    const journeyId = start.journey_id;
+
+    await stepComplete({ journey_id: journeyId, status: 'completed' });
+    await stepComplete({ journey_id: journeyId, status: 'completed' });
+    await stepComplete({ journey_id: journeyId, status: 'completed' });
+
+    const status = getJourneyStatus({ journey_id: journeyId }) as any;
+    expect(status.summary.status).toBe('completed');
+    expect(status.current_step).toBeUndefined();
+  });
+});
+
+describe('Journey session — cancel mid-journey', () => {
+  const graphId = 'test-graph-cancel';
+
+  beforeEach(() => {
+    storePlan(graphId, makePlan(['setup-project', 'install-deps', 'run-tests']));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('cancel_journey stops the journey and skips remaining steps', async () => {
+    const start = (await startJourney({ graph_id: graphId })) as any;
+    const journeyId = start.journey_id;
+
+    await stepComplete({ journey_id: journeyId, status: 'completed' });
+
+    const result = cancelJourney({ journey_id: journeyId, reason: 'User cancelled' }) as any;
+
+    expect(result.summary.status).toBe('cancelled');
+    expect(result.summary.cancel_reason).toBe('User cancelled');
+    expect(result.summary.completed_steps).toBe(1);
+  });
+
+  it('cannot step_complete after cancel', async () => {
+    const start = (await startJourney({ graph_id: graphId })) as any;
+    const journeyId = start.journey_id;
+
+    cancelJourney({ journey_id: journeyId });
+
+    const result = (await stepComplete({ journey_id: journeyId, status: 'completed' })) as any;
+    expect(result).toHaveProperty('error');
+    expect(result.error.type).toBe('invalid_state');
+  });
+
+  it('cannot cancel an already-cancelled journey', async () => {
+    const start = (await startJourney({ graph_id: graphId })) as any;
+    const journeyId = start.journey_id;
+
+    cancelJourney({ journey_id: journeyId });
+    const result = cancelJourney({ journey_id: journeyId }) as any;
+
+    expect(result).toHaveProperty('error');
+    expect(result.error.type).toBe('invalid_state');
+  });
+});
+
+describe('Journey session — failed step', () => {
+  const graphId = 'test-graph-fail';
+
+  beforeEach(() => {
+    storePlan(graphId, makePlan(['setup-project', 'install-deps', 'run-tests']));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('step_complete with failed status returns failed summary', async () => {
+    const start = (await startJourney({ graph_id: graphId })) as any;
+    const journeyId = start.journey_id;
+
+    const result = (await stepComplete({
+      journey_id: journeyId,
+      status: 'failed',
+    })) as any;
+
+    expect(result.status).toBe('failed');
+    expect(result.summary.status).toBe('failed');
+    expect(result.summary.failed_steps).toBe(1);
+  });
+
+  it('cannot advance after a failed step', async () => {
+    const start = (await startJourney({ graph_id: graphId })) as any;
+    const journeyId = start.journey_id;
+
+    await stepComplete({ journey_id: journeyId, status: 'failed' });
+
+    const result = (await stepComplete({ journey_id: journeyId, status: 'completed' })) as any;
+    expect(result).toHaveProperty('error');
+    expect(result.error.type).toBe('invalid_state');
+  });
+});
+
+describe('Journey session — error handling', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('start_journey returns not_found for unknown graph_id', async () => {
+    const result = (await startJourney({ graph_id: 'nonexistent-graph' })) as any;
+    expect(result).toHaveProperty('error');
+    expect(result.error.type).toBe('not_found');
+  });
+
+  it('step_complete returns not_found for unknown journey_id', async () => {
+    const result = (await stepComplete({
+      journey_id: 'nonexistent-journey',
+      status: 'completed',
+    })) as any;
+    expect(result).toHaveProperty('error');
+    expect(result.error.type).toBe('not_found');
+  });
+
+  it('get_journey_status returns not_found for unknown journey_id', () => {
+    const result = getJourneyStatus({ journey_id: 'nonexistent-journey' }) as any;
+    expect(result).toHaveProperty('error');
+    expect(result.error.type).toBe('not_found');
+  });
+
+  it('cancel_journey returns not_found for unknown journey_id', () => {
+    const result = cancelJourney({ journey_id: 'nonexistent-journey' }) as any;
+    expect(result).toHaveProperty('error');
+    expect(result.error.type).toBe('not_found');
+  });
+
+  it('start_journey returns error for missing graph_id', async () => {
+    const result = (await startJourney({ graph_id: '' })) as any;
+    expect(result).toHaveProperty('error');
+    expect(result.error.type).toBe('unknown');
+  });
+
+  it('step_complete returns error for missing journey_id', async () => {
+    const result = (await stepComplete({ journey_id: '', status: 'completed' })) as any;
+    expect(result).toHaveProperty('error');
+    expect(result.error.type).toBe('unknown');
+  });
+
+  it('get_journey_status returns error for missing journey_id', () => {
+    const result = getJourneyStatus({ journey_id: '' }) as any;
+    expect(result).toHaveProperty('error');
+    expect(result.error.type).toBe('unknown');
+  });
+
+  it('cancel_journey returns error for missing journey_id', () => {
+    const result = cancelJourney({ journey_id: '' }) as any;
+    expect(result).toHaveProperty('error');
+    expect(result.error.type).toBe('unknown');
+  });
+});
+
+describe('Journey session — output context propagation', () => {
+  const graphId = 'test-graph-context';
+
+  beforeEach(() => {
+    storePlan(graphId, makePlan(['step-a', 'step-b', 'step-c']));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('outputs from multiple steps are all available in context', async () => {
+    const start = (await startJourney({ graph_id: graphId })) as any;
+    const journeyId = start.journey_id;
+
+    await stepComplete({
+      journey_id: journeyId,
+      status: 'completed',
+      outputs: { host: 'localhost', port: '5432' },
+    });
+
+    const step2 = (await stepComplete({
+      journey_id: journeyId,
+      status: 'completed',
+      outputs: { db_name: 'mydb' },
+    })) as any;
+
+    expect(step2.step.context).toContain('host=localhost');
+    expect(step2.step.context).toContain('port=5432');
+    expect(step2.step.context).toContain('db_name=mydb');
+  });
+
+  it('context is empty on the first step', async () => {
+    const start = (await startJourney({ graph_id: graphId })) as any;
+    expect(start.step.context).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Completes the final phase (Phase 4: Polish) of the MCP orchestration epic (#76):

**#75 — Prompts and resources:**
- `PROTOCOL.md`: execution protocol document covering single and multi-dossier flows
- `ORCHESTRATION.md`: complete tool reference with schemas, examples, and error states
- New `dossier://orchestration` MCP resource — detailed reference for all orchestration tools
- Updated `execute-dossier` prompt: decision tree to choose single vs journey flow
- New `execute-journey` prompt: step-by-step orchestration guidance for LLMs

**#74 — Integration tests + example journey:**
- `examples/journey/` — 3-step linear journey dossiers with valid checksums:
  - `setup-project.ds.md` (outputs: `project_path`)
  - `install-deps.ds.md` (`preceded_by: setup-project`, `inputs.from_dossiers`)
  - `run-tests.ds.md` (`preceded_by: install-deps`)
- 20 integration tests covering: happy path, cancel mid-journey, failed step, error handling, output context propagation

Closes #74
Closes #75

## Test plan

- [ ] `cd mcp-server && npm test` — all 120 tests pass
- [ ] Example dossiers have valid checksums (`ai-dossier checksum examples/journey/*.ds.md`)
- [ ] MCP server builds cleanly (`cd mcp-server && npm run build`)
- [ ] `dossier://orchestration` resource returns `ORCHESTRATION.md` content
- [ ] `execute-dossier` prompt includes decision tree for single vs journey flow
- [ ] `execute-journey` prompt guides through resolve → verify → start → step flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)