### PR TITLE
fix(registry): add correlation IDs to auth error responses

### DIFF
--- a/registry/api/auth/callback.ts
+++ b/registry/api/auth/callback.ts
@@ -92,13 +92,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(200).send(renderSuccessPage(user.login, orgs, displayCode, clientId));
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
-    console.error('[auth/callback] OAuth callback failed:', error.message, error.stack);
+    const errorRef = crypto.randomBytes(4).toString('hex');
+    console.error(
+      `[auth/callback] OAuth callback failed (ref=${errorRef}):`,
+      error.message,
+      error.stack
+    );
     return res
       .status(500)
       .send(
         renderErrorPage(
           'Authentication Error',
-          'Failed to complete authentication. Please try again.'
+          'Failed to complete authentication. Please try again.',
+          errorRef
         )
       );
   }
@@ -234,7 +240,9 @@ function renderSuccessPage(
 </html>`;
 }
 
-function renderErrorPage(title: string, message: string): string {
+function renderErrorPage(title: string, message: string, errorRef?: string): string {
+  const refHtml = errorRef ? `<p class="error-ref">Reference: ${escapeHtml(errorRef)}</p>` : '';
+
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -264,6 +272,7 @@ function renderErrorPage(title: string, message: string): string {
     h1 { color: #dc3545; margin-bottom: 16px; font-size: 24px; }
     .message { color: #666; line-height: 1.6; }
     .error-icon { font-size: 48px; margin-bottom: 16px; }
+    .error-ref { color: #999; font-size: 12px; margin-top: 16px; font-family: monospace; }
   </style>
 </head>
 <body>
@@ -271,6 +280,7 @@ function renderErrorPage(title: string, message: string): string {
     <div class="error-icon">&#10060;</div>
     <h1>${escapeHtml(title)}</h1>
     <p class="message">${escapeHtml(message)}</p>
+    ${refHtml}
   </div>
 </body>
 </html>`;

--- a/registry/api/auth/login.ts
+++ b/registry/api/auth/login.ts
@@ -28,8 +28,13 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
     console.log(`[auth/login] Redirecting to GitHub OAuth`);
     res.redirect(`https://github.com/login/oauth/authorize?${params}`);
   } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
     const errorRef = crypto.randomBytes(4).toString('hex');
-    console.error(`[auth/login] Failed to initiate login redirect (ref=${errorRef}):`, err);
+    console.error(
+      `[auth/login] Failed to initiate login redirect (ref=${errorRef}):`,
+      error.message,
+      error.stack
+    );
     return res.status(500).json({
       error: {
         code: 'LOGIN_ERROR',

--- a/registry/api/auth/login.ts
+++ b/registry/api/auth/login.ts
@@ -28,11 +28,13 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
     console.log(`[auth/login] Redirecting to GitHub OAuth`);
     res.redirect(`https://github.com/login/oauth/authorize?${params}`);
   } catch (err) {
-    console.error('[auth/login] Failed to initiate login redirect:', err);
+    const errorRef = crypto.randomBytes(4).toString('hex');
+    console.error(`[auth/login] Failed to initiate login redirect (ref=${errorRef}):`, err);
     return res.status(500).json({
       error: {
         code: 'LOGIN_ERROR',
         message: 'Failed to initiate login. Please try again.',
+        ref: errorRef,
       },
     });
   }

--- a/registry/tests/supportability.test.ts
+++ b/registry/tests/supportability.test.ts
@@ -1,0 +1,122 @@
+import crypto from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import { OAUTH_STATE_COOKIE } from '../lib/constants';
+
+describe('error correlation IDs', () => {
+  it('callback handler includes error ref in 500 response and log', async () => {
+    const callbackModule = await import('../api/auth/callback');
+    const handler = callbackModule.default;
+
+    // Provide valid state so we reach the try/catch block (code exchange will fail)
+    const state = crypto.randomBytes(32).toString('hex');
+    const req = {
+      method: 'GET',
+      query: { code: 'bad-code', state },
+      headers: { cookie: `${OAUTH_STATE_COOKIE}=${state}` },
+    } as any;
+
+    let statusCode = 0;
+    let body = '';
+    const res = {
+      status: (code: number) => {
+        statusCode = code;
+        return {
+          send: (b: string) => {
+            body = b;
+          },
+          json: (b: any) => {
+            body = JSON.stringify(b);
+          },
+        };
+      },
+      setHeader: () => {},
+    } as any;
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await handler(req, res);
+
+    expect(statusCode).toBe(500);
+
+    // Error page should contain a reference code (8 hex chars)
+    const refMatch = body.match(/Reference:\s*([a-f0-9]{8})/);
+    expect(refMatch).not.toBeNull();
+    const errorRef = refMatch![1];
+
+    // Console log should contain the same ref
+    const logCall = consoleSpy.mock.calls.find((call) =>
+      String(call[0]).includes(`ref=${errorRef}`)
+    );
+    expect(logCall).toBeDefined();
+
+    consoleSpy.mockRestore();
+  });
+
+  it('login handler includes error ref in 500 response when login fails', async () => {
+    // Mock config to cause a failure (missing clientId)
+    const originalEnv = process.env.GITHUB_CLIENT_ID;
+    delete process.env.GITHUB_CLIENT_ID;
+
+    // Force re-import to get fresh module
+    vi.resetModules();
+
+    // Mock config to throw on clientId access
+    vi.doMock('../lib/config', () => ({
+      default: {
+        auth: {
+          github: {
+            get clientId(): string {
+              throw new Error('GITHUB_CLIENT_ID is not set');
+            },
+            clientSecret: 'test',
+            scopes: 'read:user',
+            tokenUrl: 'https://github.com/login/oauth/access_token',
+            apiUrl: 'https://api.github.com',
+          },
+          jwt: { secret: 'test' },
+        },
+        baseUrl: 'https://test.example.com',
+      },
+    }));
+
+    const loginModule = await import('../api/auth/login');
+    const handler = loginModule.default;
+
+    const req = { method: 'GET' } as any;
+
+    let statusCode = 0;
+    let body: any = {};
+    const res = {
+      status: (code: number) => {
+        statusCode = code;
+        return {
+          json: (b: any) => {
+            body = b;
+          },
+        };
+      },
+      setHeader: () => {},
+      redirect: () => {},
+    } as any;
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    handler(req, res);
+
+    expect(statusCode).toBe(500);
+    expect(body.error.ref).toMatch(/^[a-f0-9]{8}$/);
+
+    // Console log should contain the same ref
+    const logCall = consoleSpy.mock.calls.find((call) =>
+      String(call[0]).includes(`ref=${body.error.ref}`)
+    );
+    expect(logCall).toBeDefined();
+
+    consoleSpy.mockRestore();
+    vi.doUnmock('../lib/config');
+
+    if (originalEnv !== undefined) {
+      process.env.GITHUB_CLIENT_ID = originalEnv;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add error reference codes (`crypto.randomBytes(4).toString('hex')`) to auth handler error responses
- Callback handler catch block now includes a correlation ID in both the console log and the user-facing error page
- Login handler catch block now includes a correlation ID in both the console log and the JSON error response
- Added `supportability.test.ts` with tests verifying correlation IDs appear in both logs and responses

Closes #190

## Test plan
- [x] New `registry/tests/supportability.test.ts` verifies correlation IDs in callback and login error paths
- [x] All 684 existing tests pass across all packages

Co-Authored-By: Claude <noreply@anthropic.com>