### PR TITLE
docs: fix documentation staleness and contradictions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,14 +23,14 @@ Dossier is a lightweight automation standard built on three principles:
 
 ### Core Library (`@ai-dossier/core`)
 Shared verification and parsing logic used by all tools. Handles:
-- Dossier parsing (YAML frontmatter + Markdown body)
+- Dossier parsing (JSON frontmatter + Markdown body)
 - SHA256 checksum verification
 - Signature verification (Minisign, AWS KMS)
 
 ### CLI Tool (`@ai-dossier/cli`)
 Command-line verification tool for end users:
 ```bash
-dossier-verify <file-or-url>
+ai-dossier verify <file-or-url>
 ```
 
 ### MCP Server (`@ai-dossier/mcp-server`)
@@ -38,14 +38,18 @@ Model Context Protocol integration for AI agents like Claude Code.
 
 ## File Format
 
-Dossiers are Markdown files with YAML frontmatter:
+Dossiers are Markdown files with JSON frontmatter using the `---dossier` delimiter:
 
 ```markdown
----
-title: Example Dossier
-version: "1.0.0"
-checksum: "sha256:abc123..."
-signature: "minisign:xyz789..."
+---dossier
+{
+  "title": "Example Dossier",
+  "version": "1.0.0",
+  "checksum": {
+    "algorithm": "sha256",
+    "hash": "e3b0c44298fc1c149afbf4c8996fb924..."
+  }
+}
 ---
 
 # Instructions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [@ai-dossier/cli@0.4.1] - 2026-02-20
+
+### Fixed
+- Skip URL download in dry-run mode (#128)
+- Detect non-TTY stdin and fail gracefully instead of hanging (#107, #127)
+- Add CDN propagation warning after publish and remove (#106, #118)
+- install-skill cache validation, `--fresh` flag, and `--json` output (#117)
+
+### Changed
+- Return `VerifyResult` from crypto verification instead of bare boolean (#83, #125)
+- Use core `validateFrontmatter` and import constants from core (#119, #123)
+
+### Added
+- `--json` flag on `remove`, `whoami`, `list`, and `publish` commands (#105, #102, #121, #114)
+- `commands` command for JSON inventory of all CLI commands (#122)
+- Publish collision warning and full path output (#114)
+
+## [@ai-dossier/cli@0.4.0] - 2026-01-15
+
+### Added
+- Unified dossier parser across core/cli/mcp (#81, #115)
+- Registry integration — merged dossier-registry into monorepo (#68)
+- Batch verification for dossier graphs (#71, #111)
+- Dependency graph resolver for dossier relationships (#100)
+
+### Changed
+- License changed from ELv2 to AGPL-3.0 (#129)
+- Use core library signers directly in sign command (#99)
+- Upgraded to Node 24 and ES2024 target
+
+### Fixed
+- Security vulnerabilities in dependencies (#65)
+- Biome lint enforcement on every commit and PR (#57)
+
+## [@ai-dossier/cli@0.3.0] - 2025-12-15
+
+### Added
+- Modular TypeScript migration from monolithic CLI (#54, #59)
+- Comprehensive test suite with 261+ tests (#47, #62)
+- CLI parity with dossier-tools (#61, #63, #64)
+- npm CI/CD publishing under `@ai-dossier` scope (#48)
+
+### Changed
+- Package scope: `@imboard-ai/*` → `@ai-dossier/*`
+- Default registry URL updated to `dossier-registry.vercel.app`
+
 ## [@imboard-ai/dossier-cli@0.2.1] - 2025-11-15
 
 ### Added
@@ -147,7 +193,10 @@ git log --oneline
 
 For detailed publishing instructions, see [docs/guides/publishing-packages.md](docs/guides/publishing-packages.md).
 
-[Unreleased]: https://github.com/imboard-ai/dossier/compare/v0.1.0...HEAD
-[@dossier/core@1.0.0]: https://github.com/imboard-ai/dossier/releases/tag/v1.0.0
-[@dossier/cli@0.1.0]: https://github.com/imboard-ai/dossier/releases/tag/v0.1.0
-[@dossier/mcp-server@1.0.0]: https://github.com/imboard-ai/dossier/releases/tag/v1.0.0
+[Unreleased]: https://github.com/imboard-ai/ai-dossier/compare/v0.4.1...HEAD
+[@ai-dossier/cli@0.4.1]: https://github.com/imboard-ai/ai-dossier/compare/v0.4.0...v0.4.1
+[@ai-dossier/cli@0.4.0]: https://github.com/imboard-ai/ai-dossier/compare/v0.3.0...v0.4.0
+[@ai-dossier/cli@0.3.0]: https://github.com/imboard-ai/ai-dossier/compare/v0.2.1...v0.3.0
+[@dossier/core@1.0.0]: https://github.com/imboard-ai/ai-dossier/releases/tag/v1.0.0
+[@dossier/cli@0.1.0]: https://github.com/imboard-ai/ai-dossier/releases/tag/v0.1.0
+[@dossier/mcp-server@1.0.0]: https://github.com/imboard-ai/ai-dossier/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ Use GitHub Discussions for:
    ```bash
    cd cli
    npm test  # If tests are available
-   node bin/dossier-verify.js --help
+   npx ai-dossier verify --help
    ```
 
 5. **Test the MCP server** (requires Claude Code):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Use GitHub Discussions for:
 1. **Clone the repository**:
    ```bash
    git clone https://github.com/imboard-ai/ai-dossier.git
-   cd dossier
+   cd ai-dossier
    ```
 
 2. **Install dependencies** (for CLI and MCP server):

--- a/README.md
+++ b/README.md
@@ -66,9 +66,8 @@ Verify dossier security before execution:
 ```bash
 # Clone the repo and use the CLI verification tool
 git clone https://github.com/imboard-ai/ai-dossier.git
-cd dossier
-chmod +x cli/bin/dossier-verify
-cli/bin/dossier-verify examples/git-project-review/atomic/readme-reality-check.ds.md
+cd ai-dossier
+npx @ai-dossier/cli verify examples/git-project-review/atomic/readme-reality-check.ds.md
 ```
 
 ---
@@ -144,7 +143,7 @@ https://raw.githubusercontent.com/imboard-ai/ai-dossier/main/examples/git-projec
 
 ## Security & Verification
 
-- Use the CLI tool (`cli/bin/dossier-verify`) to verify checksums/signatures before execution
+- Use the CLI tool (`ai-dossier verify`) to verify checksums/signatures before execution
 - Prefer MCP mode for sandboxed, permissioned operations
 - See [SECURITY_STATUS.md](./SECURITY_STATUS.md) for current guarantees and limitations
 

--- a/SECURITY_STATUS.md
+++ b/SECURITY_STATUS.md
@@ -87,14 +87,14 @@ That was wrong. Security cannot be delegated to LLMs - it must be enforced by co
 
 ### Short-Term (3-6 months)
 
-**Command-Line Tool**: `dossier-verify`
+**Command-Line Tool**: `ai-dossier verify`
 ```bash
 # Verify before executing
-dossier-verify https://example.com/dossier.ds.md
+ai-dossier verify https://example.com/dossier.ds.md
 # Exit code 0 = safe, 1 = unsafe
 
 # Verify and run (enforces verification)
-dossier-verify --run https://example.com/dossier.ds.md
+ai-dossier verify --run https://example.com/dossier.ds.md
 ```
 
 **Platform Support**: Advocate for native dossier support in:
@@ -160,7 +160,7 @@ This would let MCP servers intercept file access and enforce verification.
 
 ## 3. What We're Providing Today
 
-### Command-Line Tool: `dossier-verify`
+### Command-Line Tool: `ai-dossier verify`
 
 **Install**:
 ```bash
@@ -170,18 +170,18 @@ npm install -g @ai-dossier/cli
 **Usage**:
 ```bash
 # Verify a dossier (exit 0 = safe, 1 = unsafe)
-dossier-verify path/to/dossier.ds.md
-dossier-verify https://example.com/dossier.ds.md
+ai-dossier verify path/to/dossier.ds.md
+ai-dossier verify https://example.com/dossier.ds.md
 
 # Verify and display report
-dossier-verify --verbose path/to/dossier.ds.md
+ai-dossier verify --verbose path/to/dossier.ds.md
 
 # Verify and run (enforces verification)
-dossier-verify --run path/to/dossier.ds.md
+ai-dossier verify --run path/to/dossier.ds.md
 
 # Pass to your LLM tool only if verification passes
-dossier-verify https://example.com/dossier.ds.md && \
-  claude-code "run $(dossier-verify --output-path)"
+ai-dossier verify https://example.com/dossier.ds.md && \
+  claude-code "run $(ai-dossier verify --output-path)"
 ```
 
 **What it does**:
@@ -198,7 +198,7 @@ dossier-verify https://example.com/dossier.ds.md && \
 ```bash
 # Add to your shell profile
 claude-run-dossier() {
-  dossier-verify "$1" && claude-code "run $1"
+  ai-dossier verify "$1" && claude-code "run $1"
 }
 
 # Then use:
@@ -208,7 +208,7 @@ claude-run-dossier https://example.com/dossier.ds.md
 **Cursor**:
 ```bash
 cursor-run-dossier() {
-  dossier-verify "$1" && cursor "run $1"
+  ai-dossier verify "$1" && cursor "run $1"
 }
 ```
 
@@ -218,7 +218,7 @@ safe-run-dossier() {
   local url="$1"
   local tool="${2:-claude-code}"  # Default to claude-code
 
-  if dossier-verify "$url"; then
+  if ai-dossier verify "$url"; then
     "$tool" "run $url"
   else
     echo "❌ Security verification failed. Dossier not executed."
@@ -302,7 +302,7 @@ As the dossier standard gains adoption, security enforcement will improve throug
 **Security Level**: Low (manual, optional)
 
 #### Layer 2: Tooling Adoption (3-6 months)
-- ✅ `dossier-verify` CLI enforces verification
+- ✅ `ai-dossier verify` CLI enforces verification
 - ✅ Shell wrappers provide convenience
 - ✅ Community shares best practices
 
@@ -366,7 +366,7 @@ As the dossier standard gains adoption, security enforcement will improve throug
 
 ```bash
 # 1. Verify the dossier once
-dossier-verify https://raw.githubusercontent.com/imboard-ai/ai-dossier/main/examples/devops/deploy-to-aws.ds.md
+ai-dossier verify https://raw.githubusercontent.com/imboard-ai/ai-dossier/main/examples/devops/deploy-to-aws.ds.md
 
 # 2. If it passes, you can use it
 claude-code "run https://raw.githubusercontent.com/imboard-ai/ai-dossier/main/examples/devops/deploy-to-aws.ds.md"
@@ -403,7 +403,7 @@ safe-run-dossier https://example.com/unknown-dossier.ds.md
 curl https://example.com/dossier.ds.md > /tmp/dossier.ds.md
 
 # 2. Verify
-dossier-verify /tmp/dossier.ds.md
+ai-dossier verify /tmp/dossier.ds.md
 
 # 3. Read the code manually
 less /tmp/dossier.ds.md
@@ -499,13 +499,13 @@ New dossier to run?
 - ✅ Have valid checksums
 - ✅ Some are signed
 
-But still verify them using `dossier-verify` to build good habits.
+But still verify them using `ai-dossier verify` to build good habits.
 
 ### Q: What if my LLM tool doesn't have MCP support?
 
-**A**: Use the command-line `dossier-verify` tool:
+**A**: Use the command-line `ai-dossier verify` tool:
 ```bash
-dossier-verify URL && your-tool "run URL"
+ai-dossier verify URL && your-tool "run URL"
 ```
 
 This works with ANY LLM tool.
@@ -533,7 +533,7 @@ Timeline: 6-12 months for major platform support.
 **A**: Be honest:
 - ✅ Dossiers are powerful for automation
 - ⚠️ Security requires active verification
-- ✅ Tools are available (dossier-verify)
+- ✅ Tools are available (`ai-dossier verify`)
 - ⚠️ Automatic enforcement coming later
 - ✅ Use trusted sources in the meantime
 
@@ -544,7 +544,7 @@ Timeline: 6-12 months for major platform support.
 ### For Individual Users
 
 **Today**:
-1. Install `dossier-verify` CLI (when available)
+1. Install `ai-dossier` CLI (when available)
 2. Always verify before execution
 3. Use official examples to learn
 4. Build verification into your workflow
@@ -565,7 +565,7 @@ Timeline: 6-12 months for major platform support.
 1. ✅ Establish policy: "Always verify dossiers"
 2. ✅ Use only trusted sources initially
 3. ✅ Train team on verification process
-4. ✅ Set up `dossier-verify` for all developers
+4. ✅ Set up `ai-dossier verify` for all developers
 
 **Short-term (1-3 months)**:
 1. ✅ Create organization-specific trusted keys list
@@ -624,7 +624,7 @@ We commit to:
 
 ### Contribute
 
-**Tooling**: Help build `dossier-verify` CLI
+**Tooling**: Help build `ai-dossier` CLI
 **Documentation**: Improve security guidance
 **Advocacy**: Request support from your tool vendor
 **Wrappers**: Share your enforcement scripts
@@ -652,7 +652,7 @@ We commit to:
 - 🌐 Registry and trust infrastructure
 
 **What You Should Do**:
-- ✅ Use `dossier-verify` when available
+- ✅ Use `ai-dossier verify` when available
 - ✅ Verify before execution
 - ✅ Trust known sources
 - ✅ Stay informed about updates

--- a/cli/README.md
+++ b/cli/README.md
@@ -36,8 +36,8 @@ cd cli
 npm link  # Links the CLI globally for development
 
 # Or use directly
-chmod +x bin/dossier-verify
-./bin/dossier-verify <file-or-url>
+chmod +x bin/ai-dossier
+./bin/ai-dossier verify <file-or-url>
 ```
 
 ---
@@ -74,10 +74,10 @@ Commands that require confirmation (`publish`, `remove`, `cache clean`) will fai
 
 ```bash
 # Verify local file
-dossier-verify path/to/dossier.ds.md
+ai-dossier verify path/to/dossier.ds.md
 
 # Verify remote dossier
-dossier-verify https://example.com/dossier.ds.md
+ai-dossier verify https://example.com/dossier.ds.md
 ```
 
 **Exit codes**:
@@ -88,7 +88,7 @@ dossier-verify https://example.com/dossier.ds.md
 ### Verbose Mode
 
 ```bash
-dossier-verify --verbose path/to/dossier.ds.md
+ai-dossier verify --verbose path/to/dossier.ds.md
 ```
 
 Shows:
@@ -103,7 +103,7 @@ Shows:
 ```bash
 # Shell function wrapper
 claude-run-dossier() {
-  if dossier-verify "$1"; then
+  if ai-dossier verify "$1"; then
     claude-code "The dossier at $1 has been verified. Please execute it."
   else
     echo "❌ Security verification failed. Not executing."
@@ -117,7 +117,7 @@ claude-run-dossier https://example.com/dossier.ds.md
 **Cursor**:
 ```bash
 cursor-run-dossier() {
-  if dossier-verify "$1"; then
+  if ai-dossier verify "$1"; then
     cursor "Execute the verified dossier at $1"
   else
     echo "❌ Verification failed"
@@ -132,7 +132,7 @@ safe-run-dossier() {
   local url="$1"
   local tool="${2:-claude-code}"
 
-  if dossier-verify "$url"; then
+  if ai-dossier verify "$url"; then
     echo "✅ Dossier verified. Passing to $tool..."
     "$tool" "run $url"
   else
@@ -199,7 +199,7 @@ safe-run-dossier https://example.com/dossier.ds.md cursor
 ### Example 1: Legitimate Dossier (Passes)
 
 ```bash
-$ dossier-verify examples/data-science/train-ml-model.ds.md
+$ ai-dossier verify examples/data-science/train-ml-model.ds.md
 
 🔐 Dossier Verification Tool
 
@@ -228,7 +228,7 @@ $ echo $?
 ### Example 2: Malicious Dossier (Blocked)
 
 ```bash
-$ dossier-verify https://raw.githubusercontent.com/imboard-ai/ai-dossier/main/examples/security/validate-project-config.ds.md
+$ ai-dossier verify https://raw.githubusercontent.com/imboard-ai/ai-dossier/main/examples/security/validate-project-config.ds.md
 
 🔐 Dossier Verification Tool
 
@@ -268,7 +268,7 @@ $ echo $?
 # Wrapper function for Claude Code
 claude-run-dossier() {
   echo "Verifying dossier security..."
-  if ~/projects/dossier/cli/bin/dossier-verify "$1"; then
+  if ai-dossier verify "$1"; then
     echo ""
     echo "✅ Verification passed. Executing with Claude Code..."
     claude-code "Execute the verified dossier at $1"
@@ -292,7 +292,7 @@ claude-run-dossier https://example.com/dossier.ds.md
 
 ```
 User Command:
-dossier-verify https://example.com/dossier.ds.md
+ai-dossier verify https://example.com/dossier.ds.md
          ↓
     Download/Read File
          ↓
@@ -357,23 +357,28 @@ Exit 0 (safe) or 1 (unsafe)
 
 ## Roadmap
 
-### v0.1.0 (Current)
+### v0.1.0
 - ✅ Basic checksum verification
 - ✅ Signature presence detection
 - ✅ Exit code support
 - ✅ URL download support
 
-### v0.2.0 (Next)
-- ⏳ Full minisign signature verification
-- ⏳ Trusted keys management (~/.dossier/trusted-keys.txt)
-- ⏳ --run flag implementation
-- ⏳ Better error messages
+### v0.2.0
+- ✅ Multi-command CLI structure (`ai-dossier <command>`)
+- ✅ `dossier run` command with 5-stage verification pipeline
+- ✅ LLM auto-detection and execution integration
 
-### v0.3.0 (Future)
-- ⏳ Interactive trust prompts
-- ⏳ Key import/export
-- ⏳ Signature verification caching
-- ⏳ JSON output mode (for tooling)
+### v0.3.0
+- ✅ Modular TypeScript migration
+- ✅ Comprehensive test suite (261+ tests)
+- ✅ CLI parity with dossier-tools
+- ✅ `@ai-dossier` npm scope and CI/CD publishing
+
+### v0.4.0 (Current)
+- ✅ Unified dossier parser across core/cli/mcp
+- ✅ JSON output mode (`--json` flag on commands)
+- ✅ Registry integration (publish, remove, install-skill)
+- ✅ Non-TTY stdin detection
 
 ### v1.0.0 (Stable)
 - ⏳ Complete signature verification
@@ -392,10 +397,10 @@ cd cli
 npm link  # For local testing
 
 # Test
-dossier-verify ../examples/devops/deploy-to-aws.ds.md
+ai-dossier verify ../examples/devops/deploy-to-aws.ds.md
 
 # Test with malicious example
-dossier-verify ../examples/security/validate-project-config.ds.md
+ai-dossier verify ../examples/security/validate-project-config.ds.md
 ```
 
 ### Adding Features

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -72,7 +72,7 @@ export function verifySignature(dossier: Dossier): SignatureResult
 
 **Purpose**: Command-line verification for users
 
-**Entry Point**: `bin/dossier-verify`
+**Entry Point**: `bin/ai-dossier`
 
 **Flow**:
 ```

--- a/docs/contributing/workflows.md
+++ b/docs/contributing/workflows.md
@@ -205,7 +205,7 @@ Actions → Publish Packages to GitHub Packages → Run workflow
 **Automatic Publishing (Push-based)**
 ```bash
 # Make changes to CLI
-vim cli/bin/dossier-verify
+vim cli/bin/ai-dossier
 
 # Commit and push
 git add cli/

--- a/docs/explanation/agents.md
+++ b/docs/explanation/agents.md
@@ -751,7 +751,7 @@ cd /home/yuvaldim/projects/dossier/main && git status
 ```bash
 # Clone repository
 git clone https://github.com/imboard-ai/ai-dossier.git
-cd dossier
+cd ai-dossier
 
 # Explore core documentation
 cat README.md          # Start here

--- a/docs/explanation/faq.md
+++ b/docs/explanation/faq.md
@@ -358,7 +358,7 @@ https://raw.githubusercontent.com/you/dossiers/main/deploy.ds.md
 
 **From community**:
 - ⚠️ Treat like code: review before executing
-- ✅ Use verification tools: `dossier-verify`
+- ✅ Use verification tools: `ai-dossier verify`
 - ✅ Test in safe environments first
 - ✅ Check dossier metadata (risk level, author)
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -21,7 +21,7 @@ See [installation.md](installation.md) for detailed installation instructions fo
 Once installed, try verifying an example dossier:
 
 ```bash
-dossier-verify https://raw.githubusercontent.com/imboard-ai/ai-dossier/main/examples/devops/deploy-to-aws.ds.md
+ai-dossier verify https://raw.githubusercontent.com/imboard-ai/ai-dossier/main/examples/devops/deploy-to-aws.ds.md
 ```
 
 ## Next Steps

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -37,7 +37,7 @@ These tools can read files, so they can learn about dossiers on-the-fly.
 ```bash
 # Clone this repo (has example dossiers)
 git clone https://github.com/imboard-ai/ai-dossier.git
-cd dossier
+cd ai-dossier
 ```
 
 Or add dossiers to your existing project:
@@ -122,9 +122,9 @@ The AI will follow the dossier instructions, adapt to your project, and execute 
 
 ---
 
-### Path 3: I Want Zero Friction 🚀 (Future)
+### Path 3: I Want Zero Friction 🚀 (MCP Server)
 
-**Coming Soon**: MCP Server for Claude Desktop and other MCP-compatible tools
+**Available Now**: MCP Server for Claude Code and other MCP-compatible tools
 
 With the MCP server, you can simply say:
 
@@ -138,7 +138,7 @@ And it just works! The AI automatically:
 - Reads the content
 - Executes following the protocol
 
-**Status**: Specification complete, implementation in progress.
+**Status**: MVP Complete — core security verification tools working, ready for testing.
 
 📚 See [mcp-server/README.md](./mcp-server/README.md) for details and contribute!
 
@@ -407,11 +407,11 @@ diagnose the issue. Then propose a fix."
 │   Edit: Objective, Prerequisites, Actions, Validation      │
 ├─────────────────────────────────────────────────────────────┤
 │ KEY FILES                                                   │
-│   README.md        - Dossier concept overview              │
-│   FAQ.md           - Common objections & comparisons       │
-│   SPECIFICATION.md - How to create dossiers                │
-│   PROTOCOL.md      - How to execute dossiers               │
-│   examples/        - Real-world examples                    │
+│   README.md                      - Concept overview        │
+│   PROTOCOL.md                    - Execution protocol      │
+│   docs/reference/specification.md - Dossier spec           │
+│   docs/explanation/faq.md         - FAQ & comparisons      │
+│   examples/                       - Real-world examples    │
 └─────────────────────────────────────────────────────────────┘
 ```
 

--- a/docs/guides/adopter-playbooks.md
+++ b/docs/guides/adopter-playbooks.md
@@ -20,7 +20,7 @@ Get started with dossiers in your personal projects with minimal setup.
      }
      ```
      (Replace `/path/to/dossier` with your actual cloned repo path)
-   - **Option B (CLI)**: Clone the repo and use `cli/bin/dossier-verify <dossier-path>` directly
+   - **Option B (CLI)**: Install and use `npx @ai-dossier/cli verify <dossier-path>` or `ai-dossier verify <dossier-path>` directly
 
 2. **Try the Hello Dossier example**
    - Copy the **Hello Dossier** block from the README into your LLM
@@ -77,8 +77,7 @@ Add dossiers to your open-source project to help contributors and maintainers.
      - name: Verify README reality check
        if: contains(github.event.pull_request.changed_files, 'README.md') || contains(github.event.pull_request.changed_files, 'docs/')
        run: |
-         chmod +x dossier-tools/cli/bin/dossier-verify
-         dossier-tools/cli/bin/dossier-verify dossiers/readme-reality-check.ds.md
+         npx @ai-dossier/cli verify dossiers/readme-reality-check.ds.md
      ```
 
 5. **Document dossier usage in CONTRIBUTING.md**
@@ -208,8 +207,7 @@ Create a **failure response guide** for when validations fail:
 
    - name: Verify deploy dossier
      run: |
-       chmod +x dossier-tools/cli/bin/dossier-verify
-       dossier-tools/cli/bin/dossier-verify dossiers/deploy.ds.md
+       npx @ai-dossier/cli verify dossiers/deploy.ds.md
 
    - name: Execute deploy
      run: # ... deployment steps

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -248,7 +248,7 @@ dossier-mcp-server/
 ```bash
 # Clone and install
 git clone https://github.com/imboard-ai/ai-dossier.git
-cd dossier/mcp-server
+cd ai-dossier/mcp-server
 npm install
 
 # Build


### PR DESCRIPTION
## Summary

Fixes all 7 documentation issues identified in #87:

1. **MCP "Coming Soon" → "MVP Complete"** — Quick Start Path 3 updated to reflect that the MCP server is published and working
2. **ARCHITECTURE.md checksum format** — Replaced stale YAML frontmatter example with actual `---dossier` JSON format including nested `checksum` object
3. **`dossier-verify` → `ai-dossier verify`** — Updated all user-facing docs (CLI README, main README, SECURITY_STATUS, CONTRIBUTING, Quick Start, FAQ, adopter playbooks, architecture overview). Planning/historical docs left unchanged.
4. **CLI README roadmap** — Updated from v0.1.0 "Current" to v0.4.0 with actual completed milestones for v0.2.0–v0.4.0
5. **Quick Start file references** — Fixed key files card to show actual paths (`docs/reference/specification.md`, `docs/explanation/faq.md` instead of bare `SPECIFICATION.md`, `FAQ.md`)
6. **`cd dossier` → `cd ai-dossier`** — Fixed in both main README and Quick Start
7. **CHANGELOG** — Added entries for v0.3.0, v0.4.0, and v0.4.1 based on git history

### Files changed (11)
`ARCHITECTURE.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `README.md`, `SECURITY_STATUS.md`, `cli/README.md`, `docs/architecture/overview.md`, `docs/explanation/faq.md`, `docs/getting-started/README.md`, `docs/getting-started/installation.md`, `docs/guides/adopter-playbooks.md`

## Test plan

- [ ] Verify all internal markdown links resolve correctly
- [ ] Spot-check `ai-dossier verify` command examples match actual CLI usage
- [ ] Confirm CHANGELOG entries align with git history

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)