### PR TITLE
docs(cli): improve multi-registry discoverability

### DIFF
--- a/cli/src/__tests__/agent-flag.test.ts
+++ b/cli/src/__tests__/agent-flag.test.ts
@@ -25,9 +25,17 @@ describe('--agent flag', () => {
       skip_prompts: '-y / --yes',
       non_tty_safe: true,
       machine_errors: true,
+      multi_registry: true,
     });
     expect(manifest.quick_start).toBeInstanceOf(Array);
     expect(manifest.quick_start.length).toBeGreaterThan(0);
+
+    // Registry section should describe multi-registry support
+    expect(manifest.registry).toBeDefined();
+    expect(manifest.registry.commands).toBeDefined();
+    expect(manifest.registry.env_vars).toBeInstanceOf(Array);
+    expect(manifest.registry.env_vars).toContain('DOSSIER_REGISTRY_URL');
+    expect(manifest.registry.project_config).toBe('.dossierrc.json');
   });
 
   it('should include agent hint in --help output', () => {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -93,12 +93,31 @@ if (process.argv.includes('--agent')) {
       skip_prompts: '-y / --yes',
       non_tty_safe: true,
       machine_errors: true,
+      multi_registry: true,
+    },
+    registry: {
+      description:
+        'Supports multiple registries queried in parallel. Configure via config command, .dossierrc.json, or DOSSIER_REGISTRY_URL env var.',
+      commands: {
+        configure: 'ai-dossier config --add-registry <name> --url <url>',
+        list_registries: 'ai-dossier config --list-registries --json',
+        set_default: 'ai-dossier config --set-default-registry <name>',
+      },
+      env_vars: [
+        'DOSSIER_REGISTRY_URL',
+        'DOSSIER_REGISTRY_TOKEN',
+        'DOSSIER_REGISTRY_USER',
+        'DOSSIER_REGISTRY_ORGS',
+      ],
+      project_config: '.dossierrc.json',
     },
     quick_start: [
       'ai-dossier commands                    # discover all commands and flags',
       'ai-dossier whoami --json               # check auth status',
       'ai-dossier search <query> --json       # find dossiers',
       'ai-dossier list --json --source registry  # list all registry dossiers',
+      'ai-dossier config --list-registries --json  # list configured registries',
+      'ai-dossier config --add-registry internal --url https://dossier.company.com  # add registry',
     ],
   };
   console.log(JSON.stringify(manifest, null, 2));

--- a/cli/src/commands/config-cmd.ts
+++ b/cli/src/commands/config-cmd.ts
@@ -4,7 +4,9 @@ import * as config from '../config';
 export function registerConfigCommand(program: Command): void {
   program
     .command('config')
-    .description('Manage dossier configuration')
+    .description(
+      'Manage dossier configuration and registry settings. Use --add-registry, --remove-registry, and --list-registries to manage multiple registries.'
+    )
     .argument('[key]', 'Configuration key (e.g., defaultLlm)')
     .argument('[value]', 'Value to set (omit to get current value)')
     .option('--list', 'List all configuration')
@@ -17,6 +19,23 @@ export function registerConfigCommand(program: Command): void {
     .option('--default', 'Mark registry as default (used with --add-registry)')
     .option('--readonly', 'Mark registry as read-only (used with --add-registry)')
     .option('--json', 'Output as JSON')
+    .addHelpText(
+      'after',
+      `
+Project-level config:
+  Place a .dossierrc.json in your project root for team-shared registry settings:
+  {
+    "registries": { "internal": { "url": "https://dossier.company.com" } },
+    "defaultRegistry": "internal"
+  }
+
+Environment variables:
+  DOSSIER_REGISTRY_URL    Override/add a registry URL (creates virtual "env" registry)
+  DOSSIER_REGISTRY_TOKEN  Auth token for the default registry
+  DOSSIER_REGISTRY_USER   Username for registry authentication
+  DOSSIER_REGISTRY_ORGS   Comma-separated org scopes for registry queries
+`
+    )
     .action(
       (
         key: string | undefined,

--- a/cli/src/commands/export.ts
+++ b/cli/src/commands/export.ts
@@ -7,7 +7,7 @@ import { parseNameVersion } from '../registry-client';
 export function registerExportCommand(program: Command): void {
   program
     .command('export')
-    .description('Download a dossier and save to a local file')
+    .description('Download a dossier and save to a local file. Searches all configured registries.')
     .argument('<name>', 'Dossier name (use name@version for a specific version)')
     .option('-o, --output <path>', 'Output file path')
     .option('--stdout', 'Print to stdout instead of saving to file')

--- a/cli/src/commands/get.ts
+++ b/cli/src/commands/get.ts
@@ -7,7 +7,9 @@ import { parseNameVersion } from '../registry-client';
 export function registerGetCommand(program: Command): void {
   program
     .command('get')
-    .description('Get dossier metadata from the registry')
+    .description(
+      'Get dossier metadata from the registry. Searches all configured registries and returns the first match.'
+    )
     .argument('<name>', 'Dossier name (optionally with @version, e.g., my-dossier@1.0.0)')
     .option('--json', 'Output as JSON')
     .action(async (nameArg: string, options: { json?: boolean }) => {

--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -11,7 +11,7 @@ import { parseNameVersion } from '../registry-client';
 export function registerInfoCommand(program: Command): void {
   program
     .command('info')
-    .description('Show dossier metadata')
+    .description('Show dossier metadata. For registry names, searches all configured registries.')
     .argument('<file-or-name>', 'Local dossier file path or registry dossier name')
     .option('--json', 'Output as JSON')
     .action(async (fileOrName: string, options: { json?: boolean }) => {

--- a/cli/src/commands/list.ts
+++ b/cli/src/commands/list.ts
@@ -16,7 +16,9 @@ import { multiRegistryList } from '../multi-registry';
 export function registerListCommand(program: Command): void {
   program
     .command('list')
-    .description('List available dossiers from registry, directory, or repository')
+    .description(
+      'List available dossiers from registry, directory, or repository. With --source registry, queries all configured registries in parallel.'
+    )
     .argument('[source]', 'Directory, GitHub repo (github:owner/repo), or URL', '.')
     .option('-r, --recursive', 'Search subdirectories recursively (default for remote)')
     .option('--signed-only', 'Only show signed dossiers')
@@ -28,6 +30,16 @@ export function registerListCommand(program: Command): void {
     .option('--source <type>', 'Source type: registry, local, github')
     .option('--page <number>', 'Page number (registry only)', '1')
     .option('--per-page <number>', 'Results per page (registry only)', '20')
+    .addHelpText(
+      'after',
+      `
+Multi-registry note:
+  When multiple registries are configured, --page and --per-page apply to each
+  registry independently. For consistent results across registries, use
+  --per-page with a value large enough to capture all dossiers per registry,
+  or use 'search' for filtered queries.
+`
+    )
     .action(
       async (
         source: string,

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -6,8 +6,18 @@ import { runOAuthFlow } from '../oauth';
 export function registerLoginCommand(program: Command): void {
   program
     .command('login')
-    .description('Authenticate with the dossier registry via GitHub')
+    .description(
+      'Authenticate with the dossier registry via GitHub. Use --registry to target a specific registry.'
+    )
     .option('--registry <name>', 'Registry to authenticate with')
+    .addHelpText(
+      'after',
+      `
+For non-interactive environments (CI/CD), use environment variables instead:
+  DOSSIER_REGISTRY_TOKEN  Auth token for registry access
+  DOSSIER_REGISTRY_URL    Registry URL (creates virtual "env" registry)
+`
+    )
     .action(async (options: { registry?: string }) => {
       if (!process.stdin.isTTY) {
         console.error('\n❌ Non-interactive session detected. Cannot run OAuth flow.');

--- a/cli/src/commands/pull.ts
+++ b/cli/src/commands/pull.ts
@@ -10,7 +10,9 @@ import { parseNameVersion } from '../registry-client';
 export function registerPullCommand(program: Command): void {
   program
     .command('pull')
-    .description('Download a dossier from the registry to local cache')
+    .description(
+      'Download a dossier from the registry to local cache. Searches all configured registries.'
+    )
     .argument('<name...>', 'Dossier name(s) (use name@version for a specific version)')
     .option('--force', 'Re-download even if already cached')
     .action(async (names: string[], options: { force?: boolean }) => {

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -18,7 +18,9 @@ import { parseNameVersion } from '../registry-client';
 export function registerRunCommand(program: Command): void {
   program
     .command('run')
-    .description('Verify, audit, and execute dossier')
+    .description(
+      'Verify, audit, and execute dossier. Registry names are resolved across all configured registries.'
+    )
     .argument('<file>', 'Dossier file, URL, or registry name to run')
     .option('--llm <name>', 'LLM to use (claude-code, auto)')
     .option('--headless', 'Run in headless mode (non-interactive, for CI/CD)')

--- a/cli/src/commands/search.ts
+++ b/cli/src/commands/search.ts
@@ -8,7 +8,7 @@ import { getClientForRegistry } from '../registry-client';
 export function registerSearchCommand(program: Command): void {
   program
     .command('search')
-    .description('Search the registry for dossiers')
+    .description('Search for dossiers across all configured registries')
     .argument('<query>', 'Search keywords')
     .option(
       '--category <category>',


### PR DESCRIPTION
## Summary
- Updates `config` command description and help text to document registry management, `.dossierrc.json`, and environment variables
- Adds `registry` section and multi-registry capabilities to the `--agent` JSON manifest
- Updates descriptions of all read commands (`list`, `search`, `get`, `info`, `pull`, `export`, `run`) to document multi-registry parallel query behavior
- Adds pagination limitation note to `list` command help
- Adds env var documentation to `login` command help

Closes #198

## Test plan
- [x] All 360 existing tests pass (41 test files)
- [x] Agent-flag test updated and passing with new registry manifest assertions
- [x] Config-cmd tests pass
- [x] Build succeeds (`npm run build`)
- [ ] Manual: `ai-dossier config --help` shows registry and env var info
- [ ] Manual: `ai-dossier --agent` includes registry section
- [ ] Manual: `ai-dossier list --help` shows pagination note

Co-Authored-By: Claude <noreply@anthropic.com>