### PR TITLE
fix: extract authenticateRequest to deduplicate auth guard

### DIFF
--- a/registry/api/v1/dossiers/[...name].ts
+++ b/registry/api/v1/dossiers/[...name].ts
@@ -91,29 +91,11 @@ async function handleDelete(
   dossierName: string,
   version: string | undefined
 ) {
-  const token = auth.extractBearerToken(req);
-  if (!token) {
-    return res.status(401).json({
-      error: {
-        code: 'MISSING_TOKEN',
-        message: 'Authorization header required. Use: Bearer <token>',
-      },
-    });
+  const authResult = auth.authenticateRequest(req);
+  if (!authResult.ok) {
+    return res.status(authResult.status).json({ error: authResult.error });
   }
-
-  let jwtPayload: import('../../../lib/types').JwtPayload;
-  try {
-    jwtPayload = auth.verifyJwt(token);
-  } catch (err) {
-    if (err instanceof Error && err.name === 'TokenExpiredError') {
-      return res.status(401).json({
-        error: { code: 'TOKEN_EXPIRED', message: 'Token has expired. Please login again.' },
-      });
-    }
-    return res.status(401).json({
-      error: { code: 'INVALID_TOKEN', message: 'Invalid token. Please login again.' },
-    });
-  }
+  const jwtPayload = authResult.payload;
 
   const rootNamespace = getRootNamespace(dossierName);
   const permission = canPublishTo(jwtPayload, rootNamespace);

--- a/registry/api/v1/dossiers/index.ts
+++ b/registry/api/v1/dossiers/index.ts
@@ -69,29 +69,11 @@ async function handleList(_req: VercelRequest, res: VercelResponse) {
 }
 
 async function handlePublish(req: VercelRequest, res: VercelResponse) {
-  const token = auth.extractBearerToken(req);
-  if (!token) {
-    return res.status(401).json({
-      error: {
-        code: 'MISSING_TOKEN',
-        message: 'Authorization header required. Use: Bearer <token>',
-      },
-    });
+  const authResult = auth.authenticateRequest(req);
+  if (!authResult.ok) {
+    return res.status(authResult.status).json({ error: authResult.error });
   }
-
-  let jwtPayload: import('../../../lib/types').JwtPayload;
-  try {
-    jwtPayload = auth.verifyJwt(token);
-  } catch (err) {
-    if (err instanceof Error && err.name === 'TokenExpiredError') {
-      return res.status(401).json({
-        error: { code: 'TOKEN_EXPIRED', message: 'Token has expired. Please login again.' },
-      });
-    }
-    return res.status(401).json({
-      error: { code: 'INVALID_TOKEN', message: 'Invalid token. Please login again.' },
-    });
-  }
+  const jwtPayload = authResult.payload;
 
   const { namespace, content, changelog } = req.body || {};
 

--- a/registry/api/v1/me.ts
+++ b/registry/api/v1/me.ts
@@ -11,56 +11,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     });
   }
 
-  const token = auth.extractBearerToken(req);
-
-  if (!token) {
-    return res.status(401).json({
-      error: {
-        code: 'MISSING_TOKEN',
-        message: 'Authorization header required. Use: Bearer <token>',
-      },
-    });
+  const authResult = auth.authenticateRequest(req);
+  if (!authResult.ok) {
+    return res.status(authResult.status).json({ error: authResult.error });
   }
+  const { payload } = authResult;
 
-  try {
-    const payload = auth.verifyJwt(token);
+  const username = payload.sub;
+  const orgs = payload.orgs || [];
 
-    const username = payload.sub;
-    const orgs = payload.orgs || [];
+  const canPublishTo = [`${username}/*`, ...orgs.map((org) => `${org}/*`)];
 
-    const canPublishTo = [`${username}/*`, ...orgs.map((org) => `${org}/*`)];
-
-    return res.status(200).json({
-      username,
-      email: payload.email || null,
-      orgs,
-      can_publish_to: canPublishTo,
-    });
-  } catch (err) {
-    if (err instanceof Error && err.name === 'TokenExpiredError') {
-      return res.status(401).json({
-        error: {
-          code: 'TOKEN_EXPIRED',
-          message: 'Token has expired. Please login again.',
-        },
-      });
-    }
-
-    if (err instanceof Error && err.name === 'JsonWebTokenError') {
-      return res.status(401).json({
-        error: {
-          code: 'INVALID_TOKEN',
-          message: 'Invalid token. Please login again.',
-        },
-      });
-    }
-
-    console.error('JWT verification error:', err);
-    return res.status(401).json({
-      error: {
-        code: 'INVALID_TOKEN',
-        message: 'Invalid or expired token',
-      },
-    });
-  }
+  return res.status(200).json({
+    username,
+    email: payload.email || null,
+    orgs,
+    can_publish_to: canPublishTo,
+  });
 }

--- a/registry/lib/auth.ts
+++ b/registry/lib/auth.ts
@@ -1,6 +1,6 @@
 import jwt from 'jsonwebtoken';
 import config from './config';
-import type { JwtPayload, VercelRequest } from './types';
+import type { AuthResult, JwtPayload, VercelRequest } from './types';
 
 export function signJwt(payload: Omit<JwtPayload, 'iat' | 'exp'>): string {
   return jwt.sign(payload, config.auth.jwt.secret, {
@@ -20,6 +20,38 @@ export function extractBearerToken(req: VercelRequest): string | null {
     return null;
   }
   return authHeader.slice('Bearer '.length);
+}
+
+export function authenticateRequest(req: VercelRequest): AuthResult {
+  const token = extractBearerToken(req);
+  if (!token) {
+    return {
+      ok: false,
+      status: 401,
+      error: {
+        code: 'MISSING_TOKEN',
+        message: 'Authorization header required. Use: Bearer <token>',
+      },
+    };
+  }
+
+  try {
+    const payload = verifyJwt(token);
+    return { ok: true, payload };
+  } catch (err) {
+    if (err instanceof Error && err.name === 'TokenExpiredError') {
+      return {
+        ok: false,
+        status: 401,
+        error: { code: 'TOKEN_EXPIRED', message: 'Token has expired. Please login again.' },
+      };
+    }
+    return {
+      ok: false,
+      status: 401,
+      error: { code: 'INVALID_TOKEN', message: 'Invalid token. Please login again.' },
+    };
+  }
 }
 
 export function encodeAsDisplayCode(token: string): string {

--- a/registry/lib/types.ts
+++ b/registry/lib/types.ts
@@ -48,6 +48,10 @@ export interface Manifest {
   sha: string | null;
 }
 
+export type AuthResult =
+  | { ok: true; payload: JwtPayload }
+  | { ok: false; status: number; error: { code: string; message: string } };
+
 export interface DeleteResult {
   found: boolean;
   version?: string | null;

--- a/registry/tests/auth.test.ts
+++ b/registry/tests/auth.test.ts
@@ -1,0 +1,66 @@
+import jwt from 'jsonwebtoken';
+import { describe, expect, it, vi } from 'vitest';
+import { authenticateRequest } from '../lib/auth';
+import type { VercelRequest } from '../lib/types';
+
+vi.mock('../lib/config', () => ({
+  default: {
+    auth: { jwt: { secret: 'test-secret' } },
+  },
+}));
+
+function makeReq(authorization?: string): VercelRequest {
+  return { headers: { authorization } } as unknown as VercelRequest;
+}
+
+function signToken(payload: Record<string, unknown>, opts?: jwt.SignOptions): string {
+  return jwt.sign(payload, 'test-secret', { algorithm: 'HS256', ...opts });
+}
+
+describe('authenticateRequest', () => {
+  it('returns MISSING_TOKEN when no Authorization header', () => {
+    const result = authenticateRequest(makeReq());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('MISSING_TOKEN');
+      expect(result.status).toBe(401);
+    }
+  });
+
+  it('returns MISSING_TOKEN when Authorization header is not Bearer', () => {
+    const result = authenticateRequest(makeReq('Basic abc'));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('MISSING_TOKEN');
+    }
+  });
+
+  it('returns payload on valid token', () => {
+    const token = signToken({ sub: 'testuser', email: 'a@b.com', orgs: ['myorg'] });
+    const result = authenticateRequest(makeReq(`Bearer ${token}`));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload.sub).toBe('testuser');
+      expect(result.payload.orgs).toEqual(['myorg']);
+    }
+  });
+
+  it('returns TOKEN_EXPIRED for expired token', () => {
+    const token = signToken({ sub: 'u', email: null, orgs: [] }, { expiresIn: -1 });
+    const result = authenticateRequest(makeReq(`Bearer ${token}`));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('TOKEN_EXPIRED');
+      expect(result.status).toBe(401);
+    }
+  });
+
+  it('returns INVALID_TOKEN for malformed token', () => {
+    const result = authenticateRequest(makeReq('Bearer not.a.valid.token'));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('INVALID_TOKEN');
+      expect(result.status).toBe(401);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Extracted the duplicated extract-bearer-token + verify-JWT + error-response pattern into a single `authenticateRequest()` helper in `registry/lib/auth.ts`
- Refactored 3 handlers (`[...name].ts`, `index.ts`, `me.ts`) to use the shared helper, removing ~60 lines of duplicated code
- Added `AuthResult` discriminated union type for type-safe auth results
- The `mockRes()` test helper duplication (item 2 in the issue) was already resolved during the TypeScript migration in PR #153

Closes #172

## Test plan
- Added 5 unit tests for `authenticateRequest` covering: missing token, non-Bearer header, valid token, expired token, malformed token
- All 356 existing tests pass (332 core + 24 registry)

Co-Authored-By: Claude <noreply@anthropic.com>