### PR TITLE
refactor(registry): extract shared helpers to fix DRY violations

### DIFF
--- a/registry/api/v1/dossiers/[...name].ts
+++ b/registry/api/v1/dossiers/[...name].ts
@@ -1,4 +1,4 @@
-import crypto from 'node:crypto';
+import { sha256Hex } from '@ai-dossier/core';
 import { authenticateRequest } from '../../../lib/auth';
 import config from '../../../lib/config';
 import { handleCors } from '../../../lib/cors';
@@ -67,7 +67,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         });
       }
 
-      const digest = crypto.createHash('sha256').update(fileContent.content).digest('hex');
+      const digest = sha256Hex(fileContent.content);
 
       res.setHeader('Content-Type', 'text/markdown');
       res.setHeader('X-Dossier-Digest', `sha256:${digest}`);

--- a/registry/api/v1/dossiers/index.ts
+++ b/registry/api/v1/dossiers/index.ts
@@ -1,9 +1,10 @@
 import { authenticateRequest } from '../../../lib/auth';
 import config from '../../../lib/config';
-import { DOSSIER_DEFAULTS, MAX_CONTENT_SIZE } from '../../../lib/constants';
+import { MAX_CONTENT_SIZE } from '../../../lib/constants';
 import { handleCors } from '../../../lib/cors';
 import * as dossier from '../../../lib/dossier';
 import * as github from '../../../lib/github';
+import { fetchManifestDossiers, normalizeDossier } from '../../../lib/manifest';
 import { canPublishTo } from '../../../lib/permissions';
 import type { ManifestDossier, VercelRequest, VercelResponse } from '../../../lib/types';
 
@@ -25,20 +26,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
 async function handleList(_req: VercelRequest, res: VercelResponse) {
   try {
-    const manifestUrl = config.getManifestUrl();
-    const response = await fetch(manifestUrl);
-
-    if (!response.ok) {
-      throw new Error(`Failed to fetch manifest: ${response.status}`);
-    }
-
-    const manifest = (await response.json()) as { dossiers: ManifestDossier[] };
-
-    const dossiers = manifest.dossiers.map((d) => ({
-      ...DOSSIER_DEFAULTS,
-      ...d,
-      url: config.getCdnUrl(d.path),
-    }));
+    const raw = await fetchManifestDossiers();
+    const dossiers = raw.map(normalizeDossier);
 
     return res.status(200).json({
       dossiers,

--- a/registry/api/v1/search.ts
+++ b/registry/api/v1/search.ts
@@ -1,7 +1,7 @@
-import config from '../../lib/config';
-import { DEFAULT_PER_PAGE, DOSSIER_DEFAULTS, MAX_PER_PAGE } from '../../lib/constants';
+import { DEFAULT_PER_PAGE, MAX_PER_PAGE } from '../../lib/constants';
 import { handleCors } from '../../lib/cors';
-import type { ManifestDossier, VercelRequest, VercelResponse } from '../../lib/types';
+import { fetchManifestDossiers, normalizeDossier } from '../../lib/manifest';
+import type { VercelRequest, VercelResponse } from '../../lib/types';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleCors(req, res)) return;
@@ -27,17 +27,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   );
 
   try {
-    const manifestUrl = config.getManifestUrl();
-    const response = await fetch(manifestUrl);
-
-    if (!response.ok) {
-      throw new Error(`Failed to fetch manifest: ${response.status}`);
-    }
-
-    const manifest = (await response.json()) as { dossiers: ManifestDossier[] };
+    const allDossiers = await fetchManifestDossiers();
 
     const query = q.toLowerCase();
-    const matched = manifest.dossiers.filter((d) => {
+    const matched = allDossiers.filter((d) => {
       if (d.name?.toLowerCase().includes(query)) return true;
       if (d.title?.toLowerCase().includes(query)) return true;
       if (typeof d.description === 'string' && d.description.toLowerCase().includes(query))
@@ -52,11 +45,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const start = (page - 1) * perPage;
     const paged = matched.slice(start, start + perPage);
 
-    const dossiers = paged.map((d) => ({
-      ...DOSSIER_DEFAULTS,
-      ...d,
-      url: config.getCdnUrl(d.path),
-    }));
+    const dossiers = paged.map(normalizeDossier);
 
     return res.status(200).json({
       dossiers,

--- a/registry/lib/github.ts
+++ b/registry/lib/github.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import config from './config';
-import { USER_AGENT } from './constants';
+import { DOSSIER_DEFAULTS, USER_AGENT } from './constants';
 import type { DeleteResult, FileContent, Manifest, ManifestDossier } from './types';
 
 const GITHUB_API = 'https://api.github.com';
@@ -198,13 +198,9 @@ export async function publishDossier(
   console.log(`[publish] Step 2/2: Updating manifest for ${metadata.name}`);
   const manifest = await getManifest();
 
-  const OPTIONAL_MANIFEST_FIELDS = [
-    'description',
-    'category',
-    'tags',
-    'authors',
-    'tools_required',
-  ] as const;
+  const OPTIONAL_MANIFEST_FIELDS = Object.keys(DOSSIER_DEFAULTS) as Array<
+    keyof typeof DOSSIER_DEFAULTS
+  >;
 
   const dossierEntry: ManifestDossier = {
     name: fullPath,

--- a/registry/lib/manifest.ts
+++ b/registry/lib/manifest.ts
@@ -1,0 +1,23 @@
+import config from './config';
+import { DOSSIER_DEFAULTS } from './constants';
+import type { ManifestDossier } from './types';
+
+export async function fetchManifestDossiers(): Promise<ManifestDossier[]> {
+  const manifestUrl = config.getManifestUrl();
+  const response = await fetch(manifestUrl);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch manifest: ${response.status}`);
+  }
+
+  const manifest = (await response.json()) as { dossiers: ManifestDossier[] };
+  return manifest.dossiers;
+}
+
+export function normalizeDossier(dossier: ManifestDossier): ManifestDossier & { url: string } {
+  return {
+    ...DOSSIER_DEFAULTS,
+    ...dossier,
+    url: config.getCdnUrl(dossier.path),
+  };
+}

--- a/registry/tests/manifest.test.ts
+++ b/registry/tests/manifest.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../lib/config', () => ({
+  default: {
+    getManifestUrl: () => 'https://raw.githubusercontent.com/org/repo/main/index.json',
+    getCdnUrl: (path: string) => `https://cdn.jsdelivr.net/gh/org/repo/${path}`,
+  },
+}));
+
+import { fetchManifestDossiers, normalizeDossier } from '../lib/manifest';
+
+describe('fetchManifestDossiers', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches and returns dossiers from manifest', async () => {
+    const mockDossiers = [
+      { name: 'test/dossier', title: 'Test', version: '1.0.0', path: 'test/dossier.ds.md' },
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ dossiers: mockDossiers }),
+      })
+    );
+
+    const result = await fetchManifestDossiers();
+    expect(result).toEqual(mockDossiers);
+  });
+
+  it('throws on non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+
+    await expect(fetchManifestDossiers()).rejects.toThrow('Failed to fetch manifest: 500');
+  });
+});
+
+describe('normalizeDossier', () => {
+  it('applies defaults and adds url', () => {
+    const dossier = { name: 'ns/d', title: 'D', version: '1.0.0', path: 'ns/d.ds.md' };
+    const result = normalizeDossier(dossier);
+
+    expect(result.url).toBe('https://cdn.jsdelivr.net/gh/org/repo/ns/d.ds.md');
+    expect(result.description).toBeNull();
+    expect(result.tags).toEqual([]);
+    expect(result.authors).toEqual([]);
+    expect(result.tools_required).toEqual([]);
+  });
+
+  it('preserves existing fields over defaults', () => {
+    const dossier = {
+      name: 'ns/d',
+      title: 'D',
+      version: '1.0.0',
+      path: 'ns/d.ds.md',
+      description: 'A description',
+      tags: ['tag1'],
+    };
+    const result = normalizeDossier(dossier);
+
+    expect(result.description).toBe('A description');
+    expect(result.tags).toEqual(['tag1']);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `fetchManifestDossiers()` and `normalizeDossier()` into `registry/lib/manifest.ts` — eliminates duplicated manifest fetching and dossier normalization in `dossiers/index.ts` and `search.ts`
- Replace `crypto.createHash('sha256')` with `sha256Hex` from `@ai-dossier/core` in `[...name].ts`
- Derive `OPTIONAL_MANIFEST_FIELDS` from `DOSSIER_DEFAULTS` keys in `github.ts` instead of hardcoding

Net: -42 lines, +106 lines (including new tests)

## Test plan
- [x] All 50 registry tests pass (including 4 new manifest helper tests)
- [x] TypeScript typecheck passes
- [x] Lint passes (pre-commit hook)

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)