### PR TITLE
ci: optimize pipeline — drop redundant runs and lint passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,13 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -50,7 +51,7 @@ jobs:
         run: npm audit --omit=dev --audit-level=high
 
       - name: Build
-        run: make build
+        run: make build-all
 
       - name: Run tests with coverage
         run: make test-coverage

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm run lint
 
       - name: Build
-        run: make build
+        run: make build-all
 
       - name: Test
         run: make test
@@ -105,7 +105,7 @@ jobs:
           git push origin "v$VERSION"
 
       - name: Build all packages
-        run: make build
+        run: make build-all
 
       - name: Check if @ai-dossier/core needs publishing
         id: check-core

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Dossier Build System
 # Handles build order dependencies across npm workspaces
 
-.PHONY: all build clean test test-coverage install help lint format check
+.PHONY: all build build-all clean test test-coverage install help lint format check
 .DEFAULT_GOAL := help
 
 ## help: Show this help message
@@ -22,8 +22,11 @@ install:
 	npm install
 	@echo "✓ Dependencies installed"
 
-## build: Build all packages in dependency order
-build: lint build-core build-mcp build-cli
+## build: Lint then build all packages (for local development)
+build: lint build-all
+
+## build-all: Build all packages in dependency order (no lint)
+build-all: build-core build-mcp build-cli
 	@echo "✓ All packages built successfully"
 
 ## build-core: Build @ai-dossier/core package


### PR DESCRIPTION
## Summary

- **Remove `push: main` trigger from `ci.yml`** — the PR already validated the code, and the publish workflow re-tests before npm publish. This was causing 3 redundant CI jobs on every merge.
- **Add concurrency group** — if you push twice quickly to a PR branch, the first CI run gets cancelled instead of wasting runner time.
- **Add `build-all` Makefile target** — builds without linting. CI test jobs now use `build-all` since the dedicated lint job already covers linting. Eliminates 2 redundant biome runs per PR.
- **`make build` unchanged** for local dev — still lints then builds.

### Impact

| | Before | After |
|---|--------|-------|
| Jobs per PR push | 3 (lint + test×2) | 3 (same, but test jobs skip redundant lint) |
| Jobs per merge | 9 (3 CI-push + 3 CI-PR + 3 publish) | 6 (3 CI-PR + 3 publish) |
| Rapid PR pushes | All run to completion | Previous cancelled |

## Test plan

- [x] `make build` still lints then builds (local dev unchanged)
- [x] `make build-all` builds without lint
- [ ] CI passes on this PR (validates the new workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)