### PR TITLE
fix(cli): prevent credential exfiltration via project config override

### DIFF
--- a/cli/src/__tests__/commands/config-cmd.test.ts
+++ b/cli/src/__tests__/commands/config-cmd.test.ts
@@ -91,4 +91,88 @@ describe('config command', () => {
     expect(config.saveConfig).toHaveBeenCalledWith(config.DEFAULT_CONFIG);
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('reset to defaults'));
   });
+
+  describe('--add-registry HTTPS validation', () => {
+    it('should reject http:// registry URLs', async () => {
+      const program = createTestProgram();
+      registerConfigCommand(program);
+
+      await expect(
+        program.parseAsync([
+          'node',
+          'dossier',
+          'config',
+          '--add-registry',
+          'insecure',
+          '--url',
+          'http://registry.example.com',
+        ])
+      ).rejects.toThrow();
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Registry URL must use HTTPS')
+      );
+    });
+
+    it('should reject file:// registry URLs', async () => {
+      const program = createTestProgram();
+      registerConfigCommand(program);
+
+      await expect(
+        program.parseAsync([
+          'node',
+          'dossier',
+          'config',
+          '--add-registry',
+          'local',
+          '--url',
+          'file:///etc/passwd',
+        ])
+      ).rejects.toThrow();
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Registry URL must use HTTPS')
+      );
+    });
+
+    it('should reject invalid URLs', async () => {
+      const program = createTestProgram();
+      registerConfigCommand(program);
+
+      await expect(
+        program.parseAsync([
+          'node',
+          'dossier',
+          'config',
+          '--add-registry',
+          'bad',
+          '--url',
+          'not-a-url',
+        ])
+      ).rejects.toThrow();
+
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Invalid URL'));
+    });
+
+    it('should accept https:// registry URLs', async () => {
+      vi.mocked(config.saveConfig).mockReturnValue(true);
+      const program = createTestProgram();
+      registerConfigCommand(program);
+
+      await expect(
+        program.parseAsync([
+          'node',
+          'dossier',
+          'config',
+          '--add-registry',
+          'secure',
+          '--url',
+          'https://registry.example.com',
+        ])
+      ).rejects.toThrow();
+
+      expect(config.saveConfig).toHaveBeenCalled();
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Added registry 'secure'"));
+    });
+  });
 });

--- a/cli/src/__tests__/config.test.ts
+++ b/cli/src/__tests__/config.test.ts
@@ -206,6 +206,33 @@ describe('config', () => {
         'https://internal.example.com'
       );
     });
+
+    it('should not allow project config to override user-configured registry URLs', () => {
+      mockedFs.existsSync.mockImplementation((p: fs.PathLike) => {
+        const s = String(p);
+        return s.endsWith('config.json') || s.endsWith('.dossierrc.json');
+      });
+
+      let callCount = 0;
+      mockedFs.readFileSync.mockImplementation(() => {
+        callCount++;
+        if (callCount <= 1) {
+          // User config: has 'public' registry
+          return JSON.stringify({
+            registries: { public: { url: 'https://user-registry.example.com' } },
+          });
+        }
+        // Project config: tries to override 'public' with attacker URL
+        return JSON.stringify({
+          registries: { public: { url: 'https://attacker.example.com' } },
+        });
+      });
+
+      const registries = resolveRegistries();
+      const pub = registries.find((r) => r.name === 'public');
+      expect(pub?.url).toBe('https://user-registry.example.com');
+      expect(pub?.url).not.toBe('https://attacker.example.com');
+    });
   });
 
   describe('resolveWriteRegistry', () => {

--- a/cli/src/__tests__/credentials.test.ts
+++ b/cli/src/__tests__/credentials.test.ts
@@ -245,8 +245,12 @@ describe('credentials', () => {
       expect(isExpired({ expiresAt: past })).toBe(true);
     });
 
-    it('should return false on invalid date string', () => {
-      expect(isExpired({ expiresAt: 'not-a-date' })).toBe(false);
+    it('should return true on invalid date string (NaN bypass)', () => {
+      expect(isExpired({ expiresAt: 'not-a-date' })).toBe(true);
+    });
+
+    it('should return false on empty string expiresAt (treated as no expiration)', () => {
+      expect(isExpired({ expiresAt: '' })).toBe(false);
     });
   });
 });

--- a/cli/src/commands/config-cmd.ts
+++ b/cli/src/commands/config-cmd.ts
@@ -83,6 +83,19 @@ export function registerConfigCommand(program: Command): void {
             process.exit(1);
           }
 
+          // Validate HTTPS — reject http:// and other insecure protocols
+          try {
+            const parsed = new URL(options.url);
+            if (parsed.protocol !== 'https:') {
+              console.error(`\n❌ Registry URL must use HTTPS: ${options.url}\n`);
+              console.error('Only https:// URLs are allowed to protect credentials in transit.\n');
+              process.exit(1);
+            }
+          } catch {
+            console.error(`\n❌ Invalid URL: ${options.url}\n`);
+            process.exit(1);
+          }
+
           const currentConfig = config.loadConfig();
           if (!currentConfig.registries) {
             currentConfig.registries = {};

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -149,6 +149,10 @@ function resolveRegistries(): ResolvedRegistry[] {
 
   if (projectConfig?.registries) {
     for (const [name, entry] of Object.entries(projectConfig.registries)) {
+      if (name in merged) {
+        // Project config cannot override user-configured registries (credential exfiltration vector)
+        continue;
+      }
       merged[name] = entry;
     }
   }

--- a/cli/src/credentials.ts
+++ b/cli/src/credentials.ts
@@ -174,12 +174,11 @@ function isExpired(credentials: Pick<Credentials, 'expiresAt'>): boolean {
   if (!credentials.expiresAt) {
     return false;
   }
-  try {
-    const expires = new Date(credentials.expiresAt);
-    return Date.now() > expires.getTime();
-  } catch {
-    return false;
+  const expires = new Date(credentials.expiresAt);
+  if (Number.isNaN(expires.getTime())) {
+    return true;
   }
+  return Date.now() > expires.getTime();
 }
 
 /**


### PR DESCRIPTION
## Summary
- Block `.dossierrc.json` from overriding user-configured registry URLs by name (prevents credential exfiltration via supply chain attack)
- Add HTTPS validation for registry URLs in `--add-registry` (rejects `http://`, `file://`, and invalid URLs)
- Fix `isExpired` NaN bypass — malformed `expiresAt` values are now treated as expired instead of silently passing

Closes #195

## Test plan
- [x] New test: project config cannot override user registry URLs
- [x] New tests: HTTPS validation rejects `http://`, `file://`, invalid URLs; accepts `https://`
- [x] Updated test: invalid date strings now return `true` (expired) instead of `false`
- [x] All 55 CLI tests passing

Co-Authored-By: Claude <noreply@anthropic.com>