### PR TITLE
refactor(registry): extract shared methodNotAllowed helper

### DIFF
--- a/registry/api/auth/callback.ts
+++ b/registry/api/auth/callback.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import * as auth from '../../lib/auth';
 import config from '../../lib/config';
 import { OAUTH_STATE_COOKIE } from '../../lib/constants';
+import { methodNotAllowed } from '../../lib/responses';
 import type { VercelRequest, VercelResponse } from '../../lib/types';
 
 function parseCookie(req: VercelRequest, name: string): string | undefined {
@@ -13,9 +14,7 @@ function parseCookie(req: VercelRequest, name: string): string | undefined {
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET') {
-    return res.status(405).json({
-      error: { code: 'METHOD_NOT_ALLOWED', message: 'Only GET is allowed' },
-    });
+    return methodNotAllowed(res, 'GET');
   }
 
   const { code, error, error_description, state } = req.query as Record<string, string>;

--- a/registry/api/auth/login.ts
+++ b/registry/api/auth/login.ts
@@ -1,13 +1,12 @@
 import crypto from 'node:crypto';
 import config from '../../lib/config';
 import { OAUTH_STATE_COOKIE, OAUTH_STATE_MAX_AGE } from '../../lib/constants';
+import { methodNotAllowed } from '../../lib/responses';
 import type { VercelRequest, VercelResponse } from '../../lib/types';
 
 export default function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET') {
-    return res.status(405).json({
-      error: { code: 'METHOD_NOT_ALLOWED', message: 'Only GET is allowed' },
-    });
+    return methodNotAllowed(res, 'GET');
   }
 
   try {

--- a/registry/api/v1/docs.ts
+++ b/registry/api/v1/docs.ts
@@ -1,5 +1,6 @@
 import config from '../../lib/config';
 import { handleCors } from '../../lib/cors';
+import { methodNotAllowed } from '../../lib/responses';
 import type { VercelRequest, VercelResponse } from '../../lib/types';
 
 const healthEndpoint = {
@@ -192,9 +193,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleCors(req, res)) return;
 
   if (req.method !== 'GET') {
-    return res.status(405).json({
-      error: { code: 'METHOD_NOT_ALLOWED', message: 'Only GET is allowed' },
-    });
+    return methodNotAllowed(res, 'GET');
   }
 
   const baseUrl = `https://${req.headers.host}`;

--- a/registry/api/v1/dossiers/[...name].ts
+++ b/registry/api/v1/dossiers/[...name].ts
@@ -4,15 +4,14 @@ import config from '../../../lib/config';
 import { handleCors } from '../../../lib/cors';
 import { validateNamespace } from '../../../lib/dossier';
 import * as github from '../../../lib/github';
+import { methodNotAllowed } from '../../../lib/responses';
 import type { VercelRequest, VercelResponse } from '../../../lib/types';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleCors(req, res)) return;
 
   if (req.method !== 'GET' && req.method !== 'HEAD' && req.method !== 'DELETE') {
-    return res.status(405).json({
-      error: { code: 'METHOD_NOT_ALLOWED', message: 'Only GET, HEAD, and DELETE are allowed' },
-    });
+    return methodNotAllowed(res, 'GET', 'HEAD', 'DELETE');
   }
 
   const { name, version } = req.query as Record<string, string | string[]>;

--- a/registry/api/v1/dossiers/index.ts
+++ b/registry/api/v1/dossiers/index.ts
@@ -5,6 +5,7 @@ import { handleCors } from '../../../lib/cors';
 import * as dossier from '../../../lib/dossier';
 import * as github from '../../../lib/github';
 import { fetchManifestDossiers, normalizeDossier } from '../../../lib/manifest';
+import { methodNotAllowed } from '../../../lib/responses';
 import type { ManifestDossier, VercelRequest, VercelResponse } from '../../../lib/types';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -18,9 +19,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return handlePublish(req, res);
   }
 
-  return res.status(405).json({
-    error: { code: 'METHOD_NOT_ALLOWED', message: 'Only GET and POST are allowed' },
-  });
+  return methodNotAllowed(res, 'GET', 'POST');
 }
 
 async function handleList(_req: VercelRequest, res: VercelResponse) {

--- a/registry/api/v1/me.ts
+++ b/registry/api/v1/me.ts
@@ -1,14 +1,13 @@
 import { authenticateRequest } from '../../lib/auth';
 import { handleCors } from '../../lib/cors';
+import { methodNotAllowed } from '../../lib/responses';
 import type { VercelRequest, VercelResponse } from '../../lib/types';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleCors(req, res)) return;
 
   if (req.method !== 'GET') {
-    return res.status(405).json({
-      error: { code: 'METHOD_NOT_ALLOWED', message: 'Only GET is allowed' },
-    });
+    return methodNotAllowed(res, 'GET');
   }
 
   const payload = await authenticateRequest(req, res);

--- a/registry/api/v1/search.ts
+++ b/registry/api/v1/search.ts
@@ -1,15 +1,14 @@
 import { DEFAULT_PER_PAGE, MAX_PER_PAGE } from '../../lib/constants';
 import { handleCors } from '../../lib/cors';
 import { fetchManifestDossiers, normalizeDossier } from '../../lib/manifest';
+import { methodNotAllowed } from '../../lib/responses';
 import type { VercelRequest, VercelResponse } from '../../lib/types';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleCors(req, res)) return;
 
   if (req.method !== 'GET') {
-    return res.status(405).json({
-      error: { code: 'METHOD_NOT_ALLOWED', message: 'Only GET is allowed' },
-    });
+    return methodNotAllowed(res, 'GET');
   }
 
   const { q, page: pageStr, per_page: perPageStr } = req.query as Record<string, string>;

--- a/registry/lib/responses.ts
+++ b/registry/lib/responses.ts
@@ -1,0 +1,16 @@
+import type { VercelResponse } from './types';
+
+function formatAllowed(methods: string[]): string {
+  if (methods.length === 1) return methods[0];
+  if (methods.length === 2) return `${methods[0]} and ${methods[1]}`;
+  return `${methods.slice(0, -1).join(', ')}, and ${methods[methods.length - 1]}`;
+}
+
+export function methodNotAllowed(res: VercelResponse, ...allowed: string[]): VercelResponse {
+  return res.status(405).json({
+    error: {
+      code: 'METHOD_NOT_ALLOWED',
+      message: `Only ${formatAllowed(allowed)} ${allowed.length === 1 ? 'is' : 'are'} allowed`,
+    },
+  });
+}

--- a/registry/tests/responses.test.ts
+++ b/registry/tests/responses.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { methodNotAllowed } from '../lib/responses';
+
+function createMockRes() {
+  const res: Record<string, unknown> = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('methodNotAllowed', () => {
+  it('returns 405 with single method', () => {
+    const res = createMockRes();
+    methodNotAllowed(res as never, 'GET');
+
+    expect(res.status).toHaveBeenCalledWith(405);
+    expect(res.json).toHaveBeenCalledWith({
+      error: { code: 'METHOD_NOT_ALLOWED', message: 'Only GET is allowed' },
+    });
+  });
+
+  it('returns 405 with two methods', () => {
+    const res = createMockRes();
+    methodNotAllowed(res as never, 'GET', 'POST');
+
+    expect(res.json).toHaveBeenCalledWith({
+      error: { code: 'METHOD_NOT_ALLOWED', message: 'Only GET and POST are allowed' },
+    });
+  });
+
+  it('returns 405 with three methods using Oxford comma', () => {
+    const res = createMockRes();
+    methodNotAllowed(res as never, 'GET', 'HEAD', 'DELETE');
+
+    expect(res.json).toHaveBeenCalledWith({
+      error: { code: 'METHOD_NOT_ALLOWED', message: 'Only GET, HEAD, and DELETE are allowed' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extracts duplicated 405 METHOD_NOT_ALLOWED response pattern into a shared `methodNotAllowed()` helper in `registry/lib/responses.ts`
- Replaces inline 405 responses across 7 API handlers (dossiers/index, search, docs, me, [...name], auth/login, auth/callback)
- Adds unit tests for the helper covering single, two, and three+ method formatting

Closes #176

## Test plan
- [x] New `responses.test.ts` tests pass (3 tests)
- [x] All existing registry tests pass (70 tests across 8 files)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Biome lint passes

Co-Authored-By: Claude <noreply@anthropic.com>