### PR TITLE
docs: fix staleness and contradictions across documentation files

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,7 +30,7 @@ Shared verification and parsing logic used by all tools. Handles:
 ### CLI Tool (`@ai-dossier/cli`)
 Command-line verification tool for end users:
 ```bash
-dossier-verify <file-or-url>
+ai-dossier verify <file-or-url>
 ```
 
 ### MCP Server (`@ai-dossier/mcp-server`)
@@ -38,14 +38,18 @@ Model Context Protocol integration for AI agents like Claude Code.
 
 ## File Format
 
-Dossiers are Markdown files with YAML frontmatter:
+Dossiers are Markdown files with a custom JSON frontmatter block (not YAML):
 
 ```markdown
----
-title: Example Dossier
-version: "1.0.0"
-checksum: "sha256:abc123..."
-signature: "minisign:xyz789..."
+---dossier
+{
+  "title": "Example Dossier",
+  "version": "1.0.0",
+  "checksum": {
+    "algorithm": "sha256",
+    "hash": "abc123..."
+  }
+}
 ---
 
 # Instructions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [@ai-dossier/cli@0.4.1] - 2026-03-06
+
+### Added
+- `--agent` flag for machine-readable capability manifest
+- `commands` command for JSON inventory of all CLI commands
+- CDN propagation warning after `publish` and `remove`
+- `--json` flag for `remove` and `whoami` commands
+
+### Fixed
+- Non-TTY stdin detection — graceful failure instead of hanging
+- Skip URL download in dry-run mode
+- Core crypto verification returns `VerifyResult` instead of bare boolean
+
+## [@ai-dossier/cli@0.4.0] - 2026-01-01
+
+### Added
+- `--json` flag for `list` and `publish` commands
+- `install-skill` cache validation, `--fresh` flag, and `--json` output
+- Publish collision warning with full path
+- Comprehensive test suite for security-critical code paths
+
+### Changed
+- Unified three disagreeing dossier parsers into one canonical implementation (core)
+
+## [@ai-dossier/cli@0.3.0] - 2025-12-01
+
+### Added
+- Full `@ai-dossier` npm scope — packages published to npm registry
+- Comprehensive test suite with 261+ tests
+- JSON output mode (`--json` flag) across commands
+- `sign` command using core library signers directly
+
+### Changed
+- **BREAKING**: Binary renamed from `dossier-verify` to `ai-dossier`
+- Package scope: `@imboard-ai/*` → `@ai-dossier/*`
+- MCP server tools now wrap CLI commands
+
+### Fixed
+- Quality review: fixed links, docs, parser deduplication, Node 18 support
+
 ## [@imboard-ai/dossier-cli@0.2.1] - 2025-11-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -66,9 +66,8 @@ Verify dossier security before execution:
 ```bash
 # Clone the repo and use the CLI verification tool
 git clone https://github.com/imboard-ai/ai-dossier.git
-cd dossier
-chmod +x cli/bin/dossier-verify
-cli/bin/dossier-verify examples/git-project-review/atomic/readme-reality-check.ds.md
+cd ai-dossier
+npx @ai-dossier/cli verify examples/git-project-review/atomic/readme-reality-check.ds.md
 ```
 
 ---
@@ -144,7 +143,7 @@ https://raw.githubusercontent.com/imboard-ai/ai-dossier/main/examples/git-projec
 
 ## Security & Verification
 
-- Use the CLI tool (`cli/bin/dossier-verify`) to verify checksums/signatures before execution
+- Use the CLI tool (`npx @ai-dossier/cli verify`) to verify checksums/signatures before execution
 - Prefer MCP mode for sandboxed, permissioned operations
 - See [SECURITY_STATUS.md](./SECURITY_STATUS.md) for current guarantees and limitations
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -36,8 +36,8 @@ cd cli
 npm link  # Links the CLI globally for development
 
 # Or use directly
-chmod +x bin/dossier-verify
-./bin/dossier-verify <file-or-url>
+chmod +x bin/ai-dossier
+./bin/ai-dossier verify <file-or-url>
 ```
 
 ---
@@ -74,10 +74,10 @@ Commands that require confirmation (`publish`, `remove`, `cache clean`) will fai
 
 ```bash
 # Verify local file
-dossier-verify path/to/dossier.ds.md
+ai-dossier verify path/to/dossier.ds.md
 
 # Verify remote dossier
-dossier-verify https://example.com/dossier.ds.md
+ai-dossier verify https://example.com/dossier.ds.md
 ```
 
 **Exit codes**:
@@ -88,7 +88,7 @@ dossier-verify https://example.com/dossier.ds.md
 ### Verbose Mode
 
 ```bash
-dossier-verify --verbose path/to/dossier.ds.md
+ai-dossier verify --verbose path/to/dossier.ds.md
 ```
 
 Shows:
@@ -103,7 +103,7 @@ Shows:
 ```bash
 # Shell function wrapper
 claude-run-dossier() {
-  if dossier-verify "$1"; then
+  if ai-dossier verify "$1"; then
     claude-code "The dossier at $1 has been verified. Please execute it."
   else
     echo "❌ Security verification failed. Not executing."
@@ -117,7 +117,7 @@ claude-run-dossier https://example.com/dossier.ds.md
 **Cursor**:
 ```bash
 cursor-run-dossier() {
-  if dossier-verify "$1"; then
+  if ai-dossier verify "$1"; then
     cursor "Execute the verified dossier at $1"
   else
     echo "❌ Verification failed"
@@ -132,7 +132,7 @@ safe-run-dossier() {
   local url="$1"
   local tool="${2:-claude-code}"
 
-  if dossier-verify "$url"; then
+  if ai-dossier verify "$url"; then
     echo "✅ Dossier verified. Passing to $tool..."
     "$tool" "run $url"
   else
@@ -199,7 +199,7 @@ safe-run-dossier https://example.com/dossier.ds.md cursor
 ### Example 1: Legitimate Dossier (Passes)
 
 ```bash
-$ dossier-verify examples/data-science/train-ml-model.ds.md
+$ ai-dossier verify examples/data-science/train-ml-model.ds.md
 
 🔐 Dossier Verification Tool
 
@@ -228,7 +228,7 @@ $ echo $?
 ### Example 2: Malicious Dossier (Blocked)
 
 ```bash
-$ dossier-verify https://raw.githubusercontent.com/imboard-ai/ai-dossier/main/examples/security/validate-project-config.ds.md
+$ ai-dossier verify https://raw.githubusercontent.com/imboard-ai/ai-dossier/main/examples/security/validate-project-config.ds.md
 
 🔐 Dossier Verification Tool
 
@@ -268,7 +268,7 @@ $ echo $?
 # Wrapper function for Claude Code
 claude-run-dossier() {
   echo "Verifying dossier security..."
-  if ~/projects/dossier/cli/bin/dossier-verify "$1"; then
+  if ~/projects/ai-dossier/cli/bin/ai-dossier verify "$1"; then
     echo ""
     echo "✅ Verification passed. Executing with Claude Code..."
     claude-code "Execute the verified dossier at $1"
@@ -292,7 +292,7 @@ claude-run-dossier https://example.com/dossier.ds.md
 
 ```
 User Command:
-dossier-verify https://example.com/dossier.ds.md
+ai-dossier verify https://example.com/dossier.ds.md
          ↓
     Download/Read File
          ↓
@@ -357,23 +357,29 @@ Exit 0 (safe) or 1 (unsafe)
 
 ## Roadmap
 
-### v0.1.0 (Current)
+### v0.1.0
 - ✅ Basic checksum verification
 - ✅ Signature presence detection
 - ✅ Exit code support
 - ✅ URL download support
 
-### v0.2.0 (Next)
-- ⏳ Full minisign signature verification
-- ⏳ Trusted keys management (~/.dossier/trusted-keys.txt)
-- ⏳ --run flag implementation
-- ⏳ Better error messages
+### v0.2.0
+- ✅ Multi-command CLI structure (`ai-dossier run`, `create`, `list`, `sign`, `publish`, etc.)
+- ✅ Full minisign signature verification
+- ✅ Registry integration (publish, list, install-skill)
+- ✅ Better error messages
 
-### v0.3.0 (Future)
-- ⏳ Interactive trust prompts
-- ⏳ Key import/export
-- ⏳ Signature verification caching
-- ⏳ JSON output mode (for tooling)
+### v0.3.0
+- ✅ Renamed binary from `dossier-verify` to `ai-dossier`
+- ✅ Comprehensive test suite (261+ tests)
+- ✅ JSON output mode (`--json` flag)
+- ✅ Interactive trust prompts
+
+### v0.4.x (Current — v0.4.1)
+- ✅ `--agent` flag for machine-readable capability manifest
+- ✅ `commands` command for JSON inventory of all CLI commands
+- ✅ Non-TTY stdin detection and graceful failure
+- ✅ CDN propagation warnings after publish/remove
 
 ### v1.0.0 (Stable)
 - ⏳ Complete signature verification
@@ -392,10 +398,10 @@ cd cli
 npm link  # For local testing
 
 # Test
-dossier-verify ../examples/devops/deploy-to-aws.ds.md
+ai-dossier verify ../examples/devops/deploy-to-aws.ds.md
 
 # Test with malicious example
-dossier-verify ../examples/security/validate-project-config.ds.md
+ai-dossier verify ../examples/security/validate-project-config.ds.md
 ```
 
 ### Adding Features

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -58,7 +58,7 @@ I want to use the dossier automation system. First, learn about it:
 
 1. Read README.md to understand what dossiers are
 2. Read one example: examples/devops/deploy-to-aws.md
-3. Read PROTOCOL.md to understand execution protocol
+3. Read docs/reference/protocol.md to understand execution protocol
 
 Then help me list and execute dossiers in this project.
 ```
@@ -122,11 +122,24 @@ The AI will follow the dossier instructions, adapt to your project, and execute 
 
 ---
 
-### Path 3: I Want Zero Friction 🚀 (Future)
+### Path 3: I Want Zero Friction 🚀
 
-**Coming Soon**: MCP Server for Claude Desktop and other MCP-compatible tools
+**Available Now**: MCP Server for Claude Desktop and other MCP-compatible tools
 
-With the MCP server, you can simply say:
+Add to `~/.claude/settings.local.json`:
+
+```json
+{
+  "mcpServers": {
+    "dossier": {
+      "command": "npx",
+      "args": ["-y", "@ai-dossier/mcp-server"]
+    }
+  }
+}
+```
+
+Then simply say:
 
 ```
 "Use the project-init dossier"
@@ -138,9 +151,9 @@ And it just works! The AI automatically:
 - Reads the content
 - Executes following the protocol
 
-**Status**: Specification complete, implementation in progress.
+**Status**: ✅ Published to npm — `npx -y @ai-dossier/mcp-server`
 
-📚 See [mcp-server/README.md](./mcp-server/README.md) for details and contribute!
+📚 See [mcp-server/README.md](../../mcp-server/README.md) for details.
 
 ---
 
@@ -268,7 +281,7 @@ Read [PROTOCOL.md](../reference/protocol.md) to learn about:
 
 ```
 # Best practice: Have AI learn once per project
-"Read README.md and PROTOCOL.md to learn about dossiers.
+"Read README.md and docs/reference/protocol.md to learn about dossiers.
 Then find and list all dossiers in this project."
 
 # Then you can just reference by name
@@ -329,7 +342,7 @@ working on the authentication feature."
 
 ```
 "Execute this dossier following the Dossier Execution Protocol
-defined in PROTOCOL.md. This includes:
+defined in docs/reference/protocol.md. This includes:
 - Pre-execution analysis
 - Context gathering
 - Decision points
@@ -407,10 +420,10 @@ diagnose the issue. Then propose a fix."
 │   Edit: Objective, Prerequisites, Actions, Validation      │
 ├─────────────────────────────────────────────────────────────┤
 │ KEY FILES                                                   │
-│   README.md        - Dossier concept overview              │
-│   FAQ.md           - Common objections & comparisons       │
-│   SPECIFICATION.md - How to create dossiers                │
-│   PROTOCOL.md      - How to execute dossiers               │
+│   README.md                    - Dossier concept overview  │
+│   docs/explanation/faq.md      - Common objections         │
+│   docs/reference/specification.md - How to create dossiers │
+│   docs/reference/protocol.md  - How to execute dossiers    │
 │   examples/        - Real-world examples                    │
 └─────────────────────────────────────────────────────────────┘
 ```


### PR DESCRIPTION
## Summary

Fixes all 7 documentation contradictions identified in #87:

- **Quick Start Path 3**: MCP server is now published to npm (`@ai-dossier/mcp-server`), not "Coming Soon"
- **ARCHITECTURE.md**: Replaced incorrect YAML frontmatter example with the actual `---dossier` JSON format; updated CLI command from `dossier-verify` to `ai-dossier verify`
- **CLI README**: Replaced all `dossier-verify` binary references with `ai-dossier verify`; updated roadmap from v0.1.0 "Current" to v0.4.1 "Current"
- **Quick Start**: Updated `PROTOCOL.md` and `SPECIFICATION.md` root references to correct `docs/reference/` paths
- **Main README**: Fixed `cd dossier` → `cd ai-dossier`; updated CLI verification command from `cli/bin/dossier-verify` to `npx @ai-dossier/cli verify`
- **CHANGELOG**: Added entries for v0.3.0, v0.4.0, and v0.4.1 (previously only documented up to v0.2.1)

## Test plan

- [ ] Verify all changed links resolve to existing files in the repo
- [ ] Confirm MCP server setup instructions match `mcp-server/README.md`
- [ ] Confirm `ai-dossier verify` is the correct binary invocation (`cli/package.json` bin field)
- [ ] Confirm `docs/reference/protocol.md` and `docs/reference/specification.md` exist

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)