### PR TITLE
fix(cli): resolve all biome lint errors across CLI commands

### DIFF
--- a/cli/src/__tests__/commands/skill-export.test.ts
+++ b/cli/src/__tests__/commands/skill-export.test.ts
@@ -167,7 +167,7 @@ describe('skill-export command', () => {
       .mocked(console.log)
       .mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('"exported"'));
     expect(jsonCall).toBeDefined();
-    const parsed = JSON.parse(jsonCall![0] as string);
+    const parsed = JSON.parse(jsonCall?.[0] as string);
     expect(parsed.exported).toBe(true);
     expect(parsed.version).toBe('1.1.0');
   });

--- a/cli/src/commands/cache.ts
+++ b/cli/src/commands/cache.ts
@@ -26,7 +26,13 @@ export function registerCacheCommand(program: Command): void {
         process.exit(0);
       }
 
-      const entries: any[] = [];
+      const entries: {
+        name: string;
+        version: string;
+        size: number;
+        cached_at: string;
+        path: string;
+      }[] = [];
       function walk(dir: string): void {
         if (!fs.existsSync(dir)) return;
         for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -111,135 +117,140 @@ export function registerCacheCommand(program: Command): void {
     .option('--older-than <days>', 'Remove entries older than N days')
     .option('--all', 'Remove all cached dossiers')
     .option('-y, --yes', 'Skip confirmation prompt')
-    .action(async (name: string | undefined, options: any) => {
-      const cacheDir = path.join(os.homedir(), '.dossier', 'cache');
+    .action(
+      async (
+        name: string | undefined,
+        options: { ver?: string; olderThan?: string; all?: boolean; yes?: boolean }
+      ) => {
+        const cacheDir = path.join(os.homedir(), '.dossier', 'cache');
 
-      if (!fs.existsSync(cacheDir)) {
-        console.log('\nNo cached dossiers.\n');
-        process.exit(0);
-      }
-
-      async function confirm(msg: string): Promise<boolean> {
-        if (options.yes) return true;
-        if (!process.stdin.isTTY) {
-          console.error(
-            '\n❌ Non-interactive session detected. Use -y/--yes to skip confirmation.\n'
-          );
-          process.exit(1);
-        }
-        const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
-        const answer = await new Promise<string>((resolve) => {
-          rl.question(`${msg} (y/N) `, resolve);
-        });
-        rl.close();
-        return answer.toString().toLowerCase() === 'y';
-      }
-
-      function rmDir(dir: string): void {
-        fs.rmSync(dir, { recursive: true, force: true });
-        let parent = path.dirname(dir);
-        while (parent !== cacheDir && parent.startsWith(cacheDir)) {
-          try {
-            const contents = fs.readdirSync(parent);
-            if (contents.length === 0) {
-              fs.rmdirSync(parent);
-              parent = path.dirname(parent);
-            } else {
-              break;
-            }
-          } catch {
-            break;
-          }
-        }
-      }
-
-      if (options.all) {
-        if (!(await confirm('Remove ALL cached dossiers?'))) {
-          console.log('\nAborted.\n');
-          process.exit(0);
-        }
-        fs.rmSync(cacheDir, { recursive: true, force: true });
-        console.log('\n✅ Cache cleared.\n');
-        process.exit(0);
-      }
-
-      if (options.olderThan) {
-        const days = parseInt(options.olderThan, 10);
-        if (Number.isNaN(days) || days <= 0) {
-          console.error('\n❌ --older-than must be a positive number\n');
-          process.exit(1);
-        }
-
-        const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
-        let count = 0;
-
-        function walkClean(dir: string): void {
-          if (!fs.existsSync(dir)) return;
-          for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-            const full = path.join(dir, entry.name);
-            if (entry.isDirectory()) {
-              walkClean(full);
-            } else if (entry.name.endsWith('.meta.json')) {
-              try {
-                const meta = JSON.parse(fs.readFileSync(full, 'utf8'));
-                if (meta.cached_at && new Date(meta.cached_at).getTime() < cutoff) {
-                  const version = entry.name.replace('.meta.json', '');
-                  const contentFile = path.join(dir, `${version}.ds.md`);
-                  fs.unlinkSync(full);
-                  if (fs.existsSync(contentFile)) fs.unlinkSync(contentFile);
-                  count++;
-                }
-              } catch {
-                // skip
-              }
-            }
-          }
-        }
-
-        if (!(await confirm(`Remove dossiers cached more than ${days} days ago?`))) {
-          console.log('\nAborted.\n');
+        if (!fs.existsSync(cacheDir)) {
+          console.log('\nNo cached dossiers.\n');
           process.exit(0);
         }
 
-        walkClean(cacheDir);
-        console.log(`\n✅ Removed ${count} cached dossier(s).\n`);
-        process.exit(0);
-      }
-
-      if (name) {
-        const dossierDir = safeDossierPath(cacheDir, name);
-        if (!fs.existsSync(dossierDir)) {
-          console.error(`\n❌ Not cached: ${name}\n`);
-          process.exit(1);
-        }
-
-        if (options.ver) {
-          const contentFile = path.join(dossierDir, `${options.ver}.ds.md`);
-          const metaFile = path.join(dossierDir, `${options.ver}.meta.json`);
-          if (!fs.existsSync(contentFile) && !fs.existsSync(metaFile)) {
-            console.error(`\n❌ Version ${options.ver} not cached for ${name}\n`);
+        async function confirm(msg: string): Promise<boolean> {
+          if (options.yes) return true;
+          if (!process.stdin.isTTY) {
+            console.error(
+              '\n❌ Non-interactive session detected. Use -y/--yes to skip confirmation.\n'
+            );
             process.exit(1);
           }
-          if (fs.existsSync(contentFile)) fs.unlinkSync(contentFile);
-          if (fs.existsSync(metaFile)) fs.unlinkSync(metaFile);
-          console.log(`\n✅ Removed: ${name}@${options.ver}\n`);
-        } else {
-          if (!(await confirm(`Remove all cached versions of '${name}'?`))) {
+          const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+          const answer = await new Promise<string>((resolve) => {
+            rl.question(`${msg} (y/N) `, resolve);
+          });
+          rl.close();
+          return answer.toString().toLowerCase() === 'y';
+        }
+
+        function rmDir(dir: string): void {
+          fs.rmSync(dir, { recursive: true, force: true });
+          let parent = path.dirname(dir);
+          while (parent !== cacheDir && parent.startsWith(cacheDir)) {
+            try {
+              const contents = fs.readdirSync(parent);
+              if (contents.length === 0) {
+                fs.rmdirSync(parent);
+                parent = path.dirname(parent);
+              } else {
+                break;
+              }
+            } catch {
+              break;
+            }
+          }
+        }
+
+        if (options.all) {
+          if (!(await confirm('Remove ALL cached dossiers?'))) {
             console.log('\nAborted.\n');
             process.exit(0);
           }
-          rmDir(dossierDir);
-          console.log(`\n✅ Removed: ${name} (all versions)\n`);
+          fs.rmSync(cacheDir, { recursive: true, force: true });
+          console.log('\n✅ Cache cleared.\n');
+          process.exit(0);
         }
+
+        if (options.olderThan) {
+          const days = parseInt(options.olderThan, 10);
+          if (Number.isNaN(days) || days <= 0) {
+            console.error('\n❌ --older-than must be a positive number\n');
+            process.exit(1);
+          }
+
+          const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+          let count = 0;
+
+          function walkClean(dir: string): void {
+            if (!fs.existsSync(dir)) return;
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+              const full = path.join(dir, entry.name);
+              if (entry.isDirectory()) {
+                walkClean(full);
+              } else if (entry.name.endsWith('.meta.json')) {
+                try {
+                  const meta = JSON.parse(fs.readFileSync(full, 'utf8'));
+                  if (meta.cached_at && new Date(meta.cached_at).getTime() < cutoff) {
+                    const version = entry.name.replace('.meta.json', '');
+                    const contentFile = path.join(dir, `${version}.ds.md`);
+                    fs.unlinkSync(full);
+                    if (fs.existsSync(contentFile)) fs.unlinkSync(contentFile);
+                    count++;
+                  }
+                } catch {
+                  // skip
+                }
+              }
+            }
+          }
+
+          if (!(await confirm(`Remove dossiers cached more than ${days} days ago?`))) {
+            console.log('\nAborted.\n');
+            process.exit(0);
+          }
+
+          walkClean(cacheDir);
+          console.log(`\n✅ Removed ${count} cached dossier(s).\n`);
+          process.exit(0);
+        }
+
+        if (name) {
+          const dossierDir = safeDossierPath(cacheDir, name);
+          if (!fs.existsSync(dossierDir)) {
+            console.error(`\n❌ Not cached: ${name}\n`);
+            process.exit(1);
+          }
+
+          if (options.ver) {
+            const contentFile = path.join(dossierDir, `${options.ver}.ds.md`);
+            const metaFile = path.join(dossierDir, `${options.ver}.meta.json`);
+            if (!fs.existsSync(contentFile) && !fs.existsSync(metaFile)) {
+              console.error(`\n❌ Version ${options.ver} not cached for ${name}\n`);
+              process.exit(1);
+            }
+            if (fs.existsSync(contentFile)) fs.unlinkSync(contentFile);
+            if (fs.existsSync(metaFile)) fs.unlinkSync(metaFile);
+            console.log(`\n✅ Removed: ${name}@${options.ver}\n`);
+          } else {
+            if (!(await confirm(`Remove all cached versions of '${name}'?`))) {
+              console.log('\nAborted.\n');
+              process.exit(0);
+            }
+            rmDir(dossierDir);
+            console.log(`\n✅ Removed: ${name} (all versions)\n`);
+          }
+          process.exit(0);
+        }
+
+        console.log('\nUsage:');
+        console.log('  dossier cache clean <name>              Remove all versions of a dossier');
+        console.log('  dossier cache clean <name> --ver X      Remove specific version');
+        console.log('  dossier cache clean --older-than <days>  Remove stale entries');
+        console.log('  dossier cache clean --all                Remove everything');
+        console.log('');
         process.exit(0);
       }
-
-      console.log('\nUsage:');
-      console.log('  dossier cache clean <name>              Remove all versions of a dossier');
-      console.log('  dossier cache clean <name> --ver X      Remove specific version');
-      console.log('  dossier cache clean --older-than <days>  Remove stale entries');
-      console.log('  dossier cache clean --all                Remove everything');
-      console.log('');
-      process.exit(0);
-    });
+    );
 }

--- a/cli/src/commands/checksum.ts
+++ b/cli/src/commands/checksum.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
-import { parseDossierContent } from '@ai-dossier/core';
+import { type DossierFrontmatter, parseDossierContent } from '@ai-dossier/core';
 import type { Command } from 'commander';
 
 export function registerChecksumCommand(program: Command): void {
@@ -22,11 +22,11 @@ export function registerChecksumCommand(program: Command): void {
 
       const content = fs.readFileSync(dossierFile, 'utf8');
 
-      let frontmatter: Record<string, any>;
+      let frontmatter: DossierFrontmatter;
       let body: string;
       try {
         const parsed = parseDossierContent(content);
-        frontmatter = parsed.frontmatter as Record<string, any>;
+        frontmatter = parsed.frontmatter;
         body = parsed.body;
       } catch (err: unknown) {
         console.log(`❌ ${(err as Error).message}`);

--- a/cli/src/commands/commands.ts
+++ b/cli/src/commands/commands.ts
@@ -45,8 +45,21 @@ function extractOption(opt: Option): OptionInfo {
 }
 
 function extractCommand(cmd: Command): CommandInfo {
+  // Commander exposes registeredArguments as a public property not reflected in the type defs
+  const registeredArgs = (
+    cmd as unknown as {
+      registeredArguments?: Array<{
+        _name: string;
+        description: string;
+        required: boolean;
+        variadic: boolean;
+        defaultValue?: unknown;
+        argChoices?: string[];
+      }>;
+    }
+  ).registeredArguments;
   const args: ArgumentInfo[] =
-    (cmd as any).registeredArguments?.map((arg: any) => {
+    registeredArgs?.map((arg) => {
       const info: ArgumentInfo = {
         name: arg._name,
         description: arg.description || '',
@@ -85,7 +98,7 @@ export function registerCommandsCommand(program: Command): void {
 
       if (options.command) {
         const cmd = program.commands.find(
-          (c) => c.name() === options.command || c.aliases().includes(options.command!)
+          (c) => c.name() === options.command || c.aliases().includes(options.command as string)
         );
         if (!cmd) {
           console.error(`\nUnknown command: ${options.command}\n`);

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -21,72 +21,85 @@ export function registerCreateCommand(program: Command): void {
     .option('--category <category>', 'Category (devops, data-science, development, etc.)')
     .option('--tags <tags>', 'Comma-separated tags')
     .option('--llm <name>', 'LLM to use (claude-code, auto)', 'auto')
-    .action(async (file: string | undefined, options: any) => {
-      try {
-        const llmOption = options.llm || config.getConfig('defaultLlm') || 'auto';
-        const llm = detectLlm(llmOption, false);
-
-        if (!llm) {
-          process.exit(2);
+    .action(
+      async (
+        file: string | undefined,
+        options: {
+          template: string;
+          title?: string;
+          objective?: string;
+          risk?: string;
+          category?: string;
+          tags?: string;
+          llm?: string;
         }
+      ) => {
+        try {
+          const llmOption = options.llm || config.getConfig('defaultLlm') || 'auto';
+          const llm = detectLlm(llmOption, false);
 
-        if (llm !== 'claude-code') {
-          console.error(`❌ Unknown LLM: ${llm}\n`);
-          console.error('Supported: claude-code, auto\n');
-          process.exit(2);
-        }
-
-        // Fetch template from registry
-        const [dossierName, version] = parseNameVersion(options.template);
-        let metaDossierContent = '';
-
-        // Check cache first
-        const cacheDir = path.join(os.homedir(), '.dossier', 'cache');
-        const dossierCacheDir = path.join(cacheDir, ...dossierName.split('/'));
-        let cached = false;
-
-        if (fs.existsSync(dossierCacheDir)) {
-          const metaFiles = fs
-            .readdirSync(dossierCacheDir)
-            .filter((f: string) => f.endsWith('.meta.json'));
-          for (const mf of metaFiles) {
-            const ver = mf.replace('.meta.json', '');
-            if (version && ver !== version) continue;
-            const contentFile = path.join(dossierCacheDir, `${ver}.ds.md`);
-            if (fs.existsSync(contentFile)) {
-              metaDossierContent = fs.readFileSync(contentFile, 'utf8');
-              cached = true;
-              console.log(`📦 Using cached template: ${dossierName}@${ver}\n`);
-              break;
-            }
-          }
-        }
-
-        if (!cached) {
-          try {
-            const client = getClient();
-            let resolvedVersion = version;
-            if (!resolvedVersion) {
-              const meta = await client.getDossier(dossierName);
-              resolvedVersion = meta.version || 'latest';
-            }
-            const result = await client.getDossierContent(dossierName, resolvedVersion);
-            metaDossierContent = result.content;
-            console.log(`📥 Fetched template: ${dossierName}@${resolvedVersion}\n`);
-          } catch (err: any) {
-            if (err.statusCode === 404) {
-              console.error(`❌ Template not found: ${options.template}`);
-              console.error(
-                '   Check the template name or use --template to specify a different one\n'
-              );
-            } else {
-              console.error(`❌ Failed to fetch template: ${err.message}\n`);
-            }
+          if (!llm) {
             process.exit(2);
           }
-        }
 
-        const contextHeader = `
+          if (llm !== 'claude-code') {
+            console.error(`❌ Unknown LLM: ${llm}\n`);
+            console.error('Supported: claude-code, auto\n');
+            process.exit(2);
+          }
+
+          // Fetch template from registry
+          const [dossierName, version] = parseNameVersion(options.template);
+          let metaDossierContent = '';
+
+          // Check cache first
+          const cacheDir = path.join(os.homedir(), '.dossier', 'cache');
+          const dossierCacheDir = path.join(cacheDir, ...dossierName.split('/'));
+          let cached = false;
+
+          if (fs.existsSync(dossierCacheDir)) {
+            const metaFiles = fs
+              .readdirSync(dossierCacheDir)
+              .filter((f: string) => f.endsWith('.meta.json'));
+            for (const mf of metaFiles) {
+              const ver = mf.replace('.meta.json', '');
+              if (version && ver !== version) continue;
+              const contentFile = path.join(dossierCacheDir, `${ver}.ds.md`);
+              if (fs.existsSync(contentFile)) {
+                metaDossierContent = fs.readFileSync(contentFile, 'utf8');
+                cached = true;
+                console.log(`📦 Using cached template: ${dossierName}@${ver}\n`);
+                break;
+              }
+            }
+          }
+
+          if (!cached) {
+            try {
+              const client = getClient();
+              let resolvedVersion = version;
+              if (!resolvedVersion) {
+                const meta = await client.getDossier(dossierName);
+                resolvedVersion = meta.version || 'latest';
+              }
+              const result = await client.getDossierContent(dossierName, resolvedVersion);
+              metaDossierContent = result.content;
+              console.log(`📥 Fetched template: ${dossierName}@${resolvedVersion}\n`);
+            } catch (err: unknown) {
+              const e = err as { statusCode?: number; message: string };
+              if (e.statusCode === 404) {
+                console.error(`❌ Template not found: ${options.template}`);
+                console.error(
+                  '   Check the template name or use --template to specify a different one\n'
+                );
+              } else {
+                console.error(`❌ Failed to fetch template: ${e.message}\n`);
+              }
+              process.exit(2);
+            }
+          }
+
+          const contextHeader = `
 # USER-PROVIDED CONTEXT
 
 The user ran the dossier create command with the following parameters:
@@ -105,39 +118,41 @@ ${options.template !== DEFAULT_CREATE_TEMPLATE ? `- **Template reference**: ${op
 
 `;
 
-        const tmpFile = path.join(os.tmpdir(), `dossier-create-${Date.now()}.ds.md`);
-        fs.writeFileSync(tmpFile, contextHeader + metaDossierContent, 'utf8');
+          const tmpFile = path.join(os.tmpdir(), `dossier-create-${Date.now()}.ds.md`);
+          fs.writeFileSync(tmpFile, contextHeader + metaDossierContent, 'utf8');
 
-        console.log('🤖 Launching dossier creation assistant (interactive mode)...\n');
+          console.log('🤖 Launching dossier creation assistant (interactive mode)...\n');
 
-        try {
-          const result = spawnSync('claude', [tmpFile], { stdio: 'inherit' });
           try {
-            fs.unlinkSync(tmpFile);
-          } catch (cleanupErr) {
-            process.stderr.write(
-              `Warning: failed to clean up temp file ${tmpFile}: ${(cleanupErr as Error).message}\n`
-            );
+            const result = spawnSync('claude', [tmpFile], { stdio: 'inherit' });
+            try {
+              fs.unlinkSync(tmpFile);
+            } catch (cleanupErr) {
+              process.stderr.write(
+                `Warning: failed to clean up temp file ${tmpFile}: ${(cleanupErr as Error).message}\n`
+              );
+            }
+            if (result.status !== 0) {
+              throw { status: result.status, message: `claude exited with code ${result.status}` };
+            }
+          } catch (execError) {
+            try {
+              fs.unlinkSync(tmpFile);
+            } catch (cleanupErr) {
+              process.stderr.write(
+                `Warning: failed to clean up temp file ${tmpFile}: ${(cleanupErr as Error).message}\n`
+              );
+            }
+            throw execError;
           }
-          if (result.status !== 0) {
-            throw { status: result.status, message: `claude exited with code ${result.status}` };
-          }
-        } catch (execError) {
-          try {
-            fs.unlinkSync(tmpFile);
-          } catch (cleanupErr) {
-            process.stderr.write(
-              `Warning: failed to clean up temp file ${tmpFile}: ${(cleanupErr as Error).message}\n`
-            );
-          }
-          throw execError;
+
+          console.log('\n✅ Dossier creation completed');
+        } catch (error: unknown) {
+          const e = error as { message?: string; status?: number };
+          console.error('\n❌ Dossier creation failed');
+          console.error(`   Error: ${e.message}`);
+          process.exit(e.status || 2);
         }
-
-        console.log('\n✅ Dossier creation completed');
-      } catch (error: any) {
-        console.error('\n❌ Dossier creation failed');
-        console.error(`   Error: ${error.message}`);
-        process.exit(error.status || 2);
       }
-    });
+    );
 }

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -35,7 +35,8 @@ export function registerCreateCommand(program: Command): void {
         }
       ) => {
         try {
-          const llmOption = options.llm || config.getConfig('defaultLlm') || 'auto';
+          const llmOption =
+            options.llm || (config.getConfig('defaultLlm') as string | undefined) || 'auto';
           const llm = detectLlm(llmOption, false);
 
           if (!llm) {

--- a/cli/src/commands/export.ts
+++ b/cli/src/commands/export.ts
@@ -20,11 +20,12 @@ export function registerExportCommand(program: Command): void {
         const result = await client.getDossierContent(dossierName, version || null);
         content = result.content;
         digest = result.digest;
-      } catch (err: any) {
-        if (err.statusCode === 404) {
+      } catch (err: unknown) {
+        const e = err as { statusCode?: number; message: string };
+        if (e.statusCode === 404) {
           console.error(`\n❌ Not found: ${name}\n`);
         } else {
-          console.error(`\n❌ Export failed: ${err.message}\n`);
+          console.error(`\n❌ Export failed: ${e.message}\n`);
         }
         process.exit(1);
         return;

--- a/cli/src/commands/format.ts
+++ b/cli/src/commands/format.ts
@@ -12,50 +12,61 @@ export function registerFormatCommand(program: Command): void {
     .option('--no-sort-keys', 'Do not sort frontmatter keys')
     .option('--indent <n>', 'JSON indentation spaces', '2')
     .option('--json', 'Output result as JSON')
-    .action((file: string, options: any) => {
-      const formatOptions = {
-        indent: parseInt(options.indent, 10),
-        sortKeys: options.sortKeys !== false,
-        updateChecksum: options.checksum !== false,
-      };
-
-      let exitCode = 0;
-      try {
-        if (options.check) {
-          const content = fs.readFileSync(file, 'utf8');
-          const result = formatDossierContent(content, formatOptions);
-
-          if (options.json) {
-            console.log(JSON.stringify({ file, formatted: !result.changed }, null, 2));
-          } else {
-            if (result.changed) {
-              console.log(`${file}: needs formatting`);
-            } else {
-              console.log(`${file}: already formatted`);
-            }
-          }
-
-          exitCode = result.changed ? 1 : 0;
-        } else {
-          const result = formatDossierFile(file, formatOptions);
-
-          if (options.json) {
-            console.log(JSON.stringify({ file, changed: result.changed }, null, 2));
-          } else {
-            if (result.changed) {
-              console.log(`${file}: formatted`);
-            } else {
-              console.log(`${file}: already formatted`);
-            }
-          }
-
-          exitCode = 0;
+    .action(
+      (
+        file: string,
+        options: {
+          check?: boolean;
+          checksum?: boolean;
+          sortKeys?: boolean;
+          indent: string;
+          json?: boolean;
         }
-      } catch (err: any) {
-        console.error(`Error: ${err.message}`);
-        exitCode = 2;
-      }
+      ) => {
+        const formatOptions = {
+          indent: parseInt(options.indent, 10),
+          sortKeys: options.sortKeys !== false,
+          updateChecksum: options.checksum !== false,
+        };
 
-      process.exit(exitCode);
-    });
+        let exitCode = 0;
+        try {
+          if (options.check) {
+            const content = fs.readFileSync(file, 'utf8');
+            const result = formatDossierContent(content, formatOptions);
+
+            if (options.json) {
+              console.log(JSON.stringify({ file, formatted: !result.changed }, null, 2));
+            } else {
+              if (result.changed) {
+                console.log(`${file}: needs formatting`);
+              } else {
+                console.log(`${file}: already formatted`);
+              }
+            }
+
+            exitCode = result.changed ? 1 : 0;
+          } else {
+            const result = formatDossierFile(file, formatOptions);
+
+            if (options.json) {
+              console.log(JSON.stringify({ file, changed: result.changed }, null, 2));
+            } else {
+              if (result.changed) {
+                console.log(`${file}: formatted`);
+              } else {
+                console.log(`${file}: already formatted`);
+              }
+            }
+
+            exitCode = 0;
+          }
+        } catch (err: unknown) {
+          console.error(`Error: ${(err as Error).message}`);
+          exitCode = 2;
+        }
+
+        process.exit(exitCode);
+      }
+    );
 }

--- a/cli/src/commands/get.ts
+++ b/cli/src/commands/get.ts
@@ -15,11 +15,12 @@ export function registerGetCommand(program: Command): void {
       try {
         const client = getClient();
         meta = await client.getDossier(dossierName, version || null);
-      } catch (err: any) {
-        if (err.statusCode === 404) {
+      } catch (err: unknown) {
+        const e = err as { statusCode?: number; message: string };
+        if (e.statusCode === 404) {
           console.error(`\n❌ Not found in registry: ${nameArg}\n`);
         } else {
-          console.error(`\n❌ Registry error: ${err.message}\n`);
+          console.error(`\n❌ Registry error: ${e.message}\n`);
         }
         process.exit(1);
       }

--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { parseDossierContent } from '@ai-dossier/core';
 import type { Command } from 'commander';
+import type { DossierInfo } from '../registry-client';
 import { getClient, parseNameVersion } from '../registry-client';
 
 export function registerInfoCommand(program: Command): void {
@@ -12,7 +13,7 @@ export function registerInfoCommand(program: Command): void {
     .argument('<file-or-name>', 'Local dossier file path or registry dossier name')
     .option('--json', 'Output as JSON')
     .action(async (fileOrName: string, options: { json?: boolean }) => {
-      let frontmatter: Record<string, any>;
+      let frontmatter: DossierInfo;
       let body: string | null;
       let source: string;
 
@@ -25,7 +26,7 @@ export function registerInfoCommand(program: Command): void {
 
         try {
           const parsed = parseDossierContent(content);
-          frontmatter = parsed.frontmatter as Record<string, any>;
+          frontmatter = parsed.frontmatter as unknown as DossierInfo;
           body = parsed.body;
         } catch {
           console.error('\n❌ Invalid dossier format: no frontmatter found\n');
@@ -39,26 +40,27 @@ export function registerInfoCommand(program: Command): void {
           const meta = await client.getDossier(dossierName, version || null);
           frontmatter = meta;
           body = null;
-        } catch (err: any) {
-          if (err.statusCode === 404) {
+        } catch (err: unknown) {
+          const e = err as { statusCode?: number; message: string };
+          if (e.statusCode === 404) {
             console.error(`\n❌ Not found: ${fileOrName}`);
             console.error('   Not a local file and not found in registry\n');
           } else {
-            console.error(`\n❌ Error: ${err.message}\n`);
+            console.error(`\n❌ Error: ${e.message}\n`);
           }
           process.exit(1);
         }
       }
 
       if (options.json) {
-        console.log(JSON.stringify(frontmatter!, null, 2));
+        console.log(JSON.stringify(frontmatter, null, 2));
         process.exit(0);
       }
 
       console.log(`\n📄 Dossier Info\n`);
       console.log(`   Source:    ${source}`);
 
-      const fm = frontmatter!;
+      const fm = frontmatter;
       const fields: [string, string][] = [
         ['Name', fm.name || fm.title || ''],
         ['Title', fm.title || ''],
@@ -78,7 +80,7 @@ export function registerInfoCommand(program: Command): void {
       const authors = fm.authors;
       if (Array.isArray(authors) && authors.length > 0) {
         const authorStr = authors
-          .map((a: any) => {
+          .map((a: string | { name: string }) => {
             if (typeof a === 'string') {
               const nameMatch = a.match(/^name:\s*(.+)$/);
               return nameMatch ? nameMatch[1] : a;

--- a/cli/src/commands/install-skill.ts
+++ b/cli/src/commands/install-skill.ts
@@ -163,8 +163,8 @@ export function registerInstallSkillCommand(program: Command): void {
           let summary = '';
           try {
             const parsed = parseDossierContent(content);
-            const fm = parsed.frontmatter as Record<string, any>;
-            summary = fm.objective || '';
+            const fm = parsed.frontmatter as Record<string, unknown>;
+            summary = (fm.objective as string) || '';
             if (!summary) {
               const firstLine = parsed.body.split('\n').find((l) => l.trim().length > 0);
               summary = firstLine?.replace(/^#+\s*/, '').trim() || '';
@@ -203,23 +203,24 @@ export function registerInstallSkillCommand(program: Command): void {
             }
             console.log('');
           }
-        } catch (err: any) {
+        } catch (err: unknown) {
+          const e = err as { statusCode?: number; message: string };
           if (options.json) {
             console.log(
               JSON.stringify(
                 {
                   success: false,
-                  error: err.statusCode === 404 ? 'not_found' : 'install_failed',
-                  message: err.statusCode === 404 ? `Not found: ${name}` : err.message,
+                  error: e.statusCode === 404 ? 'not_found' : 'install_failed',
+                  message: e.statusCode === 404 ? `Not found: ${name}` : e.message,
                 },
                 null,
                 2
               )
             );
-          } else if (err.statusCode === 404) {
+          } else if (e.statusCode === 404) {
             console.error(`\n❌ Not found in registry: ${name}\n`);
           } else {
-            console.error(`\n❌ Install failed: ${err.message}\n`);
+            console.error(`\n❌ Install failed: ${e.message}\n`);
           }
           process.exit(1);
         }

--- a/cli/src/commands/lint.ts
+++ b/cli/src/commands/lint.ts
@@ -1,5 +1,12 @@
 import fs from 'node:fs';
-import { defaultRules, LintRuleRegistry, lintDossierFile } from '@ai-dossier/core';
+import {
+  defaultRules,
+  type LintConfig,
+  type LintResult,
+  type LintRule,
+  LintRuleRegistry,
+  lintDossierFile,
+} from '@ai-dossier/core';
 import type { Command } from 'commander';
 
 export function registerLintCommand(program: Command): void {
@@ -12,104 +19,115 @@ export function registerLintCommand(program: Command): void {
     .option('--quiet', 'Only show errors (suppress warnings and info)')
     .option('--config <path>', 'Path to .dossierrc.json config file')
     .option('--list-rules', 'List all available lint rules and exit')
-    .action((file: string | undefined, options: any) => {
-      if (options.listRules) {
-        const registry = new LintRuleRegistry();
-        registry.registerAll(defaultRules);
-        const rules = registry.getRules();
+    .action(
+      (
+        file: string | undefined,
+        options: {
+          listRules?: boolean;
+          json?: boolean;
+          quiet?: boolean;
+          strict?: boolean;
+          config?: string;
+        }
+      ) => {
+        if (options.listRules) {
+          const registry = new LintRuleRegistry();
+          registry.registerAll(defaultRules);
+          const rules = registry.getRules();
+
+          if (options.json) {
+            console.log(
+              JSON.stringify(
+                rules.map((r: LintRule) => ({
+                  id: r.id,
+                  description: r.description,
+                  defaultSeverity: r.defaultSeverity,
+                })),
+                null,
+                2
+              )
+            );
+          } else {
+            console.log('Available lint rules:\n');
+            for (const rule of rules) {
+              const severity = rule.defaultSeverity.toUpperCase().padEnd(7);
+              console.log(`  ${severity}  ${rule.id}`);
+              console.log(`           ${rule.description}\n`);
+            }
+          }
+          process.exit(0);
+        }
+
+        if (!file) {
+          console.error('Error: missing required argument "file"');
+          process.exit(2);
+        }
+
+        let lintConfig: LintConfig | undefined;
+        if (options.config) {
+          try {
+            const raw = fs.readFileSync(options.config, 'utf8');
+            const parsed = JSON.parse(raw);
+            lintConfig = { rules: parsed.rules || {} };
+          } catch (err: unknown) {
+            console.error(`Error loading config: ${(err as Error).message}`);
+            process.exit(2);
+          }
+        }
+
+        let result: LintResult;
+        try {
+          result = lintDossierFile(file, lintConfig);
+        } catch (err: unknown) {
+          console.error(`Error: ${(err as Error).message}`);
+          process.exit(2);
+        }
+
+        let diagnostics = result.diagnostics;
+        if (options.quiet) {
+          diagnostics = diagnostics.filter((d) => d.severity === 'error');
+        }
 
         if (options.json) {
           console.log(
             JSON.stringify(
-              rules.map((r: any) => ({
-                id: r.id,
-                description: r.description,
-                defaultSeverity: r.defaultSeverity,
-              })),
+              {
+                file,
+                diagnostics,
+                errorCount: result.errorCount,
+                warningCount: result.warningCount,
+                infoCount: result.infoCount,
+              },
               null,
               2
             )
           );
         } else {
-          console.log('Available lint rules:\n');
-          for (const rule of rules) {
-            const severity = rule.defaultSeverity.toUpperCase().padEnd(7);
-            console.log(`  ${severity}  ${rule.id}`);
-            console.log(`           ${rule.description}\n`);
+          if (diagnostics.length === 0) {
+            console.log(`${file}: no issues found`);
+          } else {
+            for (const d of diagnostics) {
+              const icon = d.severity === 'error' ? 'x' : d.severity === 'warning' ? '!' : 'i';
+              const field = d.field ? ` (${d.field})` : '';
+              console.log(`  ${icon} ${d.severity.padEnd(7)}  ${d.message}${field}  [${d.ruleId}]`);
+            }
+            console.log(
+              `\n  ${result.errorCount} error(s), ${result.warningCount} warning(s), ${result.infoCount} info`
+            );
           }
         }
-        process.exit(0);
-      }
 
-      if (!file) {
-        console.error('Error: missing required argument "file"');
-        process.exit(2);
-      }
+        const effectiveErrors = options.strict
+          ? result.errorCount + result.warningCount
+          : result.errorCount;
 
-      let lintConfig: any;
-      if (options.config) {
-        try {
-          const raw = fs.readFileSync(options.config, 'utf8');
-          const parsed = JSON.parse(raw);
-          lintConfig = { rules: parsed.rules || {} };
-        } catch (err: any) {
-          console.error(`Error loading config: ${err.message}`);
+        if (effectiveErrors > 0) {
           process.exit(2);
-        }
-      }
-
-      let result: any;
-      try {
-        result = lintDossierFile(file, lintConfig);
-      } catch (err: any) {
-        console.error(`Error: ${err.message}`);
-        process.exit(2);
-      }
-
-      let diagnostics = result.diagnostics;
-      if (options.quiet) {
-        diagnostics = diagnostics.filter((d: any) => d.severity === 'error');
-      }
-
-      if (options.json) {
-        console.log(
-          JSON.stringify(
-            {
-              file,
-              diagnostics,
-              errorCount: result.errorCount,
-              warningCount: result.warningCount,
-              infoCount: result.infoCount,
-            },
-            null,
-            2
-          )
-        );
-      } else {
-        if (diagnostics.length === 0) {
-          console.log(`${file}: no issues found`);
+        } else if (result.warningCount > 0) {
+          process.exit(1);
         } else {
-          for (const d of diagnostics) {
-            const icon = d.severity === 'error' ? 'x' : d.severity === 'warning' ? '!' : 'i';
-            const field = d.field ? ` (${d.field})` : '';
-            console.log(`  ${icon} ${d.severity.padEnd(7)}  ${d.message}${field}  [${d.ruleId}]`);
-          }
-          console.log(
-            `\n  ${result.errorCount} error(s), ${result.warningCount} warning(s), ${result.infoCount} info`
-          );
+          process.exit(0);
         }
       }
-
-      const effectiveErrors = options.strict
-        ? result.errorCount + result.warningCount
-        : result.errorCount;
-
-      if (effectiveErrors > 0) {
-        process.exit(2);
-      } else if (result.warningCount > 0) {
-        process.exit(1);
-      } else {
-        process.exit(0);
-      }
-    });
+    );
 }

--- a/cli/src/commands/list.ts
+++ b/cli/src/commands/list.ts
@@ -28,186 +28,197 @@ export function registerListCommand(program: Command): void {
     .option('--source <type>', 'Source type: registry, local, github')
     .option('--page <number>', 'Page number (registry only)', '1')
     .option('--per-page <number>', 'Results per page (registry only)', '20')
-    .action(async (source: string, options: any) => {
-      if (options.json) {
-        options.format = 'json';
-      }
-
-      if (options.source === 'registry') {
-        const page = parseInt(options.page, 10) || 1;
-        const perPage = parseInt(options.perPage, 10) || 20;
-
-        let registryResult: ListDossiersResult;
-        try {
-          const client = getClient();
-          registryResult = await client.listDossiers({
-            category: options.category,
-            page,
-            perPage,
-          });
-        } catch (err: unknown) {
-          console.error(`\n❌ Registry list failed: ${(err as Error).message}\n`);
-          process.exit(1);
+    .action(
+      async (
+        source: string,
+        options: {
+          json?: boolean;
+          format?: string;
+          source?: string;
+          page?: string;
+          perPage?: string;
+        }
+      ) => {
+        if (options.json) {
+          options.format = 'json';
         }
 
-        const dossiers = registryResult.dossiers || registryResult.data || [];
+        if (options.source === 'registry') {
+          const page = parseInt(options.page, 10) || 1;
+          const perPage = parseInt(options.perPage, 10) || 20;
 
-        if (options.format === 'json') {
-          console.log(JSON.stringify(registryResult, null, 2));
-          process.exit(0);
-        }
+          let registryResult: ListDossiersResult;
+          try {
+            const client = getClient();
+            registryResult = await client.listDossiers({
+              category: options.category,
+              page,
+              perPage,
+            });
+          } catch (err: unknown) {
+            console.error(`\n❌ Registry list failed: ${(err as Error).message}\n`);
+            process.exit(1);
+          }
 
-        if (options.format === 'simple') {
+          const dossiers = registryResult.dossiers || registryResult.data || [];
+
+          if (options.format === 'json') {
+            console.log(JSON.stringify(registryResult, null, 2));
+            process.exit(0);
+          }
+
+          if (options.format === 'simple') {
+            for (const d of dossiers) {
+              console.log(d.name || '');
+            }
+            process.exit(0);
+          }
+
+          if (dossiers.length === 0) {
+            console.log('\n⚠️  No dossiers found in registry\n');
+            process.exit(0);
+          }
+
+          const total = registryResult.total || dossiers.length;
+          console.log(`\n📋 Registry dossiers (${total} total):\n`);
+
           for (const d of dossiers) {
-            console.log(d.name || '');
+            const name = d.name || '';
+            const version = d.version || '';
+            const title = d.title || '';
+            const category = Array.isArray(d.category) ? d.category.join(', ') : d.category || '';
+            console.log(
+              `  ${name.padEnd(30)} ${(`v${version}`).padEnd(10)} ${category.padEnd(12)} ${title}`
+            );
           }
+
+          const totalPages = registryResult.totalPages || Math.ceil(total / perPage);
+          if (totalPages > 1) {
+            console.log(`\nPage ${page}/${totalPages}`);
+            if (page < totalPages) {
+              console.log(`Use --page ${page + 1} to see more results`);
+            }
+          }
+          console.log('');
           process.exit(0);
         }
 
-        if (dossiers.length === 0) {
-          console.log('\n⚠️  No dossiers found in registry\n');
-          process.exit(0);
-        }
+        const parsed = parseListSource(source);
+        let dossiers: DossierMetadata[] = [];
 
-        const total = registryResult.total || dossiers.length;
-        console.log(`\n📋 Registry dossiers (${total} total):\n`);
-
-        for (const d of dossiers) {
-          const name = d.name || '';
-          const version = d.version || '';
-          const title = d.title || '';
-          const category = Array.isArray(d.category) ? d.category.join(', ') : d.category || '';
-          console.log(
-            `  ${name.padEnd(30)} ${(`v${version}`).padEnd(10)} ${category.padEnd(12)} ${title}`
-          );
-        }
-
-        const totalPages = registryResult.totalPages || Math.ceil(total / perPage);
-        if (totalPages > 1) {
-          console.log(`\nPage ${page}/${totalPages}`);
-          if (page < totalPages) {
-            console.log(`Use --page ${page + 1} to see more results`);
+        if (parsed.type === 'github') {
+          console.log(`\n🔍 Fetching dossiers from GitHub: ${parsed.owner}/${parsed.repo}`);
+          if (parsed.path) {
+            console.log(`   Path: ${parsed.path}`);
           }
-        }
-        console.log('');
-        process.exit(0);
-      }
+          console.log(`   Branch: ${parsed.branch}\n`);
 
-      const parsed = parseListSource(source);
-      let dossiers: DossierMetadata[] = [];
+          try {
+            const files = await findDossierFilesGitHub(
+              parsed.owner ?? '',
+              parsed.repo ?? '',
+              parsed.path || '',
+              parsed.branch ?? 'main'
+            );
 
-      if (parsed.type === 'github') {
-        console.log(`\n🔍 Fetching dossiers from GitHub: ${parsed.owner}/${parsed.repo}`);
-        if (parsed.path) {
-          console.log(`   Path: ${parsed.path}`);
-        }
-        console.log(`   Branch: ${parsed.branch}\n`);
+            if (files.length === 0) {
+              console.log('⚠️  No dossiers found (*.ds.md files)');
+              process.exit(0);
+            }
 
-        try {
-          const files = await findDossierFilesGitHub(
-            parsed.owner ?? '',
-            parsed.repo ?? '',
-            parsed.path || '',
-            parsed.branch ?? 'main'
-          );
+            console.log(`   Found ${files.length} dossier file(s)\n`);
+            console.log('📥 Fetching metadata...\n');
+
+            const batchSize = 5;
+            for (let i = 0; i < files.length; i += batchSize) {
+              const batch = files.slice(i, i + batchSize);
+              const results = await Promise.all(
+                batch.map((f) => fetchDossierMetadata(f.rawUrl, f.path))
+              );
+              dossiers.push(...results);
+            }
+          } catch (err: unknown) {
+            console.log(`❌ Error: ${(err as Error).message}`);
+            process.exit(1);
+          }
+        } else {
+          const searchDir = path.resolve(parsed.path || '.');
+
+          if (!fs.existsSync(searchDir)) {
+            console.log(`❌ Directory not found: ${searchDir}`);
+            process.exit(1);
+          }
+
+          if (!fs.statSync(searchDir).isDirectory()) {
+            console.log(`❌ Not a directory: ${searchDir}`);
+            process.exit(1);
+          }
+
+          console.log(`\n🔍 Searching for dossiers in: ${searchDir}`);
+          if (options.recursive) {
+            console.log('   (recursive search enabled)');
+          }
+
+          const files = findDossierFilesLocal(searchDir, options.recursive);
 
           if (files.length === 0) {
-            console.log('⚠️  No dossiers found (*.ds.md files)');
+            console.log('\n⚠️  No dossiers found (*.ds.md files)');
+            console.log('\nTips:');
+            console.log('  - Use --recursive to search subdirectories');
+            console.log('  - Ensure files have the .ds.md extension');
+            console.log('  - Try: dossier list github:owner/repo\n');
             process.exit(0);
           }
 
           console.log(`   Found ${files.length} dossier file(s)\n`);
-          console.log('📥 Fetching metadata...\n');
+          dossiers = files.map((f) => parseDossierMetadataLocal(f));
+        }
 
-          const batchSize = 5;
-          for (let i = 0; i < files.length; i += batchSize) {
-            const batch = files.slice(i, i + batchSize);
-            const results = await Promise.all(
-              batch.map((f) => fetchDossierMetadata(f.rawUrl, f.path))
-            );
-            dossiers.push(...results);
+        if (options.signedOnly) {
+          dossiers = dossiers.filter((d) => d.signed === true);
+        }
+        if (options.risk) {
+          const riskLevel = options.risk.toLowerCase();
+          dossiers = dossiers.filter((d) => (d.risk_level || '').toLowerCase() === riskLevel);
+        }
+        if (options.category) {
+          const category = options.category.toLowerCase();
+          dossiers = dossiers.filter((d) => (d.category || '').toLowerCase().includes(category));
+        }
+
+        if (options.format === 'json') {
+          console.log(JSON.stringify(dossiers, null, 2));
+        } else if (options.format === 'simple') {
+          for (const d of dossiers) {
+            console.log(d.path);
           }
-        } catch (err: unknown) {
-          console.log(`❌ Error: ${(err as Error).message}`);
-          process.exit(1);
-        }
-      } else {
-        const searchDir = path.resolve(parsed.path || '.');
+        } else {
+          console.log(formatTable(dossiers, options.showPath));
 
-        if (!fs.existsSync(searchDir)) {
-          console.log(`❌ Directory not found: ${searchDir}`);
-          process.exit(1);
-        }
+          console.log(`\nTotal: ${dossiers.length} dossier(s)`);
 
-        if (!fs.statSync(searchDir).isDirectory()) {
-          console.log(`❌ Not a directory: ${searchDir}`);
-          process.exit(1);
-        }
+          const signed = dossiers.filter((d) => d.signed).length;
+          const unsigned = dossiers.length - signed;
+          if (signed > 0 || unsigned > 0) {
+            console.log(`   Signed: ${signed}  |  Unsigned: ${unsigned}`);
+          }
 
-        console.log(`\n🔍 Searching for dossiers in: ${searchDir}`);
-        if (options.recursive) {
-          console.log('   (recursive search enabled)');
-        }
+          const riskCounts: Record<string, number> = {};
+          for (const d of dossiers) {
+            const risk = (d.risk_level || 'unknown').toLowerCase();
+            riskCounts[risk] = (riskCounts[risk] || 0) + 1;
+          }
+          const riskSummary = Object.entries(riskCounts)
+            .map(([k, v]) => `${k}: ${v}`)
+            .join('  |  ');
+          if (riskSummary) {
+            console.log(`   Risk: ${riskSummary}`);
+          }
 
-        const files = findDossierFilesLocal(searchDir, options.recursive);
-
-        if (files.length === 0) {
-          console.log('\n⚠️  No dossiers found (*.ds.md files)');
-          console.log('\nTips:');
-          console.log('  - Use --recursive to search subdirectories');
-          console.log('  - Ensure files have the .ds.md extension');
-          console.log('  - Try: dossier list github:owner/repo\n');
-          process.exit(0);
+          console.log('');
         }
 
-        console.log(`   Found ${files.length} dossier file(s)\n`);
-        dossiers = files.map((f) => parseDossierMetadataLocal(f));
+        process.exit(0);
       }
-
-      if (options.signedOnly) {
-        dossiers = dossiers.filter((d) => d.signed === true);
-      }
-      if (options.risk) {
-        const riskLevel = options.risk.toLowerCase();
-        dossiers = dossiers.filter((d) => (d.risk_level || '').toLowerCase() === riskLevel);
-      }
-      if (options.category) {
-        const category = options.category.toLowerCase();
-        dossiers = dossiers.filter((d) => (d.category || '').toLowerCase().includes(category));
-      }
-
-      if (options.format === 'json') {
-        console.log(JSON.stringify(dossiers, null, 2));
-      } else if (options.format === 'simple') {
-        for (const d of dossiers) {
-          console.log(d.path);
-        }
-      } else {
-        console.log(formatTable(dossiers, options.showPath));
-
-        console.log(`\nTotal: ${dossiers.length} dossier(s)`);
-
-        const signed = dossiers.filter((d) => d.signed).length;
-        const unsigned = dossiers.length - signed;
-        if (signed > 0 || unsigned > 0) {
-          console.log(`   Signed: ${signed}  |  Unsigned: ${unsigned}`);
-        }
-
-        const riskCounts: Record<string, number> = {};
-        for (const d of dossiers) {
-          const risk = (d.risk_level || 'unknown').toLowerCase();
-          riskCounts[risk] = (riskCounts[risk] || 0) + 1;
-        }
-        const riskSummary = Object.entries(riskCounts)
-          .map(([k, v]) => `${k}: ${v}`)
-          .join('  |  ');
-        if (riskSummary) {
-          console.log(`   Risk: ${riskSummary}`);
-        }
-
-        console.log('');
-      }
-
-      process.exit(0);
-    });
+    );
 }

--- a/cli/src/commands/list.ts
+++ b/cli/src/commands/list.ts
@@ -37,6 +37,11 @@ export function registerListCommand(program: Command): void {
           source?: string;
           page?: string;
           perPage?: string;
+          recursive?: boolean;
+          signedOnly?: boolean;
+          risk?: string;
+          category?: string;
+          showPath?: boolean;
         }
       ) => {
         if (options.json) {
@@ -44,8 +49,8 @@ export function registerListCommand(program: Command): void {
         }
 
         if (options.source === 'registry') {
-          const page = parseInt(options.page, 10) || 1;
-          const perPage = parseInt(options.perPage, 10) || 20;
+          const page = parseInt(options.page || '1', 10) || 1;
+          const perPage = parseInt(options.perPage || '20', 10) || 20;
 
           let registryResult: ListDossiersResult;
           try {

--- a/cli/src/commands/publish.ts
+++ b/cli/src/commands/publish.ts
@@ -63,11 +63,11 @@ export function registerPublishCommand(program: Command): void {
 
         const content = fs.readFileSync(dossierFile, 'utf8');
 
-        let frontmatter: Record<string, any>;
+        let frontmatter: DossierFrontmatter;
         let body: string;
         try {
           const parsed = parseDossierContent(content);
-          frontmatter = parsed.frontmatter as Record<string, any>;
+          frontmatter = parsed.frontmatter;
           body = parsed.body;
         } catch (err: unknown) {
           console.error(`\n❌ ${(err as Error).message}\n`);
@@ -220,32 +220,33 @@ export function registerPublishCommand(program: Command): void {
               `\n   ⏳ CDN propagation may take up to ${cdnDelaySeconds}s. Verify with:\n   $ ${verifyCommand}\n`
             );
           }
-        } catch (err: any) {
+        } catch (err: unknown) {
+          const e = err as { statusCode?: number; message: string; code?: string };
           if (options.json) {
             console.log(
               JSON.stringify(
                 {
                   published: false,
-                  error: err.message,
-                  code: err.code || 'publish_failed',
+                  error: e.message,
+                  code: e.code || 'publish_failed',
                 },
                 null,
                 2
               )
             );
-          } else if (err.statusCode === 401) {
+          } else if (e.statusCode === 401) {
             console.error('\n❌ Session expired. Run `dossier login` to re-authenticate.\n');
-          } else if (err.statusCode === 403) {
-            console.error(`\n❌ Permission denied: ${err.message}\n`);
-          } else if (err.statusCode === 409) {
-            console.error(`\n❌ Version conflict: ${registryPath} — ${err.message}\n`);
+          } else if (e.statusCode === 403) {
+            console.error(`\n❌ Permission denied: ${e.message}\n`);
+          } else if (e.statusCode === 409) {
+            console.error(`\n❌ Version conflict: ${registryPath} — ${e.message}\n`);
           } else {
-            console.error(`\n❌ Publish failed: ${err.message}`);
-            if (err.statusCode) {
-              console.error(`   Status: ${err.statusCode}`);
+            console.error(`\n❌ Publish failed: ${e.message}`);
+            if (e.statusCode) {
+              console.error(`   Status: ${e.statusCode}`);
             }
-            if (err.code) {
-              console.error(`   Code: ${err.code}`);
+            if (e.code) {
+              console.error(`   Code: ${e.code}`);
             }
             console.error('');
           }

--- a/cli/src/commands/pull.ts
+++ b/cli/src/commands/pull.ts
@@ -66,11 +66,12 @@ export function registerPullCommand(program: Command): void {
           const status = options.force ? 'updated' : 'downloaded';
           console.log(`✅ ${dossierName}@${version} (${status})`);
           console.log(`   ${contentFile}`);
-        } catch (err: any) {
-          if (err.statusCode === 404) {
+        } catch (err: unknown) {
+          const e = err as { statusCode?: number; message: string };
+          if (e.statusCode === 404) {
             console.error(`❌ ${nameArg}: not found in registry`);
           } else {
-            console.error(`❌ ${nameArg}: ${err.message}`);
+            console.error(`❌ ${nameArg}: ${e.message}`);
           }
         }
       }

--- a/cli/src/commands/remove.ts
+++ b/cli/src/commands/remove.ts
@@ -98,27 +98,28 @@ export function registerRemoveCommand(program: Command): void {
             `\n   ⏳ CDN propagation may take up to ${cdnDelaySeconds}s. Verify with:\n   $ ${verifyCommand}\n`
           );
         }
-      } catch (err: any) {
+      } catch (err: unknown) {
+        const e = err as { statusCode?: number; message: string; code?: string };
         if (options.json) {
           console.log(
             JSON.stringify(
               {
                 removed: false,
-                error: err.message,
-                code: err.code || 'remove_failed',
+                error: e.message,
+                code: e.code || 'remove_failed',
               },
               null,
               2
             )
           );
-        } else if (err.statusCode === 401) {
+        } else if (e.statusCode === 401) {
           console.error('\n❌ Session expired. Run `dossier login` to re-authenticate.\n');
-        } else if (err.statusCode === 403) {
-          console.error(`\n❌ Permission denied: ${err.message}\n`);
-        } else if (err.statusCode === 404) {
+        } else if (e.statusCode === 403) {
+          console.error(`\n❌ Permission denied: ${e.message}\n`);
+        } else if (e.statusCode === 404) {
           console.error(`\n❌ Not found: ${target}\n`);
         } else {
-          console.error(`\n❌ Remove failed: ${err.message}\n`);
+          console.error(`\n❌ Remove failed: ${e.message}\n`);
         }
         process.exit(1);
       }

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -2,7 +2,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { parseDossierContent } from '@ai-dossier/core';
+import { type DossierFrontmatter, parseDossierContent } from '@ai-dossier/core';
 import type { Command } from 'commander';
 import * as config from '../config';
 import {
@@ -28,241 +28,257 @@ export function registerRunCommand(program: Command): void {
     .option('--pull', 'Update cache before running')
     .option('--skip-checksum', 'Skip checksum verification (DANGEROUS)')
     .option('--skip-all-checks', 'Skip ALL verifications (VERY DANGEROUS)')
-    .action(async (file: string, options: any) => {
-      let resolvedFile = file;
-      const isUrl = file.startsWith('http://') || file.startsWith('https://');
-      const isLocalFile = !isUrl && fs.existsSync(path.resolve(file));
-      const isNested = process.env.CLAUDE_CODE === '1' || process.env.CLAUDECODE === '1';
-      const log = isNested
-        ? (...args: any[]) => console.error(...args)
-        : (...args: any[]) => console.log(...args);
+    .action(
+      async (
+        file: string,
+        options: {
+          llm?: string;
+          headless?: boolean;
+          dryRun?: boolean;
+          force?: boolean;
+          noPrompt?: boolean;
+          fresh?: boolean;
+          pull?: boolean;
+          skipChecksum?: boolean;
+          skipAllChecks?: boolean;
+        }
+      ) => {
+        let resolvedFile = file;
+        const isUrl = file.startsWith('http://') || file.startsWith('https://');
+        const isLocalFile = !isUrl && fs.existsSync(path.resolve(file));
+        const isNested = process.env.CLAUDE_CODE === '1' || process.env.CLAUDECODE === '1';
+        const log = isNested
+          ? (...args: unknown[]) => console.error(...args)
+          : (...args: unknown[]) => console.log(...args);
 
-      // If not a URL or local file, treat as a registry name
-      if (!isUrl && !isLocalFile) {
-        const [dossierName, version] = parseNameVersion(file);
+        // If not a URL or local file, treat as a registry name
+        if (!isUrl && !isLocalFile) {
+          const [dossierName, version] = parseNameVersion(file);
 
-        const cacheDir = path.join(os.homedir(), '.dossier', 'cache');
-        let cached = false;
+          const cacheDir = path.join(os.homedir(), '.dossier', 'cache');
+          let cached = false;
 
-        if (!options.fresh) {
-          const dossierCacheDir = safeDossierPath(cacheDir, dossierName);
-          if (fs.existsSync(dossierCacheDir)) {
-            const metaFiles = fs
-              .readdirSync(dossierCacheDir)
-              .filter((f: string) => f.endsWith('.meta.json'));
-            for (const mf of metaFiles) {
-              const ver = mf.replace('.meta.json', '');
-              if (version && ver !== version) continue;
-              const contentFile = path.join(dossierCacheDir, `${ver}.ds.md`);
-              if (fs.existsSync(contentFile)) {
-                if (!options.pull) {
-                  resolvedFile = contentFile;
-                  cached = true;
-                  log(`📦 Using cached: ${dossierName}@${ver}\n`);
-                  break;
+          if (!options.fresh) {
+            const dossierCacheDir = safeDossierPath(cacheDir, dossierName);
+            if (fs.existsSync(dossierCacheDir)) {
+              const metaFiles = fs
+                .readdirSync(dossierCacheDir)
+                .filter((f: string) => f.endsWith('.meta.json'));
+              for (const mf of metaFiles) {
+                const ver = mf.replace('.meta.json', '');
+                if (version && ver !== version) continue;
+                const contentFile = path.join(dossierCacheDir, `${ver}.ds.md`);
+                if (fs.existsSync(contentFile)) {
+                  if (!options.pull) {
+                    resolvedFile = contentFile;
+                    cached = true;
+                    log(`📦 Using cached: ${dossierName}@${ver}\n`);
+                    break;
+                  }
                 }
               }
             }
           }
+
+          if (!cached) {
+            try {
+              const client = getClient();
+              let resolvedVersion = version;
+              if (!resolvedVersion) {
+                const meta = await client.getDossier(dossierName);
+                resolvedVersion = meta.version || 'latest';
+              }
+              const result = await client.getDossierContent(dossierName, resolvedVersion);
+
+              if (!options.fresh) {
+                const dossierCacheDir = safeDossierPath(cacheDir, dossierName);
+                fs.mkdirSync(dossierCacheDir, { recursive: true, mode: 0o700 });
+                const contentFile = path.join(dossierCacheDir, `${resolvedVersion}.ds.md`);
+                fs.writeFileSync(contentFile, result.content, 'utf8');
+                fs.writeFileSync(
+                  path.join(dossierCacheDir, `${resolvedVersion}.meta.json`),
+                  JSON.stringify(
+                    {
+                      cached_at: new Date().toISOString(),
+                      version: resolvedVersion,
+                      source_registry_url: client.getRegistryBaseUrl(),
+                    },
+                    null,
+                    2
+                  ),
+                  'utf8'
+                );
+                resolvedFile = contentFile;
+                log(`📥 Fetched: ${dossierName}@${resolvedVersion}\n`);
+              } else {
+                const tmpFile = path.join(os.tmpdir(), `dossier-${Date.now()}.ds.md`);
+                fs.writeFileSync(tmpFile, result.content, 'utf8');
+                resolvedFile = tmpFile;
+                log(`📥 Fetched: ${dossierName}@${resolvedVersion} (not cached)\n`);
+              }
+            } catch (err: unknown) {
+              const e = err as { statusCode?: number; message: string };
+              if (e.statusCode === 404) {
+                console.error(`\n❌ Not found: ${file}`);
+                console.error('   Not a local file and not found in registry\n');
+              } else {
+                console.error(`\n❌ Failed to fetch: ${e.message}\n`);
+              }
+              process.exit(1);
+            }
+          }
         }
 
-        if (!cached) {
+        // If resolvedFile is still a URL, download it first
+        if (resolvedFile.startsWith('http://') || resolvedFile.startsWith('https://')) {
           try {
-            const client = getClient();
-            let resolvedVersion = version;
-            if (!resolvedVersion) {
-              const meta = await client.getDossier(dossierName);
-              resolvedVersion = meta.version || 'latest';
-            }
-            const result = await client.getDossierContent(dossierName, resolvedVersion);
-
-            if (!options.fresh) {
-              const dossierCacheDir = safeDossierPath(cacheDir, dossierName);
-              fs.mkdirSync(dossierCacheDir, { recursive: true, mode: 0o700 });
-              const contentFile = path.join(dossierCacheDir, `${resolvedVersion}.ds.md`);
-              fs.writeFileSync(contentFile, result.content, 'utf8');
-              fs.writeFileSync(
-                path.join(dossierCacheDir, `${resolvedVersion}.meta.json`),
-                JSON.stringify(
-                  {
-                    cached_at: new Date().toISOString(),
-                    version: resolvedVersion,
-                    source_registry_url: client.getRegistryBaseUrl(),
-                  },
-                  null,
-                  2
-                ),
-                'utf8'
-              );
-              resolvedFile = contentFile;
-              log(`📥 Fetched: ${dossierName}@${resolvedVersion}\n`);
-            } else {
-              const tmpFile = path.join(os.tmpdir(), `dossier-${Date.now()}.ds.md`);
-              fs.writeFileSync(tmpFile, result.content, 'utf8');
-              resolvedFile = tmpFile;
-              log(`📥 Fetched: ${dossierName}@${resolvedVersion} (not cached)\n`);
-            }
-          } catch (err: any) {
-            if (err.statusCode === 404) {
-              console.error(`\n❌ Not found: ${file}`);
-              console.error('   Not a local file and not found in registry\n');
-            } else {
-              console.error(`\n❌ Failed to fetch: ${err.message}\n`);
-            }
+            resolvedFile = downloadUrlToTempFile(resolvedFile);
+          } catch (err: unknown) {
+            console.error(`\n❌ Failed to download: ${(err as Error).message}\n`);
             process.exit(1);
           }
         }
-      }
 
-      // If resolvedFile is still a URL, download it first
-      if (resolvedFile.startsWith('http://') || resolvedFile.startsWith('https://')) {
+        // TOCTOU mitigation: read the file once and create a private copy.
+        // This prevents an attacker from swapping the file between verification
+        // and execution (threat T13).
+        let dossierContent: string;
         try {
-          resolvedFile = downloadUrlToTempFile(resolvedFile);
-        } catch (err: any) {
-          console.error(`\n❌ Failed to download: ${err.message}\n`);
+          dossierContent = fs.readFileSync(path.resolve(resolvedFile), 'utf8');
+        } catch (err: unknown) {
+          console.error(`\n❌ Failed to read dossier: ${(err as Error).message}\n`);
           process.exit(1);
         }
-      }
 
-      // TOCTOU mitigation: read the file once and create a private copy.
-      // This prevents an attacker from swapping the file between verification
-      // and execution (threat T13).
-      let dossierContent: string;
-      try {
-        dossierContent = fs.readFileSync(path.resolve(resolvedFile), 'utf8');
-      } catch (err: any) {
-        console.error(`\n❌ Failed to read dossier: ${err.message}\n`);
-        process.exit(1);
-      }
+        const secureTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dossier-run-'));
+        const secureTmpFile = path.join(secureTmpDir, path.basename(resolvedFile));
+        fs.writeFileSync(secureTmpFile, dossierContent, { mode: 0o600 });
+        resolvedFile = secureTmpFile;
 
-      const secureTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dossier-run-'));
-      const secureTmpFile = path.join(secureTmpDir, path.basename(resolvedFile));
-      fs.writeFileSync(secureTmpFile, dossierContent, { mode: 0o600 });
-      resolvedFile = secureTmpFile;
-
-      // Show metadata summary
-      try {
-        let fm: any = null;
-
+        // Show metadata summary
         try {
-          const parsed = parseDossierContent(dossierContent);
-          fm = parsed.frontmatter;
+          let fm: DossierFrontmatter | null = null;
+
+          try {
+            const parsed = parseDossierContent(dossierContent);
+            fm = parsed.frontmatter;
+          } catch (err) {
+            process.stderr.write(
+              `Warning: failed to parse dossier metadata: ${(err as Error).message}\n`
+            );
+          }
+
+          if (fm && (fm.title || fm.risk_level || fm.objective)) {
+            log('📄 Dossier Summary:');
+            if (fm.title) log(`   Title:      ${fm.title}`);
+            if (fm.version) log(`   Version:    ${fm.version}`);
+            if (fm.risk_level) log(`   Risk Level: ${fm.risk_level}`);
+            if (fm.objective || fm.description) {
+              const obj = (fm.objective || fm.description) as string;
+              const snippet = obj.length > 100 ? `${obj.slice(0, 100)}...` : obj;
+              log(`   Objective:  ${snippet}`);
+            }
+            log('');
+          }
         } catch (err) {
           process.stderr.write(
-            `Warning: failed to parse dossier metadata: ${(err as Error).message}\n`
+            `Warning: failed to read dossier summary: ${(err as Error).message}\n`
           );
         }
 
-        if (fm && (fm.title || fm.risk_level || fm.objective)) {
-          log('📄 Dossier Summary:');
-          if (fm.title) log(`   Title:      ${fm.title}`);
-          if (fm.version) log(`   Version:    ${fm.version}`);
-          if (fm.risk_level) log(`   Risk Level: ${fm.risk_level}`);
-          if (fm.objective || fm.description) {
-            const obj = fm.objective || fm.description;
-            const snippet = obj.length > 100 ? `${obj.slice(0, 100)}...` : obj;
-            log(`   Objective:  ${snippet}`);
-          }
-          log('');
-        }
-      } catch (err) {
-        process.stderr.write(
-          `Warning: failed to read dossier summary: ${(err as Error).message}\n`
-        );
-      }
-
-      // Nested session detection
-      if (process.env.CLAUDE_CODE === '1' || process.env.CLAUDECODE === '1') {
-        console.error('ℹ️  Running inside Claude Code — outputting dossier content\n');
-        process.stdout.write(dossierContent);
-        fs.unlinkSync(secureTmpFile);
-        fs.rmdirSync(secureTmpDir);
-        process.exit(0);
-      }
-
-      const result = await runVerification(resolvedFile, options);
-
-      if (!result.passed) {
-        console.log('❌ Verification failed - cannot execute\n');
-        fs.unlinkSync(secureTmpFile);
-        fs.rmdirSync(secureTmpDir);
-        process.exit(1);
-      }
-
-      const llmOption = options.llm || config.getConfig('defaultLlm') || 'auto';
-
-      console.log('📝 Audit Log:');
-      console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-      console.log(`   Timestamp:   ${new Date().toISOString()}`);
-      console.log(`   Dossier:     ${file}`);
-      console.log(`   User:        ${process.env.USER}@${os.hostname()}`);
-      console.log(`   LLM:         ${llmOption}`);
-      console.log(`   Action:      RUN`);
-      console.log('   Status:      VERIFIED');
-      console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
-
-      if (options.dryRun) {
-        console.log('🧪 DRY RUN MODE - No execution\n');
-        console.log('Would execute:');
-        console.log(`   File: ${resolvedFile}`);
-        console.log(`   LLM: ${llmOption}`);
-
-        const llmToUse = detectLlm(llmOption as string, true);
-        console.log(
-          `   Command: ${llmToUse ? `claude "${resolvedFile}"` : 'No LLM detected - would show error'}\n`
-        );
-        console.log('✅ All verifications passed - ready to execute');
-        fs.unlinkSync(secureTmpFile);
-        fs.rmdirSync(secureTmpDir);
-        process.exit(0);
-      }
-
-      const cleanupSecureTmp = () => {
-        try {
+        // Nested session detection
+        if (process.env.CLAUDE_CODE === '1' || process.env.CLAUDECODE === '1') {
+          console.error('ℹ️  Running inside Claude Code — outputting dossier content\n');
+          process.stdout.write(dossierContent);
           fs.unlinkSync(secureTmpFile);
-        } catch {
-          /* already cleaned */
-        }
-        try {
           fs.rmdirSync(secureTmpDir);
-        } catch {
-          /* already cleaned */
+          process.exit(0);
         }
-      };
 
-      console.log('🤖 Executing Dossier...\n');
+        const result = await runVerification(resolvedFile, options);
 
-      const llmToUse = detectLlm(llmOption as string);
-      if (!llmToUse) {
-        cleanupSecureTmp();
-        process.exit(2);
-      }
-
-      const descriptor = buildLlmCommand(llmToUse, resolvedFile, options.headless);
-      if (!descriptor) {
-        console.log(`❌ Unknown LLM: ${llmToUse}\n`);
-        console.log('Supported: claude-code, auto\n');
-        cleanupSecureTmp();
-        process.exit(2);
-      }
-
-      try {
-        const mode = options.headless ? 'headless' : 'interactive';
-        console.log(`   Mode: ${mode}`);
-        console.log(`   Executing: ${descriptor.description}\n`);
-        const result = spawnSync(descriptor.cmd, descriptor.args, {
-          stdio: descriptor.stdin ? ['pipe', 'inherit', 'inherit'] : 'inherit',
-          input: descriptor.stdin,
-        });
-        if (result.status !== 0) {
-          throw { status: result.status };
+        if (!result.passed) {
+          console.log('❌ Verification failed - cannot execute\n');
+          fs.unlinkSync(secureTmpFile);
+          fs.rmdirSync(secureTmpDir);
+          process.exit(1);
         }
-        console.log('\n✅ Execution completed');
-      } catch (error: any) {
-        console.log('\n❌ Execution failed');
+
+        const llmOption = options.llm || config.getConfig('defaultLlm') || 'auto';
+
+        console.log('📝 Audit Log:');
+        console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+        console.log(`   Timestamp:   ${new Date().toISOString()}`);
+        console.log(`   Dossier:     ${file}`);
+        console.log(`   User:        ${process.env.USER}@${os.hostname()}`);
+        console.log(`   LLM:         ${llmOption}`);
+        console.log(`   Action:      RUN`);
+        console.log('   Status:      VERIFIED');
+        console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
+
+        if (options.dryRun) {
+          console.log('🧪 DRY RUN MODE - No execution\n');
+          console.log('Would execute:');
+          console.log(`   File: ${resolvedFile}`);
+          console.log(`   LLM: ${llmOption}`);
+
+          const llmToUse = detectLlm(llmOption as string, true);
+          console.log(
+            `   Command: ${llmToUse ? `claude "${resolvedFile}"` : 'No LLM detected - would show error'}\n`
+          );
+          console.log('✅ All verifications passed - ready to execute');
+          fs.unlinkSync(secureTmpFile);
+          fs.rmdirSync(secureTmpDir);
+          process.exit(0);
+        }
+
+        const cleanupSecureTmp = () => {
+          try {
+            fs.unlinkSync(secureTmpFile);
+          } catch {
+            /* already cleaned */
+          }
+          try {
+            fs.rmdirSync(secureTmpDir);
+          } catch {
+            /* already cleaned */
+          }
+        };
+
+        console.log('🤖 Executing Dossier...\n');
+
+        const llmToUse = detectLlm(llmOption as string);
+        if (!llmToUse) {
+          cleanupSecureTmp();
+          process.exit(2);
+        }
+
+        const descriptor = buildLlmCommand(llmToUse, resolvedFile, options.headless);
+        if (!descriptor) {
+          console.log(`❌ Unknown LLM: ${llmToUse}\n`);
+          console.log('Supported: claude-code, auto\n');
+          cleanupSecureTmp();
+          process.exit(2);
+        }
+
+        try {
+          const mode = options.headless ? 'headless' : 'interactive';
+          console.log(`   Mode: ${mode}`);
+          console.log(`   Executing: ${descriptor.description}\n`);
+          const result = spawnSync(descriptor.cmd, descriptor.args, {
+            stdio: descriptor.stdin ? ['pipe', 'inherit', 'inherit'] : 'inherit',
+            input: descriptor.stdin,
+          });
+          if (result.status !== 0) {
+            throw { status: result.status };
+          }
+          console.log('\n✅ Execution completed');
+        } catch (error: unknown) {
+          console.log('\n❌ Execution failed');
+          cleanupSecureTmp();
+          process.exit((error as { status?: number }).status || 2);
+        }
         cleanupSecureTmp();
-        process.exit(error.status || 2);
       }
-      cleanupSecureTmp();
-    });
+    );
 }

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -204,7 +204,8 @@ export function registerRunCommand(program: Command): void {
           process.exit(1);
         }
 
-        const llmOption = options.llm || config.getConfig('defaultLlm') || 'auto';
+        const llmOption =
+          options.llm || (config.getConfig('defaultLlm') as string | undefined) || 'auto';
 
         console.log('📝 Audit Log:');
         console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');

--- a/cli/src/commands/skill-export.ts
+++ b/cli/src/commands/skill-export.ts
@@ -1,7 +1,11 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { parseDossierContent, validateFrontmatter } from '@ai-dossier/core';
+import {
+  type DossierFrontmatter,
+  parseDossierContent,
+  validateFrontmatter,
+} from '@ai-dossier/core';
 import type { Command } from 'commander';
 import { isExpired, loadCredentials } from '../credentials';
 import { getClient } from '../registry-client';
@@ -117,10 +121,10 @@ export function registerSkillExportCommand(program: Command): void {
 
         let content = fs.readFileSync(skillFile, 'utf8');
 
-        let frontmatter: Record<string, any>;
+        let frontmatter: DossierFrontmatter;
         try {
           const parsed = parseDossierContent(content);
-          frontmatter = parsed.frontmatter as Record<string, any>;
+          frontmatter = parsed.frontmatter;
         } catch (err: unknown) {
           if (options.json) {
             console.log(
@@ -235,27 +239,28 @@ export function registerSkillExportCommand(program: Command): void {
           if (!options.json) {
             console.log('');
           }
-        } catch (err: any) {
+        } catch (err: unknown) {
+          const e = err as { statusCode?: number; message: string; code?: string };
           if (options.json) {
             console.log(
               JSON.stringify(
                 {
                   exported: false,
-                  error: err.message,
-                  code: err.code || 'export_failed',
+                  error: e.message,
+                  code: e.code || 'export_failed',
                 },
                 null,
                 2
               )
             );
-          } else if (err.statusCode === 401) {
+          } else if (e.statusCode === 401) {
             console.error('\n❌ Session expired. Run `dossier login` to re-authenticate.\n');
-          } else if (err.statusCode === 403) {
-            console.error(`\n❌ Permission denied: ${err.message}\n`);
-          } else if (err.statusCode === 409) {
-            console.error(`\n❌ Version conflict: ${fullPath}@${newVersion} — ${err.message}\n`);
+          } else if (e.statusCode === 403) {
+            console.error(`\n❌ Permission denied: ${e.message}\n`);
+          } else if (e.statusCode === 409) {
+            console.error(`\n❌ Version conflict: ${fullPath}@${newVersion} — ${e.message}\n`);
           } else {
-            console.error(`\n❌ Export failed: ${err.message}\n`);
+            console.error(`\n❌ Export failed: ${e.message}\n`);
           }
           process.exit(1);
         }

--- a/cli/src/commands/skill-export.ts
+++ b/cli/src/commands/skill-export.ts
@@ -1,18 +1,14 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import {
-  type DossierFrontmatter,
-  parseDossierContent,
-  validateFrontmatter,
-} from '@ai-dossier/core';
+import { type DossierFrontmatter, parseDossierContent } from '@ai-dossier/core';
 import type { Command } from 'commander';
 import { isExpired, loadCredentials } from '../credentials';
 import { getClient } from '../registry-client';
 
 function bumpVersion(current: string, bump: 'minor' | 'major'): string {
   const parts = current.split('.').map(Number);
-  if (parts.length !== 3 || parts.some(isNaN)) {
+  if (parts.length !== 3 || parts.some(Number.isNaN)) {
     // Can't bump non-semver, return as-is
     return current;
   }
@@ -230,7 +226,7 @@ export function registerSkillExportCommand(program: Command): void {
               if (!options.json) {
                 console.log(`   ⚠️  Verification failed: ${(verifyErr as Error).message}`);
                 console.log(
-                  '   CDN propagation may take a few seconds. Try: dossier info ' + fullPath
+                  `   CDN propagation may take a few seconds. Try: dossier info ${fullPath}`
                 );
               }
             }

--- a/cli/src/commands/validate.ts
+++ b/cli/src/commands/validate.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import {
+  type DossierFrontmatter,
   parseDossierContent,
   RECOMMENDED_FIELDS,
   REQUIRED_FIELDS,
@@ -38,11 +39,11 @@ export function registerValidateCommand(program: Command): void {
       const content = fs.readFileSync(dossierFile, 'utf8');
       const errors: string[] = [];
       const warnings: string[] = [];
-      let frontmatter: Record<string, any> | null = null;
+      let frontmatter: DossierFrontmatter | null = null;
 
       try {
         const parsed = parseDossierContent(content);
-        frontmatter = parsed.frontmatter as Record<string, any>;
+        frontmatter = parsed.frontmatter;
       } catch {
         errors.push('No frontmatter found. Expected ---dossier or --- at start of file.');
       }

--- a/cli/src/commands/validate.ts
+++ b/cli/src/commands/validate.ts
@@ -65,7 +65,9 @@ export function registerValidateCommand(program: Command): void {
 
         if (
           frontmatter.risk_level &&
-          !VALID_RISK_LEVELS.includes(frontmatter.risk_level.toLowerCase())
+          !VALID_RISK_LEVELS.includes(
+            frontmatter.risk_level.toLowerCase() as (typeof VALID_RISK_LEVELS)[number]
+          )
         ) {
           warnings.push(
             `Unknown risk_level: "${frontmatter.risk_level}" (expected: ${VALID_RISK_LEVELS.join(', ')})`
@@ -74,7 +76,9 @@ export function registerValidateCommand(program: Command): void {
 
         if (
           frontmatter.status &&
-          !VALID_STATUSES.some((s: string) => s.toLowerCase() === frontmatter.status.toLowerCase())
+          !VALID_STATUSES.some(
+            (s: string) => s.toLowerCase() === (frontmatter.status as string).toLowerCase()
+          )
         ) {
           warnings.push(
             `Unknown status: "${frontmatter.status}" (expected: ${VALID_STATUSES.join(', ')})`

--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -10,6 +10,7 @@ import https from 'node:https';
 import os from 'node:os';
 import path from 'node:path';
 import {
+  type DossierFrontmatter,
   parseDossierContent,
   RECOMMENDED_FIELDS,
   REQUIRED_FIELDS,
@@ -502,16 +503,15 @@ export function parseDossierMetadataFromContent(
 ): DossierMetadata {
   try {
     const parsed = parseDossierContent(content);
-    const frontmatter = parsed.frontmatter as Record<string, any>;
+    const frontmatter: DossierFrontmatter = parsed.frontmatter;
+    const category = frontmatter.category as string | string[] | undefined;
     return {
       path: filePath,
       filename: path.basename(filePath),
       title: frontmatter.title || path.basename(filePath, '.ds.md'),
       version: frontmatter.version || '-',
       risk_level: frontmatter.risk_level || 'unknown',
-      category: Array.isArray(frontmatter.category)
-        ? frontmatter.category.join(', ')
-        : frontmatter.category || '-',
+      category: Array.isArray(category) ? category.join(', ') : (category as string) || '-',
       status: frontmatter.status || '-',
       signed: !!frontmatter.signature,
       checksum: !!frontmatter.checksum,


### PR DESCRIPTION
## Summary

- Replace all `catch (err: any)` with `catch (err: unknown)` + typed casts across 18 CLI files
- Replace `options: any` with explicit typed option objects in `run.ts`, `format.ts`, `create.ts`, `lint.ts`, `list.ts`, `cache.ts`
- Replace `Record<string, any>` with `DossierFrontmatter` or specific types in `checksum.ts`, `info.ts`, `install-skill.ts`, `skill-export.ts`, `validate.ts`
- Replace `(...args: any[])` with `(...args: unknown[])` in `run.ts` log functions
- Replace non-null assertions with optional chaining or type casts in `commands.ts`, `info.ts`, `skill-export.test.ts`
- Biome check now passes with zero errors (only pre-existing warnings in `mcp-server/`)

## Test plan

- [x] `npx biome check .` — zero errors
- [x] CLI tests: no regressions vs main branch (main has 144 failures; this branch has 37 — all pre-existing)
- [x] All changes are type-only refactors — no behavioral changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)