### PR TITLE
fix(cli): type RegistryClient return values (#84)

### DIFF
--- a/cli/src/__tests__/commands/pull.test.ts
+++ b/cli/src/__tests__/commands/pull.test.ts
@@ -13,7 +13,7 @@ describe('pull command', () => {
   const mockClient = {
     getDossier: vi.fn(),
     getDossierContent: vi.fn(),
-    baseUrl: 'https://registry.example.com/api/v1',
+    getRegistryBaseUrl: () => 'https://registry.example.com',
   };
 
   beforeEach(() => {

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -67,7 +67,7 @@ export function registerCreateCommand(program: Command): void {
             const client = getClient();
             let resolvedVersion = version;
             if (!resolvedVersion) {
-              const meta = (await client.getDossier(dossierName)) as any;
+              const meta = await client.getDossier(dossierName);
               resolvedVersion = meta.version || 'latest';
             }
             const result = await client.getDossierContent(dossierName, resolvedVersion);

--- a/cli/src/commands/get.ts
+++ b/cli/src/commands/get.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import type { DossierInfo } from '../registry-client';
 import { getClient, parseNameVersion } from '../registry-client';
 
 export function registerGetCommand(program: Command): void {
@@ -10,7 +11,7 @@ export function registerGetCommand(program: Command): void {
     .action(async (nameArg: string, options: { json?: boolean }) => {
       const [dossierName, version] = parseNameVersion(nameArg);
 
-      let meta: any;
+      let meta: DossierInfo;
       try {
         const client = getClient();
         meta = await client.getDossier(dossierName, version || null);
@@ -49,7 +50,7 @@ export function registerGetCommand(program: Command): void {
       const authors = meta.authors;
       if (Array.isArray(authors) && authors.length > 0) {
         const authorStr = authors
-          .map((a: any) => (typeof a === 'string' ? a : a.name || ''))
+          .map((a) => (typeof a === 'string' ? a : a.name || ''))
           .filter(Boolean)
           .join(', ');
         if (authorStr) console.log(`   Authors      ${authorStr}`);

--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -36,7 +36,7 @@ export function registerInfoCommand(program: Command): void {
         try {
           const [dossierName, version] = parseNameVersion(fileOrName);
           const client = getClient();
-          const meta = (await client.getDossier(dossierName, version || null)) as any;
+          const meta = await client.getDossier(dossierName, version || null);
           frontmatter = meta;
           body = null;
         } catch (err: any) {

--- a/cli/src/commands/install-skill.ts
+++ b/cli/src/commands/install-skill.ts
@@ -149,7 +149,7 @@ export function registerInstallSkillCommand(program: Command): void {
           if (!content) {
             const client = getClient();
             if (!resolvedVersion) {
-              const meta = (await client.getDossier(dossierName)) as any;
+              const meta = await client.getDossier(dossierName);
               resolvedVersion = meta.version || 'latest';
             }
             const result = await client.getDossierContent(dossierName, resolvedVersion);

--- a/cli/src/commands/list.ts
+++ b/cli/src/commands/list.ts
@@ -10,6 +10,7 @@ import {
   parseDossierMetadataLocal,
   parseListSource,
 } from '../helpers';
+import type { ListDossiersResult } from '../registry-client';
 import { getClient } from '../registry-client';
 
 export function registerListCommand(program: Command): void {
@@ -36,20 +37,20 @@ export function registerListCommand(program: Command): void {
         const page = parseInt(options.page, 10) || 1;
         const perPage = parseInt(options.perPage, 10) || 20;
 
-        let registryResult: any;
+        let registryResult: ListDossiersResult;
         try {
           const client = getClient();
-          registryResult = (await client.listDossiers({
+          registryResult = await client.listDossiers({
             category: options.category,
             page,
             perPage,
-          })) as any;
+          });
         } catch (err: unknown) {
           console.error(`\n❌ Registry list failed: ${(err as Error).message}\n`);
           process.exit(1);
         }
 
-        const dossiers: any[] = registryResult.dossiers || registryResult.data || [];
+        const dossiers = registryResult.dossiers || registryResult.data || [];
 
         if (options.format === 'json') {
           console.log(JSON.stringify(registryResult, null, 2));

--- a/cli/src/commands/prompt-hook.ts
+++ b/cli/src/commands/prompt-hook.ts
@@ -35,7 +35,7 @@ export function registerPromptHookCommand(program: Command): void {
           const perPage = 100;
 
           while (true) {
-            const result = (await client.listDossiers({ page, perPage })) as any;
+            const result = await client.listDossiers({ page, perPage });
             const items = result.dossiers || result.data || [];
             for (const d of items) {
               dossiers.push({ name: d.name, title: d.title || d.name });

--- a/cli/src/commands/publish.ts
+++ b/cli/src/commands/publish.ts
@@ -111,7 +111,7 @@ export function registerPublishCommand(program: Command): void {
         let existingVersion: string | null = null;
         let versionExists = false;
         try {
-          const existing = (await client.getDossier(fullPath, version)) as any;
+          const existing = await client.getDossier(fullPath, version);
           if (existing && existing.version === version) {
             versionExists = true;
           }
@@ -144,7 +144,7 @@ export function registerPublishCommand(program: Command): void {
 
         // Check if dossier exists at any version (for overwrite warning)
         try {
-          const existing = (await client.getDossier(fullPath)) as any;
+          const existing = await client.getDossier(fullPath);
           if (existing) {
             existingVersion = existing.version || null;
           }
@@ -186,11 +186,7 @@ export function registerPublishCommand(program: Command): void {
         }
 
         try {
-          const result = (await client.publishDossier(
-            namespace,
-            content,
-            options.changelog || null
-          )) as any;
+          const result = await client.publishDossier(namespace, content, options.changelog || null);
 
           const verifyCommand = `dossier info ${fullPath}@${version}`;
           const cdnDelaySeconds = 30;

--- a/cli/src/commands/pull.ts
+++ b/cli/src/commands/pull.ts
@@ -21,7 +21,7 @@ export function registerPullCommand(program: Command): void {
 
         try {
           if (!version) {
-            const meta = (await client.getDossier(dossierName)) as any;
+            const meta = await client.getDossier(dossierName);
             version = meta.version || 'latest';
           }
 
@@ -55,7 +55,7 @@ export function registerPullCommand(program: Command): void {
               {
                 cached_at: new Date().toISOString(),
                 version,
-                source_registry_url: (client as any).baseUrl.replace(/\/api\/v1$/, ''),
+                source_registry_url: client.getRegistryBaseUrl(),
               },
               null,
               2

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -78,7 +78,7 @@ export function registerRunCommand(program: Command): void {
             const client = getClient();
             let resolvedVersion = version;
             if (!resolvedVersion) {
-              const meta = (await client.getDossier(dossierName)) as any;
+              const meta = await client.getDossier(dossierName);
               resolvedVersion = meta.version || 'latest';
             }
             const result = await client.getDossierContent(dossierName, resolvedVersion);
@@ -94,7 +94,7 @@ export function registerRunCommand(program: Command): void {
                   {
                     cached_at: new Date().toISOString(),
                     version: resolvedVersion,
-                    source_registry_url: (client as any).baseUrl.replace(/\/api\/v1$/, ''),
+                    source_registry_url: client.getRegistryBaseUrl(),
                   },
                   null,
                   2

--- a/cli/src/commands/search.ts
+++ b/cli/src/commands/search.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import type { DossierListItem } from '../registry-client';
 import { getClient } from '../registry-client';
 
 export function registerSearchCommand(program: Command): void {
@@ -31,14 +32,14 @@ export function registerSearchCommand(program: Command): void {
         const perPage = parseInt(options.perPage, 10) || 20;
         const limit = options.limit ? parseInt(options.limit, 10) : undefined;
 
-        let allDossiers: any[];
+        let allDossiers: DossierListItem[];
         try {
           const client = getClient();
-          const result = (await client.listDossiers({
+          const result = await client.listDossiers({
             category: options.category,
             page: 1,
             perPage: 100,
-          })) as any;
+          });
           allDossiers = result.dossiers || [];
         } catch (err: unknown) {
           console.error(`\n❌ Search failed: ${(err as Error).message}\n`);
@@ -49,7 +50,7 @@ export function registerSearchCommand(program: Command): void {
         const queryLower = query.toLowerCase();
         const terms = queryLower.split(/\s+/).filter(Boolean);
 
-        let matched = allDossiers.filter((d: any) => {
+        let matched = allDossiers.filter((d) => {
           const fields = [
             d.name || '',
             d.title || '',
@@ -57,23 +58,24 @@ export function registerSearchCommand(program: Command): void {
             ...(Array.isArray(d.category) ? d.category : [d.category || '']),
             ...(d.tags || []),
           ]
-            .map((f: string) => String(f).toLowerCase())
+            .map((f) => String(f).toLowerCase())
             .join(' ');
 
           return terms.every((term) => fields.includes(term) || fields.indexOf(term) !== -1);
         });
 
         // Content search: fetch body and filter by content match
+        let contentMatches: Map<string, string> | null = null;
         if (options.content) {
           const client = getClient();
           const CONCURRENCY = 5;
-          const contentMatches: Map<string, string> = new Map();
+          contentMatches = new Map();
 
           // Process in batches for concurrency limiting
           for (let i = 0; i < matched.length; i += CONCURRENCY) {
             const batch = matched.slice(i, i + CONCURRENCY);
-            const results = await Promise.all(
-              batch.map(async (d: any) => {
+            await Promise.all(
+              batch.map(async (d) => {
                 try {
                   const { content } = await client.getDossierContent(d.name, d.version || null);
                   const bodyLower = content.toLowerCase();
@@ -87,30 +89,17 @@ export function registerSearchCommand(program: Command): void {
                       (start > 0 ? '...' : '') +
                       content.slice(start, end).replace(/\n/g, ' ') +
                       (end < content.length ? '...' : '');
-                    contentMatches.set(d.name, snippet);
-                    return d;
+                    contentMatches?.set(d.name, snippet);
                   }
-                  return null;
                 } catch {
-                  return null;
+                  // Skip dossiers that fail to fetch
                 }
               })
             );
-            // We don't filter here yet; we collect results
-            for (const r of results) {
-              if (r === null) {
-                // Mark for removal
-              }
-            }
           }
 
           // Keep only dossiers that matched in content
-          matched = matched.filter((d: any) => contentMatches.has(d.name));
-
-          // Attach snippets for display
-          for (const d of matched) {
-            (d as any)._contentSnippet = contentMatches.get(d.name);
-          }
+          matched = matched.filter((d) => contentMatches?.has(d.name));
         }
 
         if (limit && limit > 0) {
@@ -149,8 +138,9 @@ export function registerSearchCommand(program: Command): void {
               description.length > 100 ? `${description.slice(0, 100)}...` : description;
             console.log(`  ${snippet}`);
           }
-          if ((d as any)._contentSnippet) {
-            console.log(`  Content match: ${(d as any)._contentSnippet}`);
+          const snippet = contentMatches?.get(d.name);
+          if (snippet) {
+            console.log(`  Content match: ${snippet}`);
           }
           console.log('');
         }

--- a/cli/src/registry-client.ts
+++ b/cli/src/registry-client.ts
@@ -33,6 +33,50 @@ interface DossierContentResult {
   digest: string | null;
 }
 
+interface DossierInfo {
+  name: string;
+  title?: string;
+  version?: string;
+  status?: string;
+  category?: string | string[];
+  risk_level?: string;
+  objective?: string;
+  description?: string;
+  authors?: Array<string | { name: string }>;
+  tags?: string[];
+  checksum?: { algorithm?: string; hash?: string };
+  signature?: { signed_by?: string; key_id?: string };
+  content_url?: string;
+}
+
+interface DossierListItem {
+  name: string;
+  title?: string;
+  description?: string;
+  objective?: string;
+  version?: string;
+  category?: string | string[];
+  tags?: string[];
+}
+
+interface ListDossiersResult {
+  dossiers?: DossierListItem[];
+  data?: DossierListItem[];
+  total?: number;
+  totalPages?: number;
+}
+
+interface PublishResult {
+  name?: string;
+  content_url?: string;
+}
+
+interface SearchResult {
+  dossiers?: DossierListItem[];
+  total?: number;
+  totalPages?: number;
+}
+
 class RegistryClient {
   private baseUrl: string;
   private token: string | null;
@@ -40,6 +84,13 @@ class RegistryClient {
   constructor(baseUrl: string, token: string | null = null) {
     this.baseUrl = `${baseUrl.replace(/\/+$/, '')}/api/v1`;
     this.token = token;
+  }
+
+  /**
+   * Get the registry base URL (without /api/v1 suffix).
+   */
+  getRegistryBaseUrl(): string {
+    return this.baseUrl.replace(/\/api\/v1$/, '');
   }
 
   /**
@@ -59,7 +110,7 @@ class RegistryClient {
   /**
    * Handle API response, throwing on errors.
    */
-  private async _handleResponse(response: Response): Promise<unknown> {
+  private async _handleResponse<T = unknown>(response: Response): Promise<T> {
     if (!response.ok) {
       let message = `Registry request failed: ${response.status} ${response.statusText}`;
       let code: string | null = null;
@@ -78,7 +129,7 @@ class RegistryClient {
       throw new RegistryError(message, response.status, code);
     }
 
-    return response.json();
+    return response.json() as Promise<T>;
   }
 
   /**
@@ -97,7 +148,7 @@ class RegistryClient {
   /**
    * List dossiers from the registry.
    */
-  async listDossiers(options: ListDossiersOptions = {}): Promise<unknown> {
+  async listDossiers(options: ListDossiersOptions = {}): Promise<ListDossiersResult> {
     const params: Record<string, unknown> = {
       page: options.page || 1,
       per_page: options.perPage || 20,
@@ -109,13 +160,13 @@ class RegistryClient {
     const response = await fetch(this._buildUrl('/dossiers', params), {
       headers: this._buildHeaders(),
     });
-    return this._handleResponse(response);
+    return this._handleResponse<ListDossiersResult>(response);
   }
 
   /**
    * Get metadata for a dossier.
    */
-  async getDossier(name: string, version: string | null = null): Promise<unknown> {
+  async getDossier(name: string, version: string | null = null): Promise<DossierInfo> {
     const params: Record<string, unknown> = {};
     if (version) {
       params.version = version;
@@ -124,7 +175,7 @@ class RegistryClient {
     const response = await fetch(this._buildUrl(`/dossiers/${name}`, params), {
       headers: this._buildHeaders(),
     });
-    return this._handleResponse(response);
+    return this._handleResponse<DossierInfo>(response);
   }
 
   /**
@@ -170,7 +221,7 @@ class RegistryClient {
   /**
    * Search dossiers.
    */
-  async searchDossiers(query: string, options: SearchOptions = {}): Promise<unknown> {
+  async searchDossiers(query: string, options: SearchOptions = {}): Promise<SearchResult> {
     const params: Record<string, unknown> = {
       q: query,
       page: options.page || 1,
@@ -180,7 +231,7 @@ class RegistryClient {
     const response = await fetch(this._buildUrl('/search', params), {
       headers: this._buildHeaders(),
     });
-    return this._handleResponse(response);
+    return this._handleResponse<SearchResult>(response);
   }
 
   /**
@@ -190,7 +241,7 @@ class RegistryClient {
     namespace: string,
     content: string,
     changelog: string | null = null
-  ): Promise<unknown> {
+  ): Promise<PublishResult> {
     const data: Record<string, string> = { namespace, content };
     if (changelog) {
       data.changelog = changelog;
@@ -201,13 +252,16 @@ class RegistryClient {
       headers: this._buildHeaders('application/json'),
       body: JSON.stringify(data),
     });
-    return this._handleResponse(response);
+    return this._handleResponse<PublishResult>(response);
   }
 
   /**
    * Delete a dossier from the registry.
    */
-  async removeDossier(name: string, version: string | null = null): Promise<unknown> {
+  async removeDossier(
+    name: string,
+    version: string | null = null
+  ): Promise<Record<string, unknown>> {
     const params: Record<string, unknown> = {};
     if (version) {
       params.version = version;
@@ -217,29 +271,29 @@ class RegistryClient {
       method: 'DELETE',
       headers: this._buildHeaders(),
     });
-    return this._handleResponse(response);
+    return this._handleResponse<Record<string, unknown>>(response);
   }
 
   /**
    * Get current user info.
    */
-  async getMe(): Promise<unknown> {
+  async getMe(): Promise<Record<string, unknown>> {
     const response = await fetch(this._buildUrl('/me'), {
       headers: this._buildHeaders(),
     });
-    return this._handleResponse(response);
+    return this._handleResponse<Record<string, unknown>>(response);
   }
 
   /**
    * Exchange OAuth code for access token.
    */
-  async exchangeCode(code: string, redirectUri: string): Promise<unknown> {
+  async exchangeCode(code: string, redirectUri: string): Promise<Record<string, unknown>> {
     const response = await fetch(this._buildUrl('/auth/token'), {
       method: 'POST',
       headers: this._buildHeaders('application/json'),
       body: JSON.stringify({ code, redirect_uri: redirectUri }),
     });
-    return this._handleResponse(response);
+    return this._handleResponse<Record<string, unknown>>(response);
   }
 }
 
@@ -275,4 +329,15 @@ export {
   getClient,
   parseNameVersion,
   DEFAULT_REGISTRY_URL,
+};
+
+export type {
+  DossierInfo,
+  DossierListItem,
+  ListDossiersResult,
+  DossierContentResult,
+  PublishResult,
+  SearchResult,
+  ListDossiersOptions,
+  SearchOptions,
 };


### PR DESCRIPTION
## Summary

- Adds typed return interfaces (`DossierInfo`, `DossierListItem`, `ListDossiersResult`, `PublishResult`, `SearchResult`) to `RegistryClient` methods, replacing all `Promise<unknown>` returns
- Makes `_handleResponse` generic (`_handleResponse<T>`) to propagate types through to callers
- Adds `getRegistryBaseUrl()` public method, replacing `(client as any).baseUrl` access in `run.ts` and `pull.ts`
- Eliminates all 13 `as any` casts from 11 command files that consume registry client results
- Refactors `search.ts` to use the existing `contentMatches` Map for display instead of mutating dossier objects with `_contentSnippet`

Closes #84

## Test plan

- [x] `tsc` builds cleanly with no type errors
- [x] All 328 CLI tests pass (39 test files)
- [x] Biome lint passes (no new warnings introduced)
- [x] No `as any` casts remain in `cli/src/commands/` related to registry client calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)