### PR TITLE
docs(core): add API documentation for @ai-dossier/core

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -10,8 +10,8 @@ Technical specifications and reference material for the Dossier project.
 
 ## API & CLI Reference
 
+- [Core API Reference](core-api.md) - `@ai-dossier/core` library API documentation
 - [CLI Reference](cli.md) *(coming soon)* - Command-line tool options and usage
-- [API Reference](api.md) *(coming soon)* - Core library API documentation
 
 ## File Formats
 

--- a/docs/reference/core-api.md
+++ b/docs/reference/core-api.md
@@ -1,0 +1,498 @@
+# Core API Reference
+
+Complete API reference for `@ai-dossier/core` — the programmatic library for parsing, verifying, linting, and formatting dossier files.
+
+```bash
+npm install @ai-dossier/core
+```
+
+## Parsing
+
+### `parseDossierContent(content: string): ParsedDossier`
+
+Parse a dossier content string into structured data. Supports both `---dossier` (JSON/YAML) and standard `---` (YAML) frontmatter delimiters.
+
+**Parameters:**
+- `content` — Raw dossier file content as a string
+
+**Returns:** `ParsedDossier` — `{ frontmatter, body, raw }`
+
+**Throws:** `Error` if content is empty, not a string, or has no valid frontmatter delimiters.
+
+```typescript
+import { parseDossierContent } from '@ai-dossier/core';
+
+const raw = `---dossier
+{
+  "dossier_schema_version": "1.0.0",
+  "title": "Deploy API",
+  "version": "1.0.0",
+  "status": "Stable",
+  "risk_level": "medium"
+}
+---
+
+## Steps
+1. Run migrations
+2. Deploy containers
+`;
+
+const { frontmatter, body } = parseDossierContent(raw);
+console.log(frontmatter.title);      // "Deploy API"
+console.log(frontmatter.risk_level); // "medium"
+console.log(body);                   // "\n## Steps\n1. Run migrations\n..."
+```
+
+### `parseDossierFile(filePath: string): ParsedDossier`
+
+Read a dossier file from disk and parse it.
+
+**Parameters:**
+- `filePath` — Path to the `.ds.md` file
+
+**Throws:** `Error` if the file does not exist.
+
+```typescript
+import { parseDossierFile } from '@ai-dossier/core';
+
+const dossier = parseDossierFile('./deploy.ds.md');
+```
+
+### `validateFrontmatter(frontmatter: DossierFrontmatter): string[]`
+
+Validate required frontmatter fields and enum values.
+
+**Required fields:** `dossier_schema_version`, `title`, `version`
+
+**Validated enums:**
+- `status` — `"Draft"`, `"Stable"`, `"Deprecated"`, `"Experimental"`
+- `risk_level` — `"low"`, `"medium"`, `"high"`, `"critical"`
+
+**Returns:** Array of error message strings. Empty array means valid.
+
+```typescript
+import { validateFrontmatter } from '@ai-dossier/core';
+
+const errors = validateFrontmatter(dossier.frontmatter);
+if (errors.length > 0) {
+  errors.forEach(e => console.error(e));
+  // "Missing required field: dossier_schema_version"
+}
+```
+
+### Constants
+
+| Constant | Value |
+|---|---|
+| `REQUIRED_FIELDS` | `['dossier_schema_version', 'title', 'version']` |
+| `RECOMMENDED_FIELDS` | `['objective', 'risk_level', 'status']` |
+| `VALID_STATUSES` | `['Draft', 'Stable', 'Deprecated', 'Experimental']` |
+| `VALID_RISK_LEVELS` | `['low', 'medium', 'high', 'critical']` |
+
+---
+
+## Checksum Verification
+
+### `calculateChecksum(body: string): string`
+
+Calculate the SHA-256 hash of the dossier body (everything after the closing `---` delimiter).
+
+**Returns:** Hex-encoded SHA-256 hash string.
+
+```typescript
+import { calculateChecksum } from '@ai-dossier/core';
+
+const hash = calculateChecksum(dossier.body);
+// "a1b2c3d4..."
+```
+
+### `verifyIntegrity(body: string, expectedHash: string | undefined): IntegrityResult`
+
+Compare the computed body hash against the expected checksum.
+
+**Returns:** `IntegrityResult`
+
+| `status` | Meaning |
+|---|---|
+| `"valid"` | Hash matches — content is untampered |
+| `"invalid"` | Hash mismatch — content was modified |
+| `"missing"` | No checksum in frontmatter |
+
+```typescript
+import { verifyIntegrity } from '@ai-dossier/core';
+
+const result = verifyIntegrity(body, frontmatter.checksum?.hash);
+if (result.status === 'invalid') {
+  console.error('Tampered!', result.expectedHash, '!=', result.actualHash);
+}
+```
+
+---
+
+## Signature Verification
+
+### `verifySignature(content: string, signature: SignatureResult): Promise<VerifyResult>`
+
+Verify a signature using the built-in verifier registry. Automatically selects the appropriate verifier based on `signature.algorithm`.
+
+**Returns:** `Promise<VerifyResult>` — `{ valid: boolean, error?: string }`
+
+```typescript
+import { verifySignature } from '@ai-dossier/core';
+
+const result = await verifySignature(body, frontmatter.signature);
+if (result.valid) {
+  console.log('Signature verified');
+}
+```
+
+### `verifyWithEd25519(content: string, signature: string, publicKey: string): VerifyResult`
+
+Verify an Ed25519 signature directly.
+
+**Parameters:**
+- `content` — The content that was signed
+- `signature` — Base64-encoded signature
+- `publicKey` — PEM-format Ed25519 public key
+
+### `verifyWithKms(content: string, signature: string, keyId: string, region?: string): Promise<VerifyResult>`
+
+Verify an ECDSA-SHA-256 signature using AWS KMS.
+
+**Parameters:**
+- `content` — The content that was signed
+- `signature` — Base64-encoded signature
+- `keyId` — AWS KMS key ARN or alias
+- `region` — AWS region (default: `"us-east-1"`)
+
+### `loadTrustedKeys(filePath?: string): Map<string, string>`
+
+Load trusted public keys from a file.
+
+**Default path:** `~/.dossier/trusted-keys.txt`
+
+**File format:**
+```
+# Comments start with #
+<public-key-pem> <key-id>
+```
+
+**Returns:** `Map<publicKey, keyId>`
+
+---
+
+## Linting
+
+### `lintDossier(content: string, config?: LintConfig): LintResult`
+
+Lint a dossier content string against built-in rules.
+
+**Built-in rules:**
+- `checksum-valid` — Checksum matches body content
+- `schema-valid` — Frontmatter conforms to dossier schema
+- `required-sections` — Mandatory sections are present
+- `semver-version` — Version is valid semver
+- `risk-level-consistency` — Risk factors align with risk level
+- `objective-quality` — Objective meets quality standards
+- `tools-check-command` — Tool commands reference valid executables
+
+```typescript
+import { lintDossier } from '@ai-dossier/core';
+
+const result = lintDossier(content);
+console.log(`${result.errorCount} errors, ${result.warningCount} warnings`);
+
+for (const d of result.diagnostics) {
+  console.log(`[${d.severity}] ${d.ruleId}: ${d.message}`);
+}
+```
+
+### `lintDossierFile(filePath: string, config?: LintConfig): LintResult`
+
+Lint a dossier file from disk.
+
+### Lint Configuration
+
+Override rule severities:
+
+```typescript
+import { lintDossier } from '@ai-dossier/core';
+import type { LintConfig } from '@ai-dossier/core';
+
+const config: LintConfig = {
+  rules: {
+    'checksum-valid': 'error',
+    'objective-quality': 'off',    // disable this rule
+    'semver-version': 'warning',
+  },
+};
+
+const result = lintDossier(content, config);
+```
+
+### Custom Rules
+
+Implement the `LintRule` interface and register it:
+
+```typescript
+import { LintRuleRegistry } from '@ai-dossier/core';
+import type { LintRule, LintRuleContext, LintDiagnostic } from '@ai-dossier/core';
+
+const myRule: LintRule = {
+  id: 'my-custom-rule',
+  description: 'Ensure title is lowercase',
+  defaultSeverity: 'warning',
+  run(context: LintRuleContext): LintDiagnostic[] {
+    if (context.frontmatter.title !== context.frontmatter.title.toLowerCase()) {
+      return [{
+        ruleId: 'my-custom-rule',
+        severity: 'warning',
+        message: 'Title should be lowercase',
+        field: 'title',
+      }];
+    }
+    return [];
+  },
+};
+
+const registry = new LintRuleRegistry();
+registry.register(myRule);
+```
+
+---
+
+## Formatting
+
+### `formatDossierContent(content: string, options?: Partial<FormatOptions>): FormatResult`
+
+Format dossier content — sort frontmatter keys and update checksum.
+
+**Options (`FormatOptions`):**
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `indent` | `number` | `2` | JSON indentation spaces |
+| `sortKeys` | `boolean` | `true` | Sort frontmatter keys alphabetically |
+| `updateChecksum` | `boolean` | `true` | Recalculate and update checksum |
+
+**Returns:** `FormatResult` — `{ formatted: string, changed: boolean }`
+
+```typescript
+import { formatDossierContent } from '@ai-dossier/core';
+
+const { formatted, changed } = formatDossierContent(rawContent);
+if (changed) {
+  console.log('Content was reformatted');
+}
+```
+
+### `formatDossierFile(filePath: string, options?: Partial<FormatOptions>): FormatResult`
+
+Format a dossier file in place. Only writes to disk if content changed.
+
+---
+
+## Signer & Verifier Interfaces
+
+Extensible interfaces for signing and verification.
+
+### `Signer` Interface
+
+```typescript
+interface Signer {
+  readonly algorithm: string;
+  sign(content: string): Promise<SignatureResult>;
+  getPublicKey(): Promise<string>;
+}
+```
+
+### `Verifier` Interface
+
+```typescript
+interface Verifier {
+  verify(content: string, signature: SignatureResult): Promise<VerifyResult>;
+  supports(algorithm: string): boolean;
+}
+```
+
+### Built-in Implementations
+
+| Class | Algorithm | Description |
+|---|---|---|
+| `Ed25519Signer` | `ed25519` | Sign with Ed25519 private key |
+| `Ed25519Verifier` | `ed25519` | Verify Ed25519 signatures |
+| `KmsSigner` | `kms-ecdsa-sha256` | Sign with AWS KMS |
+| `KmsVerifier` | `kms-ecdsa-sha256` | Verify with AWS KMS |
+
+### `VerifierRegistry`
+
+Algorithm-based dispatch for verification:
+
+```typescript
+import { getVerifierRegistry } from '@ai-dossier/core';
+
+const registry = getVerifierRegistry();
+const verifier = registry.get('ed25519');
+const result = await verifier.verify(content, signatureResult);
+```
+
+---
+
+## Types
+
+### Core Types
+
+```typescript
+interface DossierFrontmatter {
+  dossier_schema_version?: string;
+  name?: string;
+  title: string;
+  version: string;
+  status?: 'Draft' | 'Stable' | 'Deprecated' | 'Experimental';
+  risk_level?: 'low' | 'medium' | 'high' | 'critical';
+  objective?: string;
+  risk_factors?: string[];
+  destructive_operations?: string[];
+  requires_approval?: boolean;
+  checksum?: { algorithm: string; hash: string };
+  signature?: { algorithm: string; signature: string; public_key?: string; key_id?: string };
+  [key: string]: unknown;
+}
+
+interface ParsedDossier {
+  frontmatter: DossierFrontmatter;
+  body: string;
+  raw: string;
+}
+
+type DossierStatus = 'Draft' | 'Stable' | 'Deprecated' | 'Experimental';
+```
+
+### Verification Types
+
+```typescript
+interface IntegrityResult {
+  status: 'valid' | 'invalid' | 'missing';
+  message: string;
+  expectedHash?: string;
+  actualHash?: string;
+}
+
+interface AuthenticityResult {
+  status: 'verified' | 'signed_unknown' | 'unsigned' | 'invalid' | 'error';
+  message: string;
+  signer?: string;
+  keyId?: string;
+  isTrusted: boolean;
+}
+
+interface RiskAssessment {
+  riskLevel: 'low' | 'medium' | 'high' | 'critical' | 'unknown';
+  riskFactors: string[];
+  destructiveOperations: string[];
+  requiresApproval: boolean;
+}
+
+interface VerificationResult {
+  dossierFile: string;
+  integrity: IntegrityResult;
+  authenticity: AuthenticityResult;
+  riskAssessment: RiskAssessment;
+  recommendation: 'ALLOW' | 'WARN' | 'BLOCK';
+  message: string;
+  errors: string[];
+}
+
+interface TrustedKey {
+  publicKey: string;
+  keyId: string;
+}
+
+interface DossierListItem {
+  name: string;
+  path: string;
+  version: string;
+  protocol: string;
+  status: string;
+  objective: string;
+  riskLevel: string;
+}
+```
+
+### Signing Types
+
+```typescript
+interface SignatureResult {
+  algorithm: string;
+  signature: string;
+  public_key: string;
+  key_id?: string;
+  signed_by?: string;
+  signed_at: string;
+}
+
+interface VerifyResult {
+  valid: boolean;
+  error?: string;
+}
+```
+
+### Lint Types
+
+```typescript
+type LintSeverity = 'error' | 'warning' | 'info';
+
+interface LintDiagnostic {
+  ruleId: string;
+  severity: LintSeverity;
+  message: string;
+  field?: string;
+}
+
+interface LintResult {
+  file?: string;
+  diagnostics: LintDiagnostic[];
+  errorCount: number;
+  warningCount: number;
+  infoCount: number;
+}
+
+interface LintRule {
+  id: string;
+  description: string;
+  defaultSeverity: LintSeverity;
+  run(context: LintRuleContext): LintDiagnostic[];
+}
+
+interface LintConfig {
+  rules: Record<string, LintSeverity | 'off'>;
+}
+```
+
+### Format Types
+
+```typescript
+interface FormatOptions {
+  indent: number;      // default: 2
+  sortKeys: boolean;   // default: true
+  updateChecksum: boolean; // default: true
+}
+
+interface FormatResult {
+  formatted: string;
+  changed: boolean;
+}
+```
+
+---
+
+## Utility Exports
+
+| Function | Description |
+|---|---|
+| `sha256Hash(content)` | SHA-256 as `Buffer` |
+| `sha256Hex(content)` | SHA-256 as hex string |
+| `getErrorMessage(err)` | Extract error message safely |
+| `getErrorStack(err)` | Extract error stack safely |
+| `readFileIfExists(path)` | Read file or return `undefined` |
+| `createDefaultVerificationResult(file)` | Create a default `VerificationResult` |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,63 +8,223 @@ Core parsing, verification, and linting logic for the [Dossier](https://github.c
 npm install @ai-dossier/core
 ```
 
+Requires Node.js >= 18.0.0.
+
+## Quick Start
+
+```typescript
+import {
+  parseDossierContent,
+  verifyIntegrity,
+  lintDossier,
+} from '@ai-dossier/core';
+
+// 1. Parse a dossier
+const dossier = parseDossierContent(rawContent);
+console.log(dossier.frontmatter.title); // => "My Dossier"
+
+// 2. Verify integrity
+const integrity = verifyIntegrity(
+  dossier.body,
+  dossier.frontmatter.checksum?.hash
+);
+console.log(integrity.status); // => "valid" | "invalid" | "missing"
+
+// 3. Lint for issues
+const result = lintDossier(rawContent);
+console.log(result.errorCount, result.warningCount);
+```
+
 ## API
 
 ### Parsing
 
 ```typescript
-import { parseDossierContent, parseDossierFile, validateFrontmatter } from '@ai-dossier/core';
+import {
+  parseDossierContent,
+  parseDossierFile,
+  validateFrontmatter,
+} from '@ai-dossier/core';
+```
 
-// Parse dossier content string
-const { frontmatter, body } = parseDossierContent(content);
+#### `parseDossierContent(content: string): ParsedDossier`
 
-// Parse from file path
-const parsed = parseDossierFile('./my-dossier.ds.md');
+Parse a dossier content string into frontmatter and body. Accepts both `---dossier` (JSON/YAML) and standard `---` (YAML) delimiters.
 
-// Validate required fields
+```typescript
+const { frontmatter, body, raw } = parseDossierContent(content);
+```
+
+#### `parseDossierFile(filePath: string): ParsedDossier`
+
+Read and parse a dossier file from disk.
+
+```typescript
+const parsed = parseDossierFile('./path/to/dossier.ds.md');
+```
+
+#### `validateFrontmatter(frontmatter: DossierFrontmatter): string[]`
+
+Validate required fields and enum values. Returns an array of error messages (empty if valid).
+
+```typescript
 const errors = validateFrontmatter(parsed.frontmatter);
+if (errors.length > 0) {
+  console.error('Validation errors:', errors);
+}
 ```
 
 ### Checksum Verification
 
 ```typescript
 import { calculateChecksum, verifyIntegrity } from '@ai-dossier/core';
+```
 
-const hash = calculateChecksum(body);
-const isValid = verifyIntegrity(body, expectedHash);
+#### `calculateChecksum(body: string): string`
+
+Calculate the SHA-256 hash of dossier body content (excluding frontmatter).
+
+#### `verifyIntegrity(body: string, expectedHash: string | undefined): IntegrityResult`
+
+Compare the computed hash against the expected hash from frontmatter.
+
+```typescript
+const result = verifyIntegrity(body, frontmatter.checksum?.hash);
+// result.status: "valid" | "invalid" | "missing"
 ```
 
 ### Signature Verification
 
 ```typescript
-import { verifySignature, verifyWithEd25519, loadTrustedKeys } from '@ai-dossier/core';
-
-// Verify using trusted keys
-const result = await verifySignature(frontmatter, body);
-
-// Verify with a specific Ed25519 public key
-const valid = verifyWithEd25519(data, signature, publicKeyPem);
+import {
+  verifySignature,
+  verifyWithEd25519,
+  verifyWithKms,
+  loadTrustedKeys,
+} from '@ai-dossier/core';
 ```
+
+#### `verifySignature(content: string, signature: SignatureResult): Promise<VerifyResult>`
+
+Verify a signature using the verifier registry. Automatically selects the correct verifier based on `signature.algorithm`.
+
+```typescript
+const result = await verifySignature(body, frontmatter.signature);
+console.log(result.valid); // true | false
+```
+
+#### `verifyWithEd25519(content: string, signature: string, publicKey: string): VerifyResult`
+
+Verify an Ed25519 signature directly.
+
+#### `verifyWithKms(content: string, signature: string, keyId: string, region?: string): Promise<VerifyResult>`
+
+Verify an ECDSA-SHA-256 signature using AWS KMS.
+
+#### `loadTrustedKeys(filePath?: string): Map<string, string>`
+
+Load trusted public keys from a file (default: `~/.dossier/trusted-keys.txt`). Returns a map of public key to key ID.
 
 ### Linting
 
 ```typescript
 import { lintDossier, lintDossierFile } from '@ai-dossier/core';
-
-const results = lintDossier(content);
-// or
-const results = lintDossierFile('./my-dossier.ds.md');
 ```
+
+#### `lintDossier(content: string, config?: LintConfig): LintResult`
+
+Lint dossier content against built-in rules (checksum validity, schema validation, required sections, semver version, etc.).
+
+```typescript
+const result = lintDossier(content);
+for (const d of result.diagnostics) {
+  console.log(`[${d.severity}] ${d.ruleId}: ${d.message}`);
+}
+```
+
+#### `lintDossierFile(filePath: string, config?: LintConfig): LintResult`
+
+Lint a dossier file from disk.
 
 ### Formatting
 
 ```typescript
-import { formatDossierContent } from '@ai-dossier/core';
+import { formatDossierContent, formatDossierFile } from '@ai-dossier/core';
+```
 
-const { content, changed } = formatDossierContent(rawContent, {
+#### `formatDossierContent(content: string, options?: Partial<FormatOptions>): FormatResult`
+
+Format dossier content (sort keys, update checksum). Returns `{ formatted, changed }`.
+
+```typescript
+const { formatted, changed } = formatDossierContent(rawContent, {
   sortKeys: true,
   updateChecksum: true,
 });
+```
+
+#### `formatDossierFile(filePath: string, options?: Partial<FormatOptions>): FormatResult`
+
+Format a dossier file in place. Only writes if changes were made.
+
+### Signer/Verifier Interfaces
+
+The package exports extensible interfaces for signing and verification:
+
+```typescript
+import type { Signer, Verifier, SignatureResult, VerifyResult } from '@ai-dossier/core';
+```
+
+Built-in implementations:
+- `Ed25519Signer` / `Ed25519Verifier` — Ed25519 key pair signing
+- `KmsSigner` / `KmsVerifier` — AWS KMS ECDSA-SHA-256 signing
+
+Registry for algorithm dispatch:
+```typescript
+import { getVerifierRegistry, VerifierRegistry } from '@ai-dossier/core';
+
+const registry = getVerifierRegistry();
+const verifier = registry.get('ed25519');
+const result = await verifier.verify(content, signature);
+```
+
+## Types
+
+All TypeScript types are exported from the package root:
+
+```typescript
+import type {
+  // Core types
+  DossierFrontmatter,   // Frontmatter fields (title, version, checksum, signature, ...)
+  ParsedDossier,        // { frontmatter, body, raw }
+  DossierStatus,        // "Draft" | "Stable" | "Deprecated" | "Experimental"
+  DossierListItem,      // Summary for listing dossiers
+
+  // Verification
+  IntegrityResult,      // Checksum verification result
+  AuthenticityResult,   // Signature verification result
+  RiskAssessment,       // Risk level, factors, destructive ops
+  VerificationResult,   // Combined verification report
+  TrustedKey,           // { publicKey, keyId }
+
+  // Signing
+  Signer,               // Sign interface
+  Verifier,             // Verify interface
+  SignatureResult,       // Signature metadata
+  VerifyResult,          // { valid, error? }
+  VerifierRegistry,     // Algorithm → verifier dispatch
+
+  // Linting
+  LintResult,           // { diagnostics, errorCount, warningCount, infoCount }
+  LintDiagnostic,       // { ruleId, severity, message, field? }
+  LintRule,             // Custom rule interface
+  LintConfig,           // { rules: Record<string, severity> }
+  LintSeverity,         // "error" | "warning" | "info"
+
+  // Formatting
+  FormatOptions,        // { indent, sortKeys, updateChecksum }
+  FormatResult,         // { formatted, changed }
+} from '@ai-dossier/core';
 ```
 
 ## License


### PR DESCRIPTION
## Summary
- Rewrote `packages/core/README.md` with quick start, per-function API docs, parameter/return types, and full type catalog
- Created `docs/reference/core-api.md` with comprehensive API reference including code examples for parse, verify, lint, format, and signer/verifier interfaces
- Updated `docs/reference/README.md` to link to the new core API page

Closes #89

## Test plan
- Verify README renders correctly on GitHub and npm
- Verify docs/reference/core-api.md renders with correct markdown tables and code blocks
- Confirm all documented function signatures match actual exports in `src/index.ts`

Co-Authored-By: Claude <noreply@anthropic.com>