### PR TITLE
fix(publish): use registry API for collision check, not cached CDN

### DIFF
--- a/cli/src/commands/publish.ts
+++ b/cli/src/commands/publish.ts
@@ -106,13 +106,13 @@ export function registerPublishCommand(program: Command): void {
         const fullPath = `${namespace}/${name}`;
         const registryPath = `${fullPath}@${version}`;
 
-        // Pre-publish existence check
+        // Pre-publish existence check — version-specific via registry API
         const client = getClient(credentials.token);
         let existingVersion: string | null = null;
         let versionExists = false;
         try {
           const existing = (await client.getDossier(fullPath, version)) as any;
-          if (existing) {
+          if (existing && existing.version === version) {
             versionExists = true;
           }
         } catch {

--- a/registry/api/v1/dossiers/[...name].js
+++ b/registry/api/v1/dossiers/[...name].js
@@ -31,15 +31,8 @@ module.exports = async (req, res) => {
   }
 
   try {
-    // Fetch manifest to find the dossier
-    const manifestUrl = config.getManifestUrl();
-    const response = await fetch(manifestUrl);
-
-    if (!response.ok) {
-      throw new Error(`Failed to fetch manifest: ${response.status}`);
-    }
-
-    const manifest = await response.json();
+    // Fetch manifest via GitHub API (not raw.githubusercontent.com) to avoid stale cache
+    const manifest = await github.getManifest();
     const dossier = manifest.dossiers.find((d) => d.name === dossierName);
 
     if (!dossier) {
@@ -47,6 +40,16 @@ module.exports = async (req, res) => {
         error: {
           code: 'DOSSIER_NOT_FOUND',
           message: `Dossier '${dossierName}' not found`,
+        },
+      });
+    }
+
+    // If a specific version was requested, verify it matches
+    if (version && dossier.version !== version) {
+      return res.status(404).json({
+        error: {
+          code: 'VERSION_NOT_FOUND',
+          message: `Dossier '${dossierName}' version '${version}' not found (latest: ${dossier.version})`,
         },
       });
     }


### PR DESCRIPTION
## Summary

- **Registry**: Switched GET handler from `raw.githubusercontent.com` (cached ~5min) to `github.getManifest()` (uncached GitHub API), so dossier lookups always reflect the current state of the manifest
- **Registry**: Added version-specific filtering — the `?version=` query param was previously ignored, now returns 404 if the requested version doesn't match
- **CLI**: Added defense-in-depth check verifying the returned version matches the one being published

Closes #140

## Test plan
- [ ] `remove` a dossier, then `publish` the same name — should succeed
- [ ] `publish` an existing version — should still be blocked with collision error  
- [ ] `publish` a different version of an existing dossier — should succeed
- [ ] Registry tests pass (`npx jest` in `registry/`)
- [ ] CLI builds clean (`npm run build`)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>