### PR TITLE
fix(cli): remove stub verification stages and unimplemented flags (#94)

### DIFF
--- a/cli/src/__tests__/commands/verify.test.ts
+++ b/cli/src/__tests__/commands/verify.test.ts
@@ -13,10 +13,7 @@ describe('verify command', () => {
   it('should exit 0 when verification passes', async () => {
     vi.mocked(helpers.runVerification).mockResolvedValue({
       passed: true,
-      stages: [
-        { stage: 1, name: 'Integrity', passed: true },
-        { stage: 2, name: 'Author Check', passed: true, demo: true },
-      ],
+      stages: [{ stage: 1, name: 'Integrity', passed: true }],
     });
 
     const program = createTestProgram();
@@ -44,11 +41,7 @@ describe('verify command', () => {
   it('should show stage details with --verbose', async () => {
     vi.mocked(helpers.runVerification).mockResolvedValue({
       passed: true,
-      stages: [
-        { stage: 1, name: 'Integrity', passed: true },
-        { stage: 2, name: 'Author Check', passed: true, demo: true },
-        { stage: 3, name: 'Dossier Check', skipped: true },
-      ],
+      stages: [{ stage: 1, name: 'Integrity', passed: true }],
     });
 
     const program = createTestProgram();
@@ -71,21 +64,13 @@ describe('verify command', () => {
     registerVerifyCommand(program);
 
     await expect(
-      program.parseAsync([
-        'node',
-        'dossier',
-        'verify',
-        'test.ds.md',
-        '--skip-checksum',
-        '--skip-risk-assessment',
-      ])
+      program.parseAsync(['node', 'dossier', 'verify', 'test.ds.md', '--skip-checksum'])
     ).rejects.toThrow();
 
     expect(helpers.runVerification).toHaveBeenCalledWith(
       'test.ds.md',
       expect.objectContaining({
         skipChecksum: true,
-        skipRiskAssessment: true,
       })
     );
   });

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -27,14 +27,7 @@ export function registerRunCommand(program: Command): void {
     .option('--fresh', 'Skip cache, fetch fresh from registry')
     .option('--pull', 'Update cache before running')
     .option('--skip-checksum', 'Skip checksum verification (DANGEROUS)')
-    .option('--skip-signature', 'Skip signature verification')
-    .option('--skip-author-check', 'Skip author whitelist/blacklist')
-    .option('--skip-dossier-check', 'Skip dossier whitelist/blacklist')
-    .option('--skip-risk-assessment', 'Skip risk level checks')
-    .option('--skip-review', 'Skip review dossier execution')
     .option('--skip-all-checks', 'Skip ALL verifications (VERY DANGEROUS)')
-    .option('--review-dossier <file>', 'Custom review dossier')
-    .option('--review-llm <name>', 'LLM for review step')
     .action(async (file: string, options: any) => {
       let resolvedFile = file;
       const isUrl = file.startsWith('http://') || file.startsWith('https://');

--- a/cli/src/commands/verify.ts
+++ b/cli/src/commands/verify.ts
@@ -10,13 +10,7 @@ export function registerVerifyCommand(program: Command): void {
     .option('--verbose', 'Show detailed verification output')
     .option('--json', 'Output result as JSON')
     .option('--skip-checksum', 'Skip checksum verification (DANGEROUS)')
-    .option('--skip-signature', 'Skip signature verification')
-    .option('--skip-author-check', 'Skip author whitelist/blacklist')
-    .option('--skip-dossier-check', 'Skip dossier whitelist/blacklist')
-    .option('--skip-risk-assessment', 'Skip risk level checks')
-    .option('--skip-review', 'Skip review dossier execution')
     .option('--skip-all-checks', 'Skip ALL verifications (VERY DANGEROUS)')
-    .option('--review-dossier <file>', 'Custom review dossier')
     .action(
       async (
         file: string,
@@ -39,8 +33,7 @@ export function registerVerifyCommand(program: Command): void {
           console.log('Stages completed:');
           result.stages.forEach((s) => {
             const status = s.passed ? '✅' : s.skipped ? '⚠️' : '❌';
-            const demo = s.demo ? ' (demo)' : '';
-            console.log(`  ${status} Stage ${s.stage}: ${s.name}${demo}`);
+            console.log(`  ${status} Stage ${s.stage}: ${s.name}`);
           });
         } else {
           console.log('✅ Verification passed\n');

--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -51,13 +51,8 @@ export { RECOMMENDED_FIELDS, REQUIRED_FIELDS, VALID_RISK_LEVELS, VALID_STATUSES 
 export interface VerificationOptions {
   skipChecksum?: boolean;
   skipAllChecks?: boolean;
-  skipAuthorCheck?: boolean;
-  skipDossierCheck?: boolean;
-  skipRiskAssessment?: boolean;
-  skipReview?: boolean;
   force?: boolean;
   noPrompt?: boolean;
-  reviewDossier?: string;
 }
 
 export interface VerificationStage {
@@ -65,7 +60,6 @@ export interface VerificationStage {
   name: string;
   passed?: boolean;
   skipped?: boolean;
-  demo?: boolean;
 }
 
 export interface VerificationResult {
@@ -299,13 +293,6 @@ export async function runVerification(
     console.log('⚠️  Stage 1: SKIPPED - Integrity check\n');
     results.stages.push({ stage: 1, name: 'Integrity', skipped: true });
   }
-
-  // Stages 2-5 are planned but not yet available.
-  // Skip them silently to avoid misleading output.
-  results.stages.push({ stage: 2, name: 'Author Check', skipped: true });
-  results.stages.push({ stage: 3, name: 'Dossier Check', skipped: true });
-  results.stages.push({ stage: 4, name: 'Risk Assessment', skipped: true });
-  results.stages.push({ stage: 5, name: 'Review Dossier', skipped: true });
 
   return results;
 }


### PR DESCRIPTION
## Summary

- Removes permanently-skipped verification stages 2-5 (Author Check, Dossier Check, Risk Assessment, Review Dossier) from `runVerification()` — they were always shown as "skipped" with no implementation behind them
- Removes 7 unimplemented CLI flags from `verify` and `run` commands: `--skip-signature`, `--skip-author-check`, `--skip-dossier-check`, `--skip-risk-assessment`, `--skip-review`, `--review-dossier`, `--review-llm`
- Cleans up `VerificationOptions` and `VerificationStage` interfaces (removes unused fields)

**Note:** Risk assessment is NOT lost — it's already performed inside `verifyDossier()` as part of Stage 1's integrity check (via `assessVerificationRisk()` from `@ai-dossier/core`). The "Stage 4: Risk Assessment" was misleading because it showed "skipped" when risk assessment was actually running inside Stage 1.

Closes #94

## Test plan

- [x] `tsc` builds cleanly
- [x] All 323 CLI tests pass
- [x] Biome lint passes
- [x] `dossier verify --help` no longer shows unimplemented flags
- [x] `dossier run --help` no longer shows unimplemented flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)