### PR TITLE
docs(core): add API reference for @ai-dossier/core programmatic library

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -11,7 +11,7 @@ Technical specifications and reference material for the Dossier project.
 ## API & CLI Reference
 
 - [CLI Reference](cli.md) *(coming soon)* - Command-line tool options and usage
-- [API Reference](api.md) *(coming soon)* - Core library API documentation
+- [API Reference](api.md) - `@ai-dossier/core` programmatic API documentation
 
 ## File Formats
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,531 @@
+# `@ai-dossier/core` API Reference
+
+The `@ai-dossier/core` package exposes the full dossier parsing, verification, linting, and formatting pipeline as a programmatic TypeScript API.
+
+## Installation
+
+```bash
+npm install @ai-dossier/core
+```
+
+## Quick Start
+
+```typescript
+import {
+  parseDossierContent,
+  verifyIntegrity,
+  verifySignature,
+} from '@ai-dossier/core';
+
+const { frontmatter, body } = parseDossierContent(raw);
+
+const integrity = verifyIntegrity(body, frontmatter.checksum?.hash ?? '');
+// integrity.status === 'valid' | 'invalid' | 'missing'
+
+const authenticity = await verifySignature(frontmatter, body);
+// authenticity.status === 'verified' | 'unsigned' | 'invalid' | ...
+```
+
+---
+
+## Parsing
+
+### `parseDossierContent(content)`
+
+```typescript
+function parseDossierContent(content: string): ParsedDossier
+```
+
+Parse a raw dossier string (YAML frontmatter + markdown body) into a structured object.
+
+| Parameter | Type     | Description            |
+|-----------|----------|------------------------|
+| `content` | `string` | Raw dossier file text  |
+
+Returns [`ParsedDossier`](#parseddossier).
+
+---
+
+### `parseDossierFile(filePath)`
+
+```typescript
+function parseDossierFile(filePath: string): ParsedDossier
+```
+
+Read a `.ds.md` file from disk and parse it.
+
+---
+
+### `validateFrontmatter(frontmatter)`
+
+```typescript
+function validateFrontmatter(frontmatter: DossierFrontmatter): string[]
+```
+
+Check required fields (`title`, `version`). Returns an array of error message strings — empty means valid.
+
+```typescript
+const errors = validateFrontmatter(parsed.frontmatter);
+if (errors.length) throw new Error(errors.join(', '));
+```
+
+---
+
+## Checksum Verification
+
+### `verifyIntegrity(body, expectedHash)`
+
+```typescript
+function verifyIntegrity(body: string, expectedHash: string): IntegrityResult
+```
+
+Compute the SHA-256 hash of `body` and compare it to `expectedHash`.
+
+| Parameter      | Type     | Description                          |
+|----------------|----------|--------------------------------------|
+| `body`         | `string` | Dossier body (after frontmatter)     |
+| `expectedHash` | `string` | Hash stored in `checksum.hash`       |
+
+Returns [`IntegrityResult`](#integrityresult).
+
+---
+
+### `calculateChecksum(body)`
+
+```typescript
+function calculateChecksum(body: string): string
+```
+
+Return the hex-encoded SHA-256 hash of `body`.
+
+---
+
+## Signature Verification
+
+### `verifySignature(frontmatter, body)`
+
+```typescript
+function verifySignature(
+  frontmatter: DossierFrontmatter,
+  body: string
+): Promise<AuthenticityResult>
+```
+
+Verify the dossier's cryptographic signature against the loaded trusted keys. Supports Ed25519 (Minisign) and AWS KMS.
+
+Returns [`AuthenticityResult`](#authenticityresult).
+
+---
+
+### `verifyWithEd25519(data, signature, publicKeyPem)`
+
+```typescript
+function verifyWithEd25519(
+  data: string,
+  signature: string,
+  publicKeyPem: string
+): boolean
+```
+
+Low-level Ed25519 signature check. `signature` is base64-encoded.
+
+---
+
+### `loadTrustedKeys()`
+
+```typescript
+function loadTrustedKeys(): TrustedKey[]
+```
+
+Load trusted public keys from environment variables / config. Returns an array of [`TrustedKey`](#trustedkey).
+
+---
+
+## Signing
+
+### `Ed25519Signer`
+
+```typescript
+class Ed25519Signer implements Signer {
+  constructor(privateKeyPem: string)
+  sign(content: string): Promise<SignatureResult>
+  getPublicKey(): Promise<string>
+  readonly algorithm: string
+}
+```
+
+Sign dossier content with an Ed25519 private key.
+
+```typescript
+import { Ed25519Signer } from '@ai-dossier/core';
+
+const signer = new Ed25519Signer(privateKeyPem);
+const sigResult = await signer.sign(body);
+// sigResult.algorithm, sigResult.signature, sigResult.public_key, sigResult.signed_at
+```
+
+### `KmsSigner`
+
+```typescript
+class KmsSigner implements Signer
+```
+
+Sign using an AWS KMS asymmetric key. Requires `@aws-sdk/client-kms` to be installed and AWS credentials to be configured.
+
+### `VerifierRegistry`
+
+```typescript
+class VerifierRegistry {
+  register(verifier: Verifier): void
+  verify(content: string, signature: SignatureResult): Promise<VerifyResult>
+}
+
+function getVerifierRegistry(): VerifierRegistry
+```
+
+The global registry of verifier implementations. The default registry includes `Ed25519Verifier` and `KmsVerifier`.
+
+```typescript
+import { getVerifierRegistry } from '@ai-dossier/core';
+
+const registry = getVerifierRegistry();
+const result = await registry.verify(body, signatureMetadata);
+```
+
+---
+
+## Linting
+
+### `lintDossier(content, config?)`
+
+```typescript
+function lintDossier(content: string, config?: LintConfig): LintResult
+```
+
+Lint a dossier string against the default rule set (or a custom config).
+
+```typescript
+import { lintDossier } from '@ai-dossier/core';
+
+const { diagnostics, errorCount, warningCount } = lintDossier(content);
+for (const d of diagnostics) {
+  console.log(`[${d.severity}] ${d.ruleId}: ${d.message}`);
+}
+```
+
+### `lintDossierFile(filePath, config?)`
+
+```typescript
+function lintDossierFile(filePath: string, config?: LintConfig): LintResult
+```
+
+Read a file from disk and lint it.
+
+### `LintRuleRegistry`
+
+```typescript
+class LintRuleRegistry {
+  constructor(rules?: LintRule[])
+  register(rule: LintRule): void
+  run(context: LintRuleContext, config?: LintConfig): LintDiagnostic[]
+}
+```
+
+Register custom lint rules:
+
+```typescript
+import { LintRuleRegistry, defaultRules } from '@ai-dossier/core';
+import type { LintRule } from '@ai-dossier/core';
+
+const myRule: LintRule = {
+  id: 'custom/require-objective',
+  description: 'Dossier must have an objective',
+  defaultSeverity: 'warning',
+  run({ frontmatter }) {
+    if (!frontmatter.objective) {
+      return [{
+        ruleId: 'custom/require-objective',
+        severity: 'warning',
+        message: 'Missing objective field',
+        field: 'objective',
+      }];
+    }
+    return [];
+  },
+};
+
+const registry = new LintRuleRegistry([...defaultRules, myRule]);
+```
+
+### `loadLintConfig(dir?)`
+
+```typescript
+function loadLintConfig(dir?: string): LintConfig
+```
+
+Load lint configuration from a `.dossierrc` or `dossier.config.json` file.
+
+---
+
+## Formatting
+
+### `formatDossierContent(content, options?)`
+
+```typescript
+function formatDossierContent(
+  content: string,
+  options?: Partial<FormatOptions>
+): FormatResult
+```
+
+Normalize YAML frontmatter key order and optionally recompute the checksum.
+
+| Option           | Type      | Default | Description                            |
+|------------------|-----------|---------|----------------------------------------|
+| `sortKeys`       | `boolean` | `true`  | Alphabetically sort frontmatter keys   |
+| `updateChecksum` | `boolean` | `true`  | Recompute `checksum.hash` after format |
+| `indent`         | `number`  | `2`     | YAML indentation width                 |
+
+```typescript
+import { formatDossierContent } from '@ai-dossier/core';
+
+const { formatted, changed } = formatDossierContent(rawContent, {
+  sortKeys: true,
+  updateChecksum: true,
+});
+if (changed) fs.writeFileSync(path, formatted);
+```
+
+### `formatDossierFile(filePath, options?)`
+
+```typescript
+function formatDossierFile(
+  filePath: string,
+  options?: Partial<FormatOptions>
+): FormatResult
+```
+
+Format a dossier file in place (writes back if changed).
+
+---
+
+## Type Reference
+
+### `ParsedDossier`
+
+```typescript
+interface ParsedDossier {
+  frontmatter: DossierFrontmatter;
+  body: string;   // Markdown content after the closing --- delimiter
+  raw: string;    // Original unmodified file text
+}
+```
+
+### `DossierFrontmatter`
+
+```typescript
+interface DossierFrontmatter {
+  title: string;
+  version: string;
+  dossier_schema_version?: string;
+  name?: string;
+  protocol_version?: string;
+  created?: string;
+  updated?: string;
+  objective?: string;
+  status?: 'Draft' | 'Stable' | 'Deprecated' | 'Experimental';
+  risk_level?: 'low' | 'medium' | 'high' | 'critical';
+  risk_factors?: string[];
+  destructive_operations?: string[];
+  requires_approval?: boolean;
+  checksum?: {
+    algorithm: string;
+    hash: string;
+    calculated_at?: string;
+  };
+  signature?: {
+    algorithm: string;
+    signature: string;
+    public_key?: string;
+    key_id?: string;
+    signed_by?: string;
+    signed_at?: string;
+  };
+  [key: string]: unknown;
+}
+```
+
+### `IntegrityResult`
+
+```typescript
+interface IntegrityResult {
+  status: 'valid' | 'invalid' | 'missing';
+  message: string;
+  expectedHash?: string;
+  actualHash?: string;
+}
+```
+
+### `AuthenticityResult`
+
+```typescript
+interface AuthenticityResult {
+  status: 'verified' | 'signed_unknown' | 'unsigned' | 'invalid' | 'error';
+  message: string;
+  signer?: string;
+  keyId?: string;
+  publicKey?: string;
+  isTrusted: boolean;
+  trustedAs?: string;
+}
+```
+
+### `RiskAssessment`
+
+```typescript
+interface RiskAssessment {
+  riskLevel: 'low' | 'medium' | 'high' | 'critical' | 'unknown';
+  riskFactors: string[];
+  destructiveOperations: string[];
+  requiresApproval: boolean;
+}
+```
+
+### `VerificationResult`
+
+```typescript
+interface VerificationResult {
+  dossierFile: string;
+  integrity: IntegrityResult;
+  authenticity: AuthenticityResult;
+  riskAssessment: RiskAssessment;
+  recommendation: 'ALLOW' | 'WARN' | 'BLOCK';
+  message: string;
+  errors: string[];
+}
+```
+
+### `TrustedKey`
+
+```typescript
+interface TrustedKey {
+  publicKey: string;
+  keyId: string;
+}
+```
+
+### `DossierListItem`
+
+```typescript
+interface DossierListItem {
+  name: string;
+  path: string;
+  version: string;
+  protocol: string;
+  status: string;
+  objective: string;
+  riskLevel: string;
+}
+```
+
+### `Signer`
+
+```typescript
+interface Signer {
+  readonly algorithm: string;
+  sign(content: string): Promise<SignatureResult>;
+  getPublicKey(): Promise<string>;
+}
+```
+
+### `Verifier`
+
+```typescript
+interface Verifier {
+  verify(content: string, signature: SignatureResult): Promise<VerifyResult>;
+  supports(algorithm: string): boolean;
+}
+```
+
+### `SignatureResult`
+
+```typescript
+interface SignatureResult {
+  algorithm: string;
+  signature: string;
+  public_key: string;
+  key_id?: string;
+  signed_by?: string;
+  signed_at: string;
+}
+```
+
+### `VerifyResult`
+
+```typescript
+interface VerifyResult {
+  valid: boolean;
+  error?: string;
+}
+```
+
+### `LintDiagnostic`
+
+```typescript
+type LintSeverity = 'error' | 'warning' | 'info';
+
+interface LintDiagnostic {
+  ruleId: string;
+  severity: LintSeverity;
+  message: string;
+  field?: string;
+}
+```
+
+### `LintResult`
+
+```typescript
+interface LintResult {
+  file?: string;
+  diagnostics: LintDiagnostic[];
+  errorCount: number;
+  warningCount: number;
+  infoCount: number;
+}
+```
+
+### `LintRule`
+
+```typescript
+interface LintRule {
+  id: string;
+  description: string;
+  defaultSeverity: LintSeverity;
+  run(context: LintRuleContext): LintDiagnostic[];
+}
+```
+
+### `LintConfig`
+
+```typescript
+type RuleSeverityOverride = LintSeverity | 'off';
+
+interface LintConfig {
+  rules: Record<string, RuleSeverityOverride>;
+}
+```
+
+### `FormatOptions` / `FormatResult`
+
+```typescript
+interface FormatOptions {
+  indent: number;
+  sortKeys: boolean;
+  updateChecksum: boolean;
+}
+
+interface FormatResult {
+  formatted: string;
+  changed: boolean;
+}
+```

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,69 +2,342 @@
 
 Core parsing, verification, and linting logic for the [Dossier](https://github.com/imboard-ai/ai-dossier) automation standard.
 
+Use this package to integrate dossier parsing and verification into your own tooling.
+
 ## Installation
 
 ```bash
 npm install @ai-dossier/core
 ```
 
+## Quick Start
+
+```typescript
+import {
+  parseDossierContent,
+  verifyIntegrity,
+  verifySignature,
+} from '@ai-dossier/core';
+
+const raw = `---
+title: Deploy to Production
+version: 1.0.0
+checksum:
+  algorithm: sha256
+  hash: abc123...
+---
+# Steps
+Run deployment script.
+`;
+
+// Parse the dossier
+const { frontmatter, body } = parseDossierContent(raw);
+
+// Verify body integrity
+const integrity = verifyIntegrity(body, frontmatter.checksum?.hash ?? '');
+console.log(integrity.status); // 'valid' | 'invalid' | 'missing'
+
+// Verify cryptographic signature
+const authenticity = await verifySignature(frontmatter, body);
+console.log(authenticity.status); // 'verified' | 'unsigned' | 'invalid' | ...
+```
+
 ## API
 
 ### Parsing
 
+#### `parseDossierContent(content: string): ParsedDossier`
+
+Parse a dossier string into structured data.
+
 ```typescript
-import { parseDossierContent, parseDossierFile, validateFrontmatter } from '@ai-dossier/core';
+import { parseDossierContent } from '@ai-dossier/core';
 
-// Parse dossier content string
-const { frontmatter, body } = parseDossierContent(content);
+const { frontmatter, body, raw } = parseDossierContent(content);
+```
 
-// Parse from file path
-const parsed = parseDossierFile('./my-dossier.ds.md');
+#### `parseDossierFile(filePath: string): ParsedDossier`
 
-// Validate required fields
+Parse a dossier file from disk.
+
+```typescript
+import { parseDossierFile } from '@ai-dossier/core';
+
+const parsed = parseDossierFile('./deploy.ds.md');
+```
+
+#### `validateFrontmatter(frontmatter: DossierFrontmatter): string[]`
+
+Validate required fields. Returns an array of error messages (empty = valid).
+
+```typescript
+import { validateFrontmatter } from '@ai-dossier/core';
+
 const errors = validateFrontmatter(parsed.frontmatter);
+if (errors.length > 0) {
+  console.error('Invalid dossier:', errors);
+}
 ```
 
 ### Checksum Verification
 
+#### `verifyIntegrity(body: string, expectedHash: string): IntegrityResult`
+
+Verify that the dossier body matches its recorded SHA-256 checksum.
+
 ```typescript
-import { calculateChecksum, verifyIntegrity } from '@ai-dossier/core';
+import { verifyIntegrity } from '@ai-dossier/core';
+
+const result = verifyIntegrity(body, frontmatter.checksum?.hash ?? '');
+// result.status: 'valid' | 'invalid' | 'missing'
+// result.message: human-readable explanation
+// result.actualHash: computed hash
+// result.expectedHash: hash from frontmatter
+```
+
+#### `calculateChecksum(body: string): string`
+
+Compute the SHA-256 hash of a dossier body.
+
+```typescript
+import { calculateChecksum } from '@ai-dossier/core';
 
 const hash = calculateChecksum(body);
-const isValid = verifyIntegrity(body, expectedHash);
 ```
 
 ### Signature Verification
 
+#### `verifySignature(frontmatter, body): Promise<AuthenticityResult>`
+
+Verify the dossier's cryptographic signature using the configured trusted keys.
+
 ```typescript
-import { verifySignature, verifyWithEd25519, loadTrustedKeys } from '@ai-dossier/core';
+import { verifySignature } from '@ai-dossier/core';
 
-// Verify using trusted keys
 const result = await verifySignature(frontmatter, body);
+// result.status: 'verified' | 'signed_unknown' | 'unsigned' | 'invalid' | 'error'
+// result.isTrusted: boolean
+// result.signer: string | undefined
+```
 
-// Verify with a specific Ed25519 public key
-const valid = verifyWithEd25519(data, signature, publicKeyPem);
+#### `verifyWithEd25519(data, signature, publicKeyPem): boolean`
+
+Verify an Ed25519 signature directly.
+
+```typescript
+import { verifyWithEd25519 } from '@ai-dossier/core';
+
+const valid = verifyWithEd25519(data, signatureBase64, publicKeyPem);
+```
+
+#### `loadTrustedKeys(): TrustedKey[]`
+
+Load trusted public keys from the environment / config.
+
+```typescript
+import { loadTrustedKeys } from '@ai-dossier/core';
+
+const keys = loadTrustedKeys();
+// keys[0].publicKey, keys[0].keyId
+```
+
+### Signing
+
+Use the `Signer` interface to sign dossier content programmatically.
+
+```typescript
+import { Ed25519Signer } from '@ai-dossier/core';
+
+const signer = new Ed25519Signer(privateKeyPem);
+const result = await signer.sign(body);
+// result.algorithm, result.signature, result.public_key, result.signed_at
 ```
 
 ### Linting
 
-```typescript
-import { lintDossier, lintDossierFile } from '@ai-dossier/core';
+#### `lintDossier(content, config?): LintResult`
 
-const results = lintDossier(content);
-// or
-const results = lintDossierFile('./my-dossier.ds.md');
+Lint a dossier string.
+
+```typescript
+import { lintDossier } from '@ai-dossier/core';
+
+const result = lintDossier(content);
+console.log(result.errorCount, result.warningCount);
+for (const d of result.diagnostics) {
+  console.log(`[${d.severity}] ${d.ruleId}: ${d.message}`);
+}
+```
+
+#### `lintDossierFile(filePath, config?): LintResult`
+
+Lint a dossier file from disk.
+
+#### Custom lint rules
+
+```typescript
+import { LintRuleRegistry, defaultRules } from '@ai-dossier/core';
+import type { LintRule } from '@ai-dossier/core';
+
+const myRule: LintRule = {
+  id: 'my/rule',
+  description: 'Require objective field',
+  defaultSeverity: 'warning',
+  run({ frontmatter }) {
+    if (!frontmatter.objective) {
+      return [{ ruleId: 'my/rule', severity: 'warning', message: 'Missing objective' }];
+    }
+    return [];
+  },
+};
+
+const registry = new LintRuleRegistry([...defaultRules, myRule]);
 ```
 
 ### Formatting
 
+#### `formatDossierContent(content, options?): FormatResult`
+
+Normalize YAML frontmatter formatting and optionally recompute the checksum.
+
 ```typescript
 import { formatDossierContent } from '@ai-dossier/core';
 
-const { content, changed } = formatDossierContent(rawContent, {
+const { formatted, changed } = formatDossierContent(rawContent, {
   sortKeys: true,
   updateChecksum: true,
 });
+```
+
+#### `formatDossierFile(filePath, options?): FormatResult`
+
+Format a dossier file in place.
+
+## TypeScript Types
+
+### Core data types
+
+```typescript
+interface ParsedDossier {
+  frontmatter: DossierFrontmatter;
+  body: string; // content after the closing --- delimiter
+  raw: string; // original full file content
+}
+
+interface DossierFrontmatter {
+  title: string;
+  version: string;
+  dossier_schema_version?: string;
+  name?: string;
+  objective?: string;
+  status?: 'Draft' | 'Stable' | 'Deprecated' | 'Experimental';
+  risk_level?: 'low' | 'medium' | 'high' | 'critical';
+  risk_factors?: string[];
+  destructive_operations?: string[];
+  requires_approval?: boolean;
+  checksum?: { algorithm: string; hash: string; calculated_at?: string };
+  signature?: {
+    algorithm: string;
+    signature: string;
+    public_key?: string;
+    key_id?: string;
+    signed_by?: string;
+    signed_at?: string;
+  };
+  [key: string]: unknown;
+}
+```
+
+### Verification result types
+
+```typescript
+interface IntegrityResult {
+  status: 'valid' | 'invalid' | 'missing';
+  message: string;
+  expectedHash?: string;
+  actualHash?: string;
+}
+
+interface AuthenticityResult {
+  status: 'verified' | 'signed_unknown' | 'unsigned' | 'invalid' | 'error';
+  message: string;
+  signer?: string;
+  keyId?: string;
+  publicKey?: string;
+  isTrusted: boolean;
+  trustedAs?: string;
+}
+
+interface RiskAssessment {
+  riskLevel: 'low' | 'medium' | 'high' | 'critical' | 'unknown';
+  riskFactors: string[];
+  destructiveOperations: string[];
+  requiresApproval: boolean;
+}
+
+interface VerificationResult {
+  dossierFile: string;
+  integrity: IntegrityResult;
+  authenticity: AuthenticityResult;
+  riskAssessment: RiskAssessment;
+  recommendation: 'ALLOW' | 'WARN' | 'BLOCK';
+  message: string;
+  errors: string[];
+}
+```
+
+### Signer / Verifier interfaces
+
+```typescript
+interface Signer {
+  readonly algorithm: string;
+  sign(content: string): Promise<SignatureResult>;
+  getPublicKey(): Promise<string>;
+}
+
+interface Verifier {
+  verify(content: string, signature: SignatureResult): Promise<VerifyResult>;
+  supports(algorithm: string): boolean;
+}
+
+interface SignatureResult {
+  algorithm: string;
+  signature: string;
+  public_key: string;
+  key_id?: string;
+  signed_by?: string;
+  signed_at: string;
+}
+
+interface VerifyResult {
+  valid: boolean;
+  error?: string;
+}
+```
+
+### Lint types
+
+```typescript
+type LintSeverity = 'error' | 'warning' | 'info';
+
+interface LintDiagnostic {
+  ruleId: string;
+  severity: LintSeverity;
+  message: string;
+  field?: string;
+}
+
+interface LintResult {
+  file?: string;
+  diagnostics: LintDiagnostic[];
+  errorCount: number;
+  warningCount: number;
+  infoCount: number;
+}
+
+interface LintConfig {
+  rules: Record<string, LintSeverity | 'off'>;
+}
 ```
 
 ## License


### PR DESCRIPTION
Closes #89

## Summary

- Expands `packages/core/README.md` with a Quick Start section, per-function documentation with signatures and examples, and a complete TypeScript type reference
- Creates `docs/reference/api.md` — a full API reference page covering all exported functions, classes, and interfaces with usage examples
- Updates `docs/reference/README.md` to mark the API reference as complete (removes "coming soon")

## Test plan

- [ ] Review `packages/core/README.md` — all exported functions have examples; types section matches `src/types.ts` and `src/signers/index.ts`
- [ ] Review `docs/reference/api.md` — tables, code examples, and type signatures are accurate
- [ ] Confirm `docs/reference/README.md` link to `api.md` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)