### PR TITLE
feat(cli): add skill-export command (#154)

### DIFF
--- a/cli/src/__tests__/commands/skill-export.test.ts
+++ b/cli/src/__tests__/commands/skill-export.test.ts
@@ -1,0 +1,216 @@
+import fs from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { registerSkillExportCommand } from '../../commands/skill-export';
+import * as credentials from '../../credentials';
+import * as registryClient from '../../registry-client';
+import { createTestProgram } from '../helpers/test-utils';
+
+vi.mock('node:fs');
+vi.mock('../../credentials');
+vi.mock('../../registry-client');
+
+const mockedFs = vi.mocked(fs);
+
+describe('skill-export command', () => {
+  const mockClient = {
+    publishDossier: vi.fn(),
+    getDossierContent: vi.fn(),
+  };
+
+  const validCredentials = {
+    token: 'test-token',
+    username: 'testuser',
+    orgs: ['myorg'],
+    expiresAt: null,
+  };
+
+  const skillContent =
+    '---dossier\n{"dossier_schema_version":"1.0.0","name":"my-skill","title":"My Skill","version":"1.0.0"}\n---\n# Skill body';
+
+  beforeEach(() => {
+    vi.mocked(credentials.loadCredentials).mockReturnValue(validCredentials);
+    vi.mocked(credentials.isExpired).mockReturnValue(false);
+    vi.mocked(registryClient.getClient).mockReturnValue(mockClient as any);
+    mockClient.publishDossier.mockReset();
+    mockClient.getDossierContent.mockReset();
+    mockedFs.existsSync.mockReset();
+    mockedFs.readFileSync.mockReset();
+    mockedFs.writeFileSync.mockReset();
+    mockedFs.readdirSync.mockReset();
+  });
+
+  it('should export a skill with auto minor version bump', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(skillContent);
+    mockClient.publishDossier.mockResolvedValue({
+      name: 'myorg/my-skill',
+      content_url: 'https://example.com',
+    });
+
+    const program = createTestProgram();
+    registerSkillExportCommand(program);
+
+    await program.parseAsync(['node', 'dossier', 'skill-export', 'my-skill', '-y']);
+
+    expect(mockClient.publishDossier).toHaveBeenCalledWith(
+      'myorg',
+      expect.stringContaining('1.1.0'),
+      expect.any(String)
+    );
+    expect(mockedFs.writeFileSync).toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Exported'));
+  });
+
+  it('should bump major version with --major', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(skillContent);
+    mockClient.publishDossier.mockResolvedValue({ name: 'myorg/my-skill' });
+
+    const program = createTestProgram();
+    registerSkillExportCommand(program);
+
+    await program.parseAsync(['node', 'dossier', 'skill-export', 'my-skill', '-y', '--major']);
+
+    expect(mockClient.publishDossier).toHaveBeenCalledWith(
+      'myorg',
+      expect.stringContaining('2.0.0'),
+      expect.any(String)
+    );
+  });
+
+  it('should use explicit version with --version', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(skillContent);
+    mockClient.publishDossier.mockResolvedValue({ name: 'myorg/my-skill' });
+
+    const program = createTestProgram();
+    registerSkillExportCommand(program);
+
+    await program.parseAsync([
+      'node',
+      'dossier',
+      'skill-export',
+      'my-skill',
+      '-y',
+      '--version',
+      '3.0.0',
+    ]);
+
+    expect(mockClient.publishDossier).toHaveBeenCalledWith(
+      'myorg',
+      expect.stringContaining('3.0.0'),
+      expect.any(String)
+    );
+  });
+
+  it('should skip version bump with --no-bump', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(skillContent);
+    mockClient.publishDossier.mockResolvedValue({ name: 'myorg/my-skill' });
+
+    const program = createTestProgram();
+    registerSkillExportCommand(program);
+
+    await program.parseAsync(['node', 'dossier', 'skill-export', 'my-skill', '-y', '--no-bump']);
+
+    expect(mockClient.publishDossier).toHaveBeenCalledWith(
+      'myorg',
+      expect.stringContaining('1.0.0'),
+      expect.any(String)
+    );
+    // Should NOT write back to file since version didn't change
+    expect(mockedFs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should exit 1 when not logged in', async () => {
+    vi.mocked(credentials.loadCredentials).mockReturnValue(null);
+
+    const program = createTestProgram();
+    registerSkillExportCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'dossier', 'skill-export', 'my-skill'])
+    ).rejects.toThrow();
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Not logged in'));
+  });
+
+  it('should exit 1 when skill not found', async () => {
+    mockedFs.existsSync.mockReturnValue(false);
+
+    const program = createTestProgram();
+    registerSkillExportCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'dossier', 'skill-export', 'missing-skill'])
+    ).rejects.toThrow();
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Skill 'missing-skill' not found")
+    );
+  });
+
+  it('should output JSON with --json flag', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(skillContent);
+    mockClient.publishDossier.mockResolvedValue({
+      name: 'myorg/my-skill',
+      content_url: 'https://example.com',
+    });
+
+    const program = createTestProgram();
+    registerSkillExportCommand(program);
+
+    await program.parseAsync(['node', 'dossier', 'skill-export', 'my-skill', '--json']);
+
+    const jsonCall = vi
+      .mocked(console.log)
+      .mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('"exported"'));
+    expect(jsonCall).toBeDefined();
+    const parsed = JSON.parse(jsonCall![0] as string);
+    expect(parsed.exported).toBe(true);
+    expect(parsed.version).toBe('1.1.0');
+  });
+
+  it('should use custom namespace', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(skillContent);
+    mockClient.publishDossier.mockResolvedValue({ name: 'custom-ns/my-skill' });
+
+    const program = createTestProgram();
+    registerSkillExportCommand(program);
+
+    await program.parseAsync([
+      'node',
+      'dossier',
+      'skill-export',
+      'my-skill',
+      '-y',
+      '--namespace',
+      'custom-ns',
+    ]);
+
+    expect(mockClient.publishDossier).toHaveBeenCalledWith(
+      'custom-ns',
+      expect.any(String),
+      expect.any(String)
+    );
+  });
+
+  it('should handle publish errors', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(skillContent);
+    mockClient.publishDossier.mockRejectedValue(
+      Object.assign(new Error('Permission denied'), { statusCode: 403 })
+    );
+
+    const program = createTestProgram();
+    registerSkillExportCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'dossier', 'skill-export', 'my-skill', '-y'])
+    ).rejects.toThrow();
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Permission denied'));
+  });
+});

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -33,6 +33,7 @@ import { registerResetHooksCommand } from './commands/reset-hooks';
 import { registerRunCommand } from './commands/run';
 import { registerSearchCommand } from './commands/search';
 import { registerSignCommand } from './commands/sign';
+import { registerSkillExportCommand } from './commands/skill-export';
 import { registerValidateCommand } from './commands/validate';
 // Import command registrations
 import { registerVerifyCommand } from './commands/verify';
@@ -72,6 +73,7 @@ registerPullCommand(program);
 registerExportCommand(program);
 registerCacheCommand(program);
 registerInstallSkillCommand(program);
+registerSkillExportCommand(program);
 registerKeysCommand(program);
 registerLintCommand(program);
 registerFormatCommand(program);

--- a/cli/src/commands/skill-export.ts
+++ b/cli/src/commands/skill-export.ts
@@ -1,0 +1,264 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { parseDossierContent, validateFrontmatter } from '@ai-dossier/core';
+import type { Command } from 'commander';
+import { isExpired, loadCredentials } from '../credentials';
+import { getClient } from '../registry-client';
+
+function bumpVersion(current: string, bump: 'minor' | 'major'): string {
+  const parts = current.split('.').map(Number);
+  if (parts.length !== 3 || parts.some(isNaN)) {
+    // Can't bump non-semver, return as-is
+    return current;
+  }
+  if (bump === 'major') {
+    return `${parts[0] + 1}.0.0`;
+  }
+  return `${parts[0]}.${parts[1] + 1}.0`;
+}
+
+function replaceVersion(content: string, oldVersion: string, newVersion: string): string {
+  // Replace version in frontmatter section only (between first --- delimiters)
+  const versionPattern = new RegExp(
+    `(["']?version["']?\\s*[:=]\\s*["']?)${oldVersion.replace(/\./g, '\\.')}(["']?)`,
+    'm'
+  );
+  return content.replace(versionPattern, `$1${newVersion}$2`);
+}
+
+export function registerSkillExportCommand(program: Command): void {
+  program
+    .command('skill-export')
+    .description('Publish a locally installed skill to the registry')
+    .argument('<name>', 'Skill name (directory name under ~/.claude/skills/)')
+    .option('--namespace <namespace>', 'Registry namespace (default: first org or username)')
+    .option('--major', 'Bump major version instead of minor')
+    .option('--version <version>', 'Set explicit version (e.g., 2.0.0)')
+    .option('--no-bump', 'Publish without version bump')
+    .option('--changelog <message>', 'Changelog message')
+    .option('--verify', 'Re-install after publish to verify roundtrip')
+    .option('-y, --yes', 'Skip confirmation prompt')
+    .option('--json', 'Output as JSON')
+    .action(
+      async (
+        name: string,
+        options: {
+          namespace?: string;
+          major?: boolean;
+          version?: string;
+          bump?: boolean;
+          changelog?: string;
+          verify?: boolean;
+          yes?: boolean;
+          json?: boolean;
+        }
+      ) => {
+        const credentials = loadCredentials();
+        if (!credentials) {
+          if (options.json) {
+            console.log(
+              JSON.stringify(
+                { exported: false, error: 'Not logged in', code: 'not_logged_in' },
+                null,
+                2
+              )
+            );
+          } else {
+            console.error('\n❌ Not logged in. Run `dossier login` first.\n');
+          }
+          process.exit(1);
+        }
+        if (isExpired(credentials)) {
+          if (options.json) {
+            console.log(
+              JSON.stringify(
+                { exported: false, error: 'Credentials expired', code: 'expired' },
+                null,
+                2
+              )
+            );
+          } else {
+            console.error('\n❌ Credentials expired. Run `dossier login` to re-authenticate.\n');
+          }
+          process.exit(1);
+        }
+
+        const skillsDir = path.join(os.homedir(), '.claude', 'skills');
+        const skillDir = path.join(skillsDir, name);
+        const skillFile = path.join(skillDir, 'SKILL.md');
+
+        if (!fs.existsSync(skillFile)) {
+          if (options.json) {
+            console.log(
+              JSON.stringify(
+                { exported: false, error: `Skill '${name}' not found`, code: 'not_found' },
+                null,
+                2
+              )
+            );
+          } else {
+            console.error(`\n❌ Skill '${name}' not found at ${skillDir}\n`);
+            console.error('   Installed skills:');
+            if (fs.existsSync(skillsDir)) {
+              const entries = fs
+                .readdirSync(skillsDir, { withFileTypes: true })
+                .filter(
+                  (e) => e.isDirectory() && fs.existsSync(path.join(skillsDir, e.name, 'SKILL.md'))
+                );
+              for (const e of entries) {
+                console.error(`   - ${e.name}`);
+              }
+            }
+            console.error('');
+          }
+          process.exit(1);
+        }
+
+        let content = fs.readFileSync(skillFile, 'utf8');
+
+        let frontmatter: Record<string, any>;
+        try {
+          const parsed = parseDossierContent(content);
+          frontmatter = parsed.frontmatter as Record<string, any>;
+        } catch (err: unknown) {
+          if (options.json) {
+            console.log(
+              JSON.stringify(
+                { exported: false, error: (err as Error).message, code: 'parse_error' },
+                null,
+                2
+              )
+            );
+          } else {
+            console.error(`\n❌ Failed to parse skill: ${(err as Error).message}\n`);
+          }
+          process.exit(1);
+        }
+
+        const currentVersion = frontmatter.version || '0.0.0';
+        let newVersion: string;
+
+        if (options.version) {
+          newVersion = options.version;
+        } else if (options.bump === false) {
+          newVersion = currentVersion;
+        } else {
+          newVersion = bumpVersion(currentVersion, options.major ? 'major' : 'minor');
+        }
+
+        // Update version in content if it changed
+        if (newVersion !== currentVersion) {
+          content = replaceVersion(content, currentVersion, newVersion);
+          // Write back to local file so it stays in sync
+          fs.writeFileSync(skillFile, content, 'utf8');
+        }
+
+        const namespace =
+          options.namespace ||
+          (credentials.orgs.length > 0 ? credentials.orgs[0] : credentials.username);
+
+        const dossierName = frontmatter.name || frontmatter.title || name;
+        const fullPath = `${namespace}/${dossierName}`;
+
+        if (!options.yes && !options.json) {
+          console.log('\n📦 Exporting skill to registry:\n');
+          console.log(`   Skill:     ${name}`);
+          console.log(`   Registry:  ${fullPath}@${newVersion}`);
+          if (newVersion !== currentVersion) {
+            console.log(`   Version:   ${currentVersion} → ${newVersion}`);
+          }
+          if (options.changelog) {
+            console.log(`   Changelog: ${options.changelog}`);
+          }
+          console.log('');
+        }
+
+        try {
+          const client = getClient(credentials.token);
+          const result = await client.publishDossier(
+            namespace,
+            content,
+            options.changelog || `Exported from local skill '${name}'`
+          );
+
+          if (options.json) {
+            console.log(
+              JSON.stringify(
+                {
+                  exported: true,
+                  skill: name,
+                  name: result.name || fullPath,
+                  version: newVersion,
+                  previousVersion: currentVersion !== newVersion ? currentVersion : undefined,
+                  content_url: result.content_url || null,
+                },
+                null,
+                2
+              )
+            );
+          } else {
+            console.log(`✅ Exported ${fullPath}@${newVersion}`);
+            if (result.content_url) {
+              console.log(`   URL: ${result.content_url}`);
+            }
+          }
+
+          // Verify roundtrip
+          if (options.verify) {
+            if (!options.json) {
+              console.log('\n🔄 Verifying roundtrip...');
+            }
+            try {
+              const downloaded = await client.getDossierContent(fullPath, newVersion);
+              if (downloaded.content === content) {
+                if (options.json) {
+                  // Already printed main JSON above
+                } else {
+                  console.log('   ✅ Roundtrip verified — registry content matches local');
+                }
+              } else {
+                if (!options.json) {
+                  console.log('   ⚠️  Content differs — registry may have normalized the content');
+                }
+              }
+            } catch (verifyErr: unknown) {
+              if (!options.json) {
+                console.log(`   ⚠️  Verification failed: ${(verifyErr as Error).message}`);
+                console.log(
+                  '   CDN propagation may take a few seconds. Try: dossier info ' + fullPath
+                );
+              }
+            }
+          }
+
+          if (!options.json) {
+            console.log('');
+          }
+        } catch (err: any) {
+          if (options.json) {
+            console.log(
+              JSON.stringify(
+                {
+                  exported: false,
+                  error: err.message,
+                  code: err.code || 'export_failed',
+                },
+                null,
+                2
+              )
+            );
+          } else if (err.statusCode === 401) {
+            console.error('\n❌ Session expired. Run `dossier login` to re-authenticate.\n');
+          } else if (err.statusCode === 403) {
+            console.error(`\n❌ Permission denied: ${err.message}\n`);
+          } else if (err.statusCode === 409) {
+            console.error(`\n❌ Version conflict: ${fullPath}@${newVersion} — ${err.message}\n`);
+          } else {
+            console.error(`\n❌ Export failed: ${err.message}\n`);
+          }
+          process.exit(1);
+        }
+      }
+    );
+}


### PR DESCRIPTION
## Summary

Adds `ai-dossier skill-export <name>` to close the edit→publish→install loop for skills. Reads from `~/.claude/skills/<name>/SKILL.md` and publishes to the registry.

**Usage:**
```bash
# Export with auto minor version bump (1.0.0 → 1.1.0)
ai-dossier skill-export full-cycle-issue --namespace imboard-ai

# Major bump
ai-dossier skill-export my-skill --major

# Explicit version
ai-dossier skill-export my-skill --version 2.0.0

# No version change
ai-dossier skill-export my-skill --no-bump

# Verify roundtrip after publish
ai-dossier skill-export my-skill --verify

# JSON output for agents
ai-dossier skill-export my-skill --json
```

**Features:**
- Auto minor version bump (default), `--major` for major, `--version` for explicit
- `--no-bump` to publish without version change
- `--namespace` (defaults to first org or username from credentials)
- `--verify` for roundtrip verification
- `--json` output for agent consumption
- Writes bumped version back to local file to keep in sync
- Lists available skills on error if skill not found

Closes #154

## Test plan

- [x] `tsc` builds cleanly
- [x] All 332 tests pass (40 test files), 9 new tests for skill-export
- [x] Tests cover: minor bump, major bump, explicit version, no-bump, auth errors, missing skill, JSON output, custom namespace, publish errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)