### PR TITLE
test(core): fix CI coverage threshold failures

### DIFF
--- a/packages/core/src/__tests__/errors.test.ts
+++ b/packages/core/src/__tests__/errors.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { getErrorMessage, getErrorStack } from '../utils/errors';
+
+describe('getErrorMessage', () => {
+  it('should extract message from Error instance', () => {
+    expect(getErrorMessage(new Error('test error'))).toBe('test error');
+  });
+
+  it('should convert non-Error to string', () => {
+    expect(getErrorMessage('string error')).toBe('string error');
+    expect(getErrorMessage(42)).toBe('42');
+    expect(getErrorMessage(null)).toBe('null');
+    expect(getErrorMessage(undefined)).toBe('undefined');
+  });
+});
+
+describe('getErrorStack', () => {
+  it('should extract stack from Error instance', () => {
+    const err = new Error('test');
+    const stack = getErrorStack(err);
+    expect(stack).toBeDefined();
+    expect(stack).toContain('Error: test');
+  });
+
+  it('should return undefined for non-Error types', () => {
+    expect(getErrorStack('not an error')).toBeUndefined();
+    expect(getErrorStack(42)).toBeUndefined();
+    expect(getErrorStack(null)).toBeUndefined();
+  });
+});

--- a/packages/core/src/__tests__/file-operations.test.ts
+++ b/packages/core/src/__tests__/file-operations.test.ts
@@ -1,0 +1,156 @@
+import { generateKeyPairSync, sign as cryptoSign } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { calculateChecksum } from '../checksum';
+import { formatDossierFile } from '../formatter';
+import { lintDossierFile } from '../linter';
+import { Ed25519Verifier } from '../signers/ed25519';
+import { VerifierRegistry } from '../signers/registry';
+
+function makeDossier(frontmatter: Record<string, unknown>, body = '# Test\n\n## Section\nContent') {
+  const json = JSON.stringify(frontmatter, null, 2);
+  return `---dossier\n${json}\n---\n${body}`;
+}
+
+const baseFrontmatter = {
+  dossier_schema_version: '1.0.0',
+  title: 'Test Dossier',
+  version: '1.0.0',
+  status: 'Stable',
+  objective: 'Test file-based operations for coverage',
+  risk_level: 'low',
+  requires_approval: false,
+};
+
+describe('formatDossierFile', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `dossier-fmt-test-${Date.now()}-${Math.random()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should format a file in place and return changed=true', () => {
+    const body = '# Test\n\n## Section\nContent';
+    const fm = { version: '1.0.0', title: 'Test', dossier_schema_version: '1.0.0' };
+    const content = makeDossier(fm, body);
+    const filePath = join(tempDir, 'test.ds.md');
+    writeFileSync(filePath, content, 'utf8');
+
+    const result = formatDossierFile(filePath);
+
+    expect(result.changed).toBe(true);
+    const written = readFileSync(filePath, 'utf8');
+    expect(written).toBe(result.formatted);
+  });
+
+  it('should not write when content is already formatted', () => {
+    const body = '# Test\n\n## Section\nContent';
+    const fm = {
+      ...baseFrontmatter,
+      checksum: { algorithm: 'sha256', hash: calculateChecksum(body) },
+    };
+    const content = makeDossier(fm, body);
+    const filePath = join(tempDir, 'test.ds.md');
+
+    // Format once
+    writeFileSync(filePath, content, 'utf8');
+    const first = formatDossierFile(filePath);
+    writeFileSync(filePath, first.formatted, 'utf8');
+
+    // Format again — should not change
+    const second = formatDossierFile(filePath);
+    expect(second.changed).toBe(false);
+  });
+});
+
+describe('lintDossierFile', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `dossier-lint-test-${Date.now()}-${Math.random()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should lint a file and return results with file path', () => {
+    const body = '# Test\n\n## Section\nContent';
+    const fm = {
+      ...baseFrontmatter,
+      checksum: { algorithm: 'sha256', hash: calculateChecksum(body) },
+    };
+    const content = makeDossier(fm, body);
+    const filePath = join(tempDir, 'test.ds.md');
+    writeFileSync(filePath, content, 'utf8');
+
+    const result = lintDossierFile(filePath);
+
+    expect(result.file).toBe(filePath);
+    expect(result.errorCount).toBeGreaterThanOrEqual(0);
+    expect(result.warningCount).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should detect lint issues in a file', () => {
+    const content = makeDossier({ title: 'Incomplete' });
+    const filePath = join(tempDir, 'bad.ds.md');
+    writeFileSync(filePath, content, 'utf8');
+
+    const result = lintDossierFile(filePath);
+
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(result.errorCount).toBeGreaterThan(0);
+  });
+});
+
+describe('verifySignature (via registry)', () => {
+  it('should verify using a registry with Ed25519Verifier', async () => {
+    // Exercise the registry + verifier pattern that verifySignature uses,
+    // without calling getVerifierRegistry() which uses require() at runtime.
+    const registry = new VerifierRegistry();
+    registry.register(new Ed25519Verifier());
+
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+    const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }) as string;
+    const content = 'test content for registry verify';
+    const sig = cryptoSign(null, Buffer.from(content, 'utf8'), privateKey);
+
+    const verifier = registry.get('ed25519');
+    const result = await verifier.verify(content, {
+      algorithm: 'ed25519',
+      signature: sig.toString('base64'),
+      public_key: publicKeyPem,
+      signed_at: new Date().toISOString(),
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject invalid signature through registry', async () => {
+    const registry = new VerifierRegistry();
+    registry.register(new Ed25519Verifier());
+
+    const verifier = registry.get('ed25519');
+    const result = await verifier.verify('content', {
+      algorithm: 'ed25519',
+      signature: 'dGVzdA==',
+      public_key: 'not-a-key',
+      signed_at: new Date().toISOString(),
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+});

--- a/packages/core/src/__tests__/file-operations.test.ts
+++ b/packages/core/src/__tests__/file-operations.test.ts
@@ -1,8 +1,8 @@
-import { generateKeyPairSync, sign as cryptoSign } from 'node:crypto';
+import { sign as cryptoSign, generateKeyPairSync } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { calculateChecksum } from '../checksum';
 import { formatDossierFile } from '../formatter';
 import { lintDossierFile } from '../linter';

--- a/packages/core/src/__tests__/signers.test.ts
+++ b/packages/core/src/__tests__/signers.test.ts
@@ -1,0 +1,169 @@
+import { generateKeyPairSync, sign as cryptoSign } from 'node:crypto';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Ed25519Signer, Ed25519Verifier } from '../signers/ed25519';
+import { VerifierRegistry } from '../signers/registry';
+
+describe('Ed25519Signer', () => {
+  let tempDir: string;
+  let privateKeyPath: string;
+  let publicKeyPem: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `dossier-signer-test-${Date.now()}-${Math.random()}`);
+    mkdirSync(tempDir, { recursive: true });
+
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+    publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }) as string;
+    const privateKeyPem = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+
+    privateKeyPath = join(tempDir, 'ed25519.pem');
+    writeFileSync(privateKeyPath, privateKeyPem, 'utf8');
+  });
+
+  afterEach(() => {
+    if (existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should have algorithm ed25519', () => {
+    const signer = new Ed25519Signer(privateKeyPath);
+    expect(signer.algorithm).toBe('ed25519');
+  });
+
+  it('should sign content and return valid signature result', async () => {
+    const signer = new Ed25519Signer(privateKeyPath);
+    const result = await signer.sign('test content');
+
+    expect(result.algorithm).toBe('ed25519');
+    expect(result.signature).toBeTruthy();
+    expect(result.public_key).toContain('BEGIN PUBLIC KEY');
+    expect(result.signed_at).toBeTruthy();
+  });
+
+  it('should produce verifiable signatures', async () => {
+    const signer = new Ed25519Signer(privateKeyPath);
+    const content = 'content to verify';
+    const result = await signer.sign(content);
+
+    const verifier = new Ed25519Verifier();
+    const verification = await verifier.verify(content, result);
+    expect(verification.valid).toBe(true);
+  });
+
+  it('should return public key via getPublicKey', async () => {
+    const signer = new Ed25519Signer(privateKeyPath);
+    const pk = await signer.getPublicKey();
+    expect(pk).toContain('BEGIN PUBLIC KEY');
+    expect(pk).toBe(publicKeyPem);
+  });
+});
+
+describe('Ed25519Verifier', () => {
+  it('should support ed25519 algorithm', () => {
+    const verifier = new Ed25519Verifier();
+    expect(verifier.supports('ed25519')).toBe(true);
+  });
+
+  it('should not support other algorithms', () => {
+    const verifier = new Ed25519Verifier();
+    expect(verifier.supports('ECDSA-SHA-256')).toBe(false);
+    expect(verifier.supports('rsa')).toBe(false);
+  });
+
+  it('should verify valid signature', async () => {
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+    const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }) as string;
+
+    const content = 'test content';
+    const sig = cryptoSign(null, Buffer.from(content, 'utf8'), privateKey);
+
+    const verifier = new Ed25519Verifier();
+    const result = await verifier.verify(content, {
+      algorithm: 'ed25519',
+      signature: sig.toString('base64'),
+      public_key: publicKeyPem,
+      signed_at: new Date().toISOString(),
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject tampered content', async () => {
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+    const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }) as string;
+
+    const sig = cryptoSign(null, Buffer.from('original', 'utf8'), privateKey);
+
+    const verifier = new Ed25519Verifier();
+    const result = await verifier.verify('tampered', {
+      algorithm: 'ed25519',
+      signature: sig.toString('base64'),
+      public_key: publicKeyPem,
+      signed_at: new Date().toISOString(),
+    });
+
+    expect(result.valid).toBe(false);
+  });
+
+  it('should return error for invalid key format', async () => {
+    const verifier = new Ed25519Verifier();
+    const result = await verifier.verify('content', {
+      algorithm: 'ed25519',
+      signature: 'dGVzdA==',
+      public_key: 'not-a-valid-key',
+      signed_at: new Date().toISOString(),
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+});
+
+describe('VerifierRegistry', () => {
+  it('should register and retrieve verifiers', () => {
+    const registry = new VerifierRegistry();
+    const verifier = new Ed25519Verifier();
+
+    registry.register(verifier);
+    expect(registry.get('ed25519')).toBe(verifier);
+  });
+
+  it('should throw for unsupported algorithm', () => {
+    const registry = new VerifierRegistry();
+    expect(() => registry.get('unknown-algo')).toThrow(
+      'No verifier registered for algorithm: unknown-algo'
+    );
+  });
+
+  it('should check if algorithm is supported via has()', () => {
+    const registry = new VerifierRegistry();
+    expect(registry.has('ed25519')).toBe(false);
+
+    registry.register(new Ed25519Verifier());
+    expect(registry.has('ed25519')).toBe(true);
+    expect(registry.has('rsa')).toBe(false);
+  });
+
+  it('should return supported algorithms', () => {
+    const registry = new VerifierRegistry();
+    const algorithms = registry.getSupportedAlgorithms();
+    expect(algorithms).toContain('ed25519');
+    expect(algorithms).toContain('ECDSA-SHA-256');
+  });
+});
+
+describe('getVerifierRegistry', () => {
+  it('should create a registry and register built-in verifiers manually', () => {
+    // getVerifierRegistry uses require() at runtime which doesn't work in TS tests.
+    // Instead, test that manual registration works identically to the singleton pattern.
+    const registry = new VerifierRegistry();
+    registry.register(new Ed25519Verifier());
+
+    expect(registry.has('ed25519')).toBe(true);
+    expect(registry.get('ed25519')).toBeInstanceOf(Ed25519Verifier);
+  });
+});

--- a/packages/core/src/__tests__/signers.test.ts
+++ b/packages/core/src/__tests__/signers.test.ts
@@ -1,4 +1,4 @@
-import { generateKeyPairSync, sign as cryptoSign } from 'node:crypto';
+import { sign as cryptoSign, generateKeyPairSync } from 'node:crypto';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';


### PR DESCRIPTION
## Summary

- Added tests for uncovered modules in `packages/core` that were causing CI to fail on all branches (including main)
- Coverage thresholds (80% statements, 80% functions, 80% lines) are now met

### New test files
- `signers.test.ts` — Ed25519Signer, Ed25519Verifier, VerifierRegistry
- `errors.test.ts` — getErrorMessage, getErrorStack utilities
- `file-operations.test.ts` — formatDossierFile, lintDossierFile, registry-based verification

### Coverage improvement
| Metric | Before | After | Threshold |
|--------|--------|-------|-----------|
| Statements | 76.68% | 88.48% | 80% |
| Functions | 68.75% | 90.62% | 80% |
| Lines | 77.27% | 88.63% | 80% |

## Test plan
- [x] All 135 core tests pass locally
- [x] `npx vitest run --coverage` exits with code 0
- [x] CI should pass (this was blocking all PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)