### PR TITLE
fix: resolveWriteRegistry, config reset, and multiRegistry error reporting

### DIFF
--- a/cli/src/__tests__/commands/create.test.ts
+++ b/cli/src/__tests__/commands/create.test.ts
@@ -48,7 +48,14 @@ describe('create command', () => {
       throw new Error('ENOENT');
     });
 
-    vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue(null);
+    vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
+      result: null,
+      errors: [],
+    } as any);
+    vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
+      result: null,
+      errors: [],
+    } as any);
 
     const program = createTestProgram();
     registerCreateCommand(program);
@@ -67,12 +74,12 @@ describe('create command', () => {
     vi.mocked(spawnSync).mockReturnValue({ status: 0 } as any);
 
     vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
-      version: '1.0.0',
-      _registry: 'public',
+      result: { version: '1.0.0', _registry: 'public' },
+      errors: [],
     } as any);
     vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
-      content: '# Meta dossier content',
-      _registry: 'public',
+      result: { content: '# Meta dossier content', _registry: 'public' },
+      errors: [],
     } as any);
 
     const program = createTestProgram();
@@ -97,12 +104,12 @@ describe('create command', () => {
     vi.mocked(spawnSync).mockReturnValue({ status: 1 } as any);
 
     vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
-      version: '1.0.0',
-      _registry: 'public',
+      result: { version: '1.0.0', _registry: 'public' },
+      errors: [],
     } as any);
     vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
-      content: '# Meta dossier',
-      _registry: 'public',
+      result: { content: '# Meta dossier', _registry: 'public' },
+      errors: [],
     } as any);
 
     const program = createTestProgram();

--- a/cli/src/__tests__/commands/export.test.ts
+++ b/cli/src/__tests__/commands/export.test.ts
@@ -25,9 +25,8 @@ describe('export command', () => {
 
   it('should export dossier to file', async () => {
     vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
-      content: '# Dossier content',
-      digest: 'sha256:abc',
-      _registry: 'public',
+      result: { content: '# Dossier content', digest: 'sha256:abc', _registry: 'public' },
+      errors: [],
     });
 
     const program = createTestProgram();
@@ -41,9 +40,8 @@ describe('export command', () => {
 
   it('should export specific version', async () => {
     vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
-      content: 'content',
-      digest: null,
-      _registry: 'public',
+      result: { content: 'content', digest: null, _registry: 'public' },
+      errors: [],
     });
 
     const program = createTestProgram();
@@ -56,9 +54,8 @@ describe('export command', () => {
 
   it('should write to stdout with --stdout', async () => {
     vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
-      content: 'dossier content here',
-      digest: null,
-      _registry: 'public',
+      result: { content: 'dossier content here', digest: null, _registry: 'public' },
+      errors: [],
     });
     const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
 
@@ -73,7 +70,10 @@ describe('export command', () => {
   });
 
   it('should exit 1 when not found', async () => {
-    vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue(null);
+    vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
+      result: null,
+      errors: [],
+    });
 
     const program = createTestProgram();
     registerExportCommand(program);
@@ -87,9 +87,8 @@ describe('export command', () => {
 
   it('should use custom output path with -o', async () => {
     vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
-      content: 'content',
-      digest: null,
-      _registry: 'public',
+      result: { content: 'content', digest: null, _registry: 'public' },
+      errors: [],
     });
 
     const program = createTestProgram();

--- a/cli/src/__tests__/commands/get.test.ts
+++ b/cli/src/__tests__/commands/get.test.ts
@@ -25,15 +25,18 @@ describe('get command', () => {
 
   it('should display dossier metadata from registry', async () => {
     vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
-      name: 'deploy-app',
-      title: 'Deploy Application',
-      version: '1.0.0',
-      status: 'stable',
-      category: ['devops'],
-      objective: 'Deploy to production',
-      authors: [{ name: 'Alice' }],
-      tags: ['deploy', 'ci'],
-      _registry: 'public',
+      result: {
+        name: 'deploy-app',
+        title: 'Deploy Application',
+        version: '1.0.0',
+        status: 'stable',
+        category: ['devops'],
+        objective: 'Deploy to production',
+        authors: [{ name: 'Alice' }],
+        tags: ['deploy', 'ci'],
+        _registry: 'public',
+      },
+      errors: [],
     });
 
     const program = createTestProgram();
@@ -48,10 +51,13 @@ describe('get command', () => {
 
   it('should pass version when using name@version', async () => {
     vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
-      name: 'deploy-app',
-      title: 'Deploy Application',
-      version: '2.0.0',
-      _registry: 'public',
+      result: {
+        name: 'deploy-app',
+        title: 'Deploy Application',
+        version: '2.0.0',
+        _registry: 'public',
+      },
+      errors: [],
     });
 
     const program = createTestProgram();
@@ -66,10 +72,8 @@ describe('get command', () => {
 
   it('should output JSON with --json', async () => {
     vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
-      name: 'test',
-      title: 'Test',
-      version: '1.0.0',
-      _registry: 'public',
+      result: { name: 'test', title: 'Test', version: '1.0.0', _registry: 'public' },
+      errors: [],
     });
 
     const program = createTestProgram();
@@ -86,7 +90,10 @@ describe('get command', () => {
   });
 
   it('should exit 1 on not found', async () => {
-    vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue(null);
+    vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
+      result: null,
+      errors: [],
+    });
 
     const program = createTestProgram();
     registerGetCommand(program);

--- a/cli/src/__tests__/commands/info.test.ts
+++ b/cli/src/__tests__/commands/info.test.ts
@@ -58,10 +58,13 @@ describe('info command', () => {
   it('should fetch info from registry when not a local file', async () => {
     mockedFs.existsSync.mockReturnValue(false);
     vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
-      name: 'org/dossier',
-      title: 'Registry Dossier',
-      version: '1.0.0',
-      _registry: 'public',
+      result: {
+        name: 'org/dossier',
+        title: 'Registry Dossier',
+        version: '1.0.0',
+        _registry: 'public',
+      },
+      errors: [],
     });
 
     const program = createTestProgram();
@@ -93,7 +96,10 @@ describe('info command', () => {
 
   it('should exit 1 on registry 404', async () => {
     mockedFs.existsSync.mockReturnValue(false);
-    vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue(null);
+    vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
+      result: null,
+      errors: [],
+    });
 
     const program = createTestProgram();
     registerInfoCommand(program);

--- a/cli/src/__tests__/commands/install-skill.test.ts
+++ b/cli/src/__tests__/commands/install-skill.test.ts
@@ -91,12 +91,12 @@ describe('install-skill command', () => {
   it('should install from registry', async () => {
     mockedFs.existsSync.mockReturnValue(false);
     vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
-      version: '1.0.0',
-      _registry: 'public',
+      result: { version: '1.0.0', _registry: 'public' },
+      errors: [],
     } as any);
     vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
-      content: '# Skill content',
-      _registry: 'public',
+      result: { content: '# Skill content', _registry: 'public' },
+      errors: [],
     } as any);
 
     const program = createTestProgram();

--- a/cli/src/__tests__/commands/pull.test.ts
+++ b/cli/src/__tests__/commands/pull.test.ts
@@ -29,13 +29,12 @@ describe('pull command', () => {
 
   it('should download and cache a dossier', async () => {
     vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
-      version: '1.0.0',
-      _registry: 'public',
+      result: { version: '1.0.0', _registry: 'public' },
+      errors: [],
     } as any);
     vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
-      content: '# Dossier',
-      digest: null,
-      _registry: 'public',
+      result: { content: '# Dossier', digest: null, _registry: 'public' },
+      errors: [],
     });
     mockedFs.existsSync.mockReturnValue(false);
 
@@ -51,8 +50,8 @@ describe('pull command', () => {
 
   it('should skip already cached dossier', async () => {
     vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
-      version: '1.0.0',
-      _registry: 'public',
+      result: { version: '1.0.0', _registry: 'public' },
+      errors: [],
     } as any);
     mockedFs.existsSync.mockReturnValue(true);
 
@@ -67,13 +66,12 @@ describe('pull command', () => {
 
   it('should force re-download with --force', async () => {
     vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
-      version: '1.0.0',
-      _registry: 'public',
+      result: { version: '1.0.0', _registry: 'public' },
+      errors: [],
     } as any);
     vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
-      content: '# Updated',
-      digest: null,
-      _registry: 'public',
+      result: { content: '# Updated', digest: null, _registry: 'public' },
+      errors: [],
     });
     mockedFs.existsSync.mockReturnValue(true);
 
@@ -87,7 +85,10 @@ describe('pull command', () => {
   });
 
   it('should handle 404 error', async () => {
-    vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue(null);
+    vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
+      result: null,
+      errors: [],
+    } as any);
     mockedFs.existsSync.mockReturnValue(false);
 
     const program = createTestProgram();
@@ -100,9 +101,8 @@ describe('pull command', () => {
 
   it('should pull specific version', async () => {
     vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
-      content: '# Content',
-      digest: null,
-      _registry: 'public',
+      result: { content: '# Content', digest: null, _registry: 'public' },
+      errors: [],
     });
     mockedFs.existsSync.mockReturnValue(false);
 

--- a/cli/src/__tests__/commands/run.test.ts
+++ b/cli/src/__tests__/commands/run.test.ts
@@ -94,7 +94,10 @@ describe('run command', () => {
   it('should exit 1 when registry dossier not found', async () => {
     mockedFs.existsSync.mockReturnValue(false);
     mockedFs.readdirSync.mockReturnValue([]);
-    vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue(null);
+    vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
+      result: null,
+      errors: [],
+    } as any);
 
     const program = createTestProgram();
     registerRunCommand(program);

--- a/cli/src/__tests__/config.test.ts
+++ b/cli/src/__tests__/config.test.ts
@@ -230,6 +230,21 @@ describe('config', () => {
       );
       expect(() => resolveWriteRegistry('mirror')).toThrow('read-only');
     });
+
+    it('should throw when all registries are readonly', () => {
+      mockedFs.existsSync.mockImplementation((p: fs.PathLike) => String(p).endsWith('config.json'));
+      mockedFs.readFileSync.mockReturnValue(
+        JSON.stringify({
+          registries: {
+            mirror1: { url: 'https://mirror1.example.com', readonly: true },
+            mirror2: { url: 'https://mirror2.example.com', readonly: true },
+          },
+        })
+      );
+      expect(() => resolveWriteRegistry()).toThrow(
+        'No writable registry configured. All registries are read-only.'
+      );
+    });
   });
 
   describe('resolveRegistryByName', () => {

--- a/cli/src/__tests__/integration/registry-flow.test.ts
+++ b/cli/src/__tests__/integration/registry-flow.test.ts
@@ -125,10 +125,13 @@ describe('registry flow integration', () => {
     // Step 3: Info from registry
     mockedFs.existsSync.mockReturnValue(false); // Not a local file
     vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
-      name: 'org/my-workflow',
-      title: 'My Workflow',
-      version: '1.0.0',
-      _registry: 'public',
+      result: {
+        name: 'org/my-workflow',
+        title: 'My Workflow',
+        version: '1.0.0',
+        _registry: 'public',
+      },
+      errors: [],
     });
 
     const info = createTestProgram();
@@ -140,9 +143,8 @@ describe('registry flow integration', () => {
     // Step 4: Export
     mockedFs.existsSync.mockReturnValue(true); // Output dir exists
     vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
-      content: dossierContent,
-      digest: null,
-      _registry: 'public',
+      result: { content: dossierContent, digest: null, _registry: 'public' },
+      errors: [],
     });
 
     const exp = createTestProgram();

--- a/cli/src/__tests__/multi-registry.test.ts
+++ b/cli/src/__tests__/multi-registry.test.ts
@@ -84,19 +84,29 @@ describe('multi-registry', () => {
     it('should return dossier from first succeeding registry', async () => {
       mockClient.getDossier.mockResolvedValue({ name: 'test', version: '1.0.0' });
 
-      const result = await multiRegistryGetDossier('test');
+      const { result } = await multiRegistryGetDossier('test');
       expect(result).toBeDefined();
       expect(result?._registry).toBe('public');
       expect(result?.version).toBe('1.0.0');
     });
 
-    it('should return null when not found in any registry', async () => {
+    it('should return null with errors when not found in any registry', async () => {
       mockClient.getDossier.mockRejectedValue(
         Object.assign(new Error('Not found'), { statusCode: 404 })
       );
 
-      const result = await multiRegistryGetDossier('missing');
+      const { result, errors } = await multiRegistryGetDossier('missing');
       expect(result).toBeNull();
+      expect(errors).toHaveLength(1);
+      expect(errors[0].registry).toBe('public');
+      expect(errors[0].error).toBe('Not found');
+    });
+
+    it('should return empty errors on success', async () => {
+      mockClient.getDossier.mockResolvedValue({ name: 'test', version: '1.0.0' });
+
+      const { errors } = await multiRegistryGetDossier('test');
+      expect(errors).toHaveLength(0);
     });
 
     it('should pass version to getDossier', async () => {
@@ -114,19 +124,21 @@ describe('multi-registry', () => {
         digest: 'sha256:abc',
       });
 
-      const result = await multiRegistryGetContent('test');
+      const { result } = await multiRegistryGetContent('test');
       expect(result).toBeDefined();
       expect(result?.content).toBe('# Test content');
       expect(result?._registry).toBe('public');
     });
 
-    it('should return null when not found', async () => {
+    it('should return null with errors when not found', async () => {
       mockClient.getDossierContent.mockRejectedValue(
         Object.assign(new Error('Not found'), { statusCode: 404 })
       );
 
-      const result = await multiRegistryGetContent('missing');
+      const { result, errors } = await multiRegistryGetContent('missing');
       expect(result).toBeNull();
+      expect(errors).toHaveLength(1);
+      expect(errors[0].registry).toBe('public');
     });
   });
 });

--- a/cli/src/commands/config-cmd.ts
+++ b/cli/src/commands/config-cmd.ts
@@ -172,10 +172,22 @@ export function registerConfigCommand(program: Command): void {
         }
 
         if (options.reset) {
-          if (config.saveConfig(config.DEFAULT_CONFIG)) {
-            console.log('✅ Configuration reset to defaults\n');
-            Object.entries(config.DEFAULT_CONFIG).forEach(([k, v]) => {
-              console.log(`   ${k}: ${v}`);
+          const currentConfig = config.loadConfig();
+          const resetConfig: config.DossierConfig = { ...config.DEFAULT_CONFIG };
+          if (currentConfig.registries) {
+            resetConfig.registries = currentConfig.registries;
+          }
+          if (currentConfig.defaultRegistry) {
+            resetConfig.defaultRegistry = currentConfig.defaultRegistry;
+          }
+          if (config.saveConfig(resetConfig)) {
+            console.log('✅ Configuration reset to defaults (registry settings preserved)\n');
+            Object.entries(resetConfig).forEach(([k, v]) => {
+              if (typeof v === 'object' && v !== null) {
+                console.log(`   ${k}: ${JSON.stringify(v)}`);
+              } else {
+                console.log(`   ${k}: ${v}`);
+              }
             });
           } else {
             console.log('❌ Failed to reset configuration');

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -80,15 +80,22 @@ export function registerCreateCommand(program: Command): void {
             try {
               let resolvedVersion = version;
               if (!resolvedVersion) {
-                const meta = await multiRegistryGetDossier(dossierName);
+                const { result: meta } = await multiRegistryGetDossier(dossierName);
                 resolvedVersion = meta?.version || 'latest';
               }
-              const result = await multiRegistryGetContent(dossierName, resolvedVersion);
+              const { result, errors: contentErrors } = await multiRegistryGetContent(
+                dossierName,
+                resolvedVersion
+              );
               if (!result) {
                 console.error(`❌ Template not found: ${options.template}`);
                 console.error(
-                  '   Check the template name or use --template to specify a different one\n'
+                  '   Check the template name or use --template to specify a different one'
                 );
+                for (const e of contentErrors) {
+                  console.error(`   ${e.registry}: ${e.error}`);
+                }
+                console.error('');
                 process.exit(2);
               }
               metaDossierContent = result.content;

--- a/cli/src/commands/export.ts
+++ b/cli/src/commands/export.ts
@@ -17,9 +17,13 @@ export function registerExportCommand(program: Command): void {
       let content: string;
       let digest: string | null;
       try {
-        const result = await multiRegistryGetContent(dossierName, version || null);
+        const { result, errors } = await multiRegistryGetContent(dossierName, version || null);
         if (!result) {
-          console.error(`\n❌ Not found: ${name}\n`);
+          console.error(`\n❌ Not found: ${name}`);
+          for (const e of errors) {
+            console.error(`   ${e.registry}: ${e.error}`);
+          }
+          console.error('');
           process.exit(1);
           return;
         }

--- a/cli/src/commands/get.ts
+++ b/cli/src/commands/get.ts
@@ -15,9 +15,13 @@ export function registerGetCommand(program: Command): void {
 
       let meta: DossierInfo & { _registry?: string };
       try {
-        const result = await multiRegistryGetDossier(dossierName, version || null);
+        const { result, errors } = await multiRegistryGetDossier(dossierName, version || null);
         if (!result) {
-          console.error(`\n❌ Not found in any registry: ${nameArg}\n`);
+          console.error(`\n❌ Not found in any registry: ${nameArg}`);
+          for (const e of errors) {
+            console.error(`   ${e.registry}: ${e.error}`);
+          }
+          console.error('');
           process.exit(1);
         }
         meta = result;

--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -37,10 +37,17 @@ export function registerInfoCommand(program: Command): void {
       } else {
         try {
           const [dossierName, version] = parseNameVersion(fileOrName);
-          const meta = await multiRegistryGetDossier(dossierName, version || null);
+          const { result: meta, errors: metaErrors } = await multiRegistryGetDossier(
+            dossierName,
+            version || null
+          );
           if (!meta) {
             console.error(`\n❌ Not found: ${fileOrName}`);
-            console.error('   Not a local file and not found in any registry\n');
+            console.error('   Not a local file and not found in any registry');
+            for (const e of metaErrors) {
+              console.error(`   ${e.registry}: ${e.error}`);
+            }
+            console.error('');
             process.exit(1);
           }
           frontmatter = meta;

--- a/cli/src/commands/install-skill.ts
+++ b/cli/src/commands/install-skill.ts
@@ -149,17 +149,20 @@ export function registerInstallSkillCommand(program: Command): void {
 
           if (!content) {
             if (!resolvedVersion) {
-              const meta = await multiRegistryGetDossier(dossierName);
+              const { result: meta } = await multiRegistryGetDossier(dossierName);
               if (!meta) {
                 throw { statusCode: 404, message: `Not found: ${dossierName}` };
               }
               resolvedVersion = meta.version || 'latest';
             }
-            const result = await multiRegistryGetContent(dossierName, resolvedVersion);
-            if (!result) {
+            const { result: fetchedContent } = await multiRegistryGetContent(
+              dossierName,
+              resolvedVersion
+            );
+            if (!fetchedContent) {
               throw { statusCode: 404, message: `Not found: ${dossierName}` };
             }
-            content = result.content;
+            content = fetchedContent.content;
           }
 
           fs.mkdirSync(skillDir, { recursive: true });

--- a/cli/src/commands/pull.ts
+++ b/cli/src/commands/pull.ts
@@ -21,9 +21,12 @@ export function registerPullCommand(program: Command): void {
 
         try {
           if (!version) {
-            const meta = await multiRegistryGetDossier(dossierName);
+            const { result: meta, errors: metaErrors } = await multiRegistryGetDossier(dossierName);
             if (!meta) {
               console.error(`❌ ${nameArg}: not found in any registry`);
+              for (const e of metaErrors) {
+                console.error(`   ${e.registry}: ${e.error}`);
+              }
               continue;
             }
             version = meta.version || 'latest';
@@ -39,9 +42,15 @@ export function registerPullCommand(program: Command): void {
             continue;
           }
 
-          const result = await multiRegistryGetContent(dossierName, version);
+          const { result, errors: contentErrors } = await multiRegistryGetContent(
+            dossierName,
+            version
+          );
           if (!result) {
             console.error(`❌ ${nameArg}: not found in any registry`);
+            for (const e of contentErrors) {
+              console.error(`   ${e.registry}: ${e.error}`);
+            }
             continue;
           }
           const content = result.content;

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -85,18 +85,30 @@ export function registerRunCommand(program: Command): void {
             try {
               let resolvedVersion = version;
               if (!resolvedVersion) {
-                const meta = await multiRegistryGetDossier(dossierName);
+                const { result: meta, errors: metaErrors } =
+                  await multiRegistryGetDossier(dossierName);
                 if (!meta) {
                   console.error(`\n❌ Not found: ${file}`);
-                  console.error('   Not a local file and not found in any registry\n');
+                  console.error('   Not a local file and not found in any registry');
+                  for (const e of metaErrors) {
+                    console.error(`   ${e.registry}: ${e.error}`);
+                  }
+                  console.error('');
                   process.exit(1);
                 }
                 resolvedVersion = meta.version || 'latest';
               }
-              const result = await multiRegistryGetContent(dossierName, resolvedVersion);
+              const { result, errors: contentErrors } = await multiRegistryGetContent(
+                dossierName,
+                resolvedVersion
+              );
               if (!result) {
                 console.error(`\n❌ Not found: ${file}`);
-                console.error('   Not a local file and not found in any registry\n');
+                console.error('   Not a local file and not found in any registry');
+                for (const e of contentErrors) {
+                  console.error(`   ${e.registry}: ${e.error}`);
+                }
+                console.error('');
                 process.exit(1);
               }
 

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -218,7 +218,7 @@ function resolveWriteRegistry(registryFlag?: string): ResolvedRegistry {
   const writable = registries.find((r) => !r.readonly);
   if (writable) return writable;
 
-  return registries[0];
+  throw new Error('No writable registry configured. All registries are read-only.');
 }
 
 /**

--- a/cli/src/multi-registry.ts
+++ b/cli/src/multi-registry.ts
@@ -35,6 +35,16 @@ export interface MultiRegistrySearchResult {
   errors: Array<{ registry: string; error: string }>;
 }
 
+export interface MultiRegistryGetDossierResult {
+  result: LabeledDossierInfo | null;
+  errors: Array<{ registry: string; error: string }>;
+}
+
+export interface MultiRegistryGetContentResult {
+  result: (DossierContentResult & { _registry: string }) | null;
+  errors: Array<{ registry: string; error: string }>;
+}
+
 function getTokenForRegistry(registryName: string): string | null {
   const creds = loadCredentials(registryName);
   return creds?.token || null;
@@ -127,11 +137,12 @@ async function multiRegistrySearch(
 /**
  * Get dossier info from the first registry that has it.
  * Tries all registries in parallel, returns the first success.
+ * Returns error details when all registries fail.
  */
 async function multiRegistryGetDossier(
   name: string,
   version: string | null = null
-): Promise<LabeledDossierInfo | null> {
+): Promise<MultiRegistryGetDossierResult> {
   const registries = resolveRegistries();
 
   const results = await Promise.allSettled(
@@ -143,22 +154,29 @@ async function multiRegistryGetDossier(
     })
   );
 
-  for (const result of results) {
-    if (result.status === 'fulfilled') {
-      return result.value;
+  const errors: Array<{ registry: string; error: string }> = [];
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    if (r.status === 'fulfilled') {
+      return { result: r.value, errors: [] };
     }
+    errors.push({
+      registry: registries[i].name,
+      error: r.reason?.message || String(r.reason),
+    });
   }
 
-  return null;
+  return { result: null, errors };
 }
 
 /**
  * Get dossier content from the first registry that has it.
+ * Returns error details when all registries fail.
  */
 async function multiRegistryGetContent(
   name: string,
   version: string | null = null
-): Promise<(DossierContentResult & { _registry: string }) | null> {
+): Promise<MultiRegistryGetContentResult> {
   const registries = resolveRegistries();
 
   const results = await Promise.allSettled(
@@ -170,13 +188,19 @@ async function multiRegistryGetContent(
     })
   );
 
-  for (const result of results) {
-    if (result.status === 'fulfilled') {
-      return result.value;
+  const errors: Array<{ registry: string; error: string }> = [];
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    if (r.status === 'fulfilled') {
+      return { result: r.value, errors: [] };
     }
+    errors.push({
+      registry: registries[i].name,
+      error: r.reason?.message || String(r.reason),
+    });
   }
 
-  return null;
+  return { result: null, errors };
 }
 
 export {


### PR DESCRIPTION
## Summary
- **resolveWriteRegistry** now throws an explicit error when all configured registries are read-only, instead of silently returning a read-only registry that would fail confusingly at the server level
- **config --reset** preserves `registries` and `defaultRegistry` settings, preventing users from accidentally losing their multi-registry setup
- **multiRegistryGetDossier/multiRegistryGetContent** now return error details (registry name + error message) alongside null results, so callers can report which registries failed and why instead of just "not found in any registry"

Closes #196

## Test plan
- [x] Added test: `resolveWriteRegistry` throws when all registries are read-only
- [x] Updated `multiRegistryGetDossier` tests to verify error details are returned
- [x] Updated `multiRegistryGetContent` tests to verify error details are returned
- [x] Updated all 7 command test files + integration test to use new return types
- [x] All multi-registry tests pass; pre-existing failures on main are unchanged

Co-Authored-By: Claude <noreply@anthropic.com>