### PR TITLE
fix(registry): address maintainability findings

### DIFF
--- a/registry/api/auth/callback.ts
+++ b/registry/api/auth/callback.ts
@@ -104,6 +104,29 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 }
 
+function basePageStyles(): string {
+  return `
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f5f5f5;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+    }
+    .container {
+      background: white;
+      border-radius: 12px;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.1);
+      padding: 40px;
+      max-width: 500px;
+      width: 100%;
+      text-align: center;
+    }`;
+}
+
 function renderSuccessPage(
   username: string,
   orgs: string[],
@@ -123,26 +146,7 @@ function renderSuccessPage(
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dossier Login - Success</title>
-  <style>
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      background: #f5f5f5;
-      min-height: 100vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 20px;
-    }
-    .container {
-      background: white;
-      border-radius: 12px;
-      box-shadow: 0 4px 24px rgba(0,0,0,0.1);
-      padding: 40px;
-      max-width: 500px;
-      width: 100%;
-      text-align: center;
-    }
+  <style>${basePageStyles()}
     h1 { color: #1a1a1a; margin-bottom: 8px; font-size: 24px; }
     .subtitle { color: #666; margin-bottom: 16px; }
     .orgs-section { margin-bottom: 20px; }
@@ -241,26 +245,7 @@ function renderErrorPage(title: string, message: string): string {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dossier Login - Error</title>
-  <style>
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      background: #f5f5f5;
-      min-height: 100vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 20px;
-    }
-    .container {
-      background: white;
-      border-radius: 12px;
-      box-shadow: 0 4px 24px rgba(0,0,0,0.1);
-      padding: 40px;
-      max-width: 500px;
-      width: 100%;
-      text-align: center;
-    }
+  <style>${basePageStyles()}
     h1 { color: #dc3545; margin-bottom: 16px; font-size: 24px; }
     .message { color: #666; line-height: 1.6; }
     .error-icon { font-size: 48px; margin-bottom: 16px; }

--- a/registry/lib/config.ts
+++ b/registry/lib/config.ts
@@ -10,8 +10,8 @@ const config = {
   apiVersion: 'MVP1',
 
   content: {
-    org: 'imboard-ai',
-    repo: 'dossier-content',
+    org: process.env.CONTENT_ORG || 'imboard-ai',
+    repo: process.env.CONTENT_REPO || 'dossier-content',
     branch: 'main',
     get botToken(): string {
       return requireEnv('GITHUB_BOT_TOKEN');

--- a/registry/lib/constants.ts
+++ b/registry/lib/constants.ts
@@ -22,6 +22,9 @@ export const JWT_EXPIRY_SECONDS = 7 * 24 * 60 * 60;
 /** Valid slug pattern: lowercase alphanumeric with hyphens, no leading/trailing hyphen. */
 export const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
 
+/** GitHub API version header value. */
+export const GITHUB_API_VERSION = '2022-11-28';
+
 /** User-Agent header for outgoing GitHub API requests. */
 export const USER_AGENT = 'Dossier-Registry';
 

--- a/registry/lib/github.ts
+++ b/registry/lib/github.ts
@@ -1,9 +1,7 @@
 import path from 'node:path';
 import config from './config';
-import { DOSSIER_DEFAULTS, USER_AGENT } from './constants';
+import { DOSSIER_DEFAULTS, GITHUB_API_VERSION, USER_AGENT } from './constants';
 import type { DeleteResult, FileContent, Manifest, ManifestDossier } from './types';
-
-const GITHUB_API = 'https://api.github.com';
 
 export class PathTraversalError extends Error {
   constructor(filePath: string) {
@@ -21,7 +19,7 @@ function sanitizePath(filePath: string): string {
 }
 
 async function githubRequest(endpoint: string, options: RequestInit = {}): Promise<Response> {
-  const url = endpoint.startsWith('http') ? endpoint : `${GITHUB_API}${endpoint}`;
+  const url = endpoint.startsWith('http') ? endpoint : `${config.auth.github.apiUrl}${endpoint}`;
 
   let response: Response;
   try {
@@ -30,7 +28,7 @@ async function githubRequest(endpoint: string, options: RequestInit = {}): Promi
       headers: {
         Authorization: `Bearer ${config.content.botToken}`,
         Accept: 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
+        'X-GitHub-Api-Version': GITHUB_API_VERSION,
         'User-Agent': USER_AGENT,
         ...(options.headers as Record<string, string>),
       },

--- a/registry/tests/github.test.ts
+++ b/registry/tests/github.test.ts
@@ -9,6 +9,11 @@ vi.mock('../lib/config', () => ({
       branch: 'main',
       botToken: 'fake-token',
     },
+    auth: {
+      github: {
+        apiUrl: 'https://api.github.com',
+      },
+    },
   },
 }));
 


### PR DESCRIPTION
## Summary
- Extract shared CSS into `basePageStyles()` to deduplicate `renderSuccessPage`/`renderErrorPage` in callback.ts
- Consolidate GitHub API URL: remove local `GITHUB_API` constant from `github.ts`, use `config.auth.github.apiUrl`
- Extract magic string `'2022-11-28'` to `GITHUB_API_VERSION` constant in `constants.ts`
- Add env-var overrides (`CONTENT_ORG`, `CONTENT_REPO`) for hardcoded org/repo in `config.ts`
- Finding #3 (`handleDelete` length) was already addressed — it uses `authorizePublish` middleware

Closes #174

## Test plan
- [x] All 67 registry tests pass (7 test files)
- [x] Build succeeds across all packages
- [x] Updated `github.test.ts` mock to include `auth.github.apiUrl`

Co-Authored-By: Claude <noreply@anthropic.com>