### PR TITLE
docs(registry): fix documentation mismatches with code

### DIFF
--- a/registry/docs/planning/auth-and-publish.md
+++ b/registry/docs/planning/auth-and-publish.md
@@ -238,11 +238,20 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
 ```
 
 **Response (401 Unauthorized):**
+
+Three distinct error codes are returned depending on the failure:
+
+| Code | Message | When |
+|------|---------|------|
+| `MISSING_TOKEN` | `Authorization header required. Use: Bearer <token>` | No Authorization header |
+| `TOKEN_EXPIRED` | `Token has expired. Please login again.` | JWT has expired |
+| `INVALID_TOKEN` | `Invalid token. Please login again.` | JWT signature invalid |
+
 ```json
 {
   "error": {
-    "code": "INVALID_TOKEN",
-    "message": "Invalid or expired token"
+    "code": "MISSING_TOKEN",
+    "message": "Authorization header required. Use: Bearer <token>"
   }
 }
 ```
@@ -280,14 +289,8 @@ Dossier content here...
 ```
 
 **Response (401 Unauthorized):**
-```json
-{
-  "error": {
-    "code": "INVALID_TOKEN",
-    "message": "Invalid or expired token"
-  }
-}
-```
+
+Same three distinct error codes as `GET /api/v1/me` above (`MISSING_TOKEN`, `TOKEN_EXPIRED`, `INVALID_TOKEN`).
 
 **Response (403 Forbidden):**
 ```json

--- a/registry/docs/planning/mvp1-phase1-implementation.md
+++ b/registry/docs/planning/mvp1-phase1-implementation.md
@@ -64,6 +64,8 @@ Functions implemented:
 - `signJwt(payload)` - Create signed JWT with claims
 - `verifyJwt(token)` - Verify and decode JWT
 - `extractBearerToken(req)` - Extract token from Authorization header
+- `authenticateRequest(req, res)` - Verify JWT from request, send 401 with specific error codes (MISSING_TOKEN, TOKEN_EXPIRED, INVALID_TOKEN)
+- `authorizePublish(req, res, namespace)` - Authenticate and check namespace publish permission
 - `encodeAsDisplayCode(token)` - Base64url encode JWT for display
 - `decodeDisplayCode(code)` - Decode display code back to JWT
 - `exchangeGitHubCode(code)` - Exchange OAuth code for access token

--- a/registry/docs/planning/mvp1-phase2-implementation.md
+++ b/registry/docs/planning/mvp1-phase2-implementation.md
@@ -134,14 +134,19 @@ Add publish tests.
 
 ```
 lib/
-  config.js      # Add github.botToken config
-  auth.js        # Existing JWT utilities
-  dossier.js     # NEW - Dossier parsing/validation
-  github.js      # NEW - GitHub API for commits
-  permissions.js # NEW - Namespace permission checking
+  auth.ts         # JWT utilities and request authentication
+  config.ts       # Add github.botToken config
+  constants.ts    # Shared constants (user agent, CDN URLs)
+  cors.ts         # CORS handling utilities
+  dossier.ts      # Dossier parsing/validation
+  github.ts       # GitHub API for commits
+  manifest.ts     # Manifest fetching and normalization
+  permissions.ts  # Namespace permission checking
+  responses.ts    # Shared HTTP response helpers
+  types.ts        # TypeScript type definitions
 api/v1/
   dossiers/
-    index.js     # UPDATE - Add POST handler
+    index.ts      # UPDATE - Add POST handler
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Add `authenticateRequest` and `authorizePublish` to Phase 1 `lib/auth.js` function list
- Update Phase 2 file structure to reflect actual TypeScript modules (`constants.ts`, `cors.ts`, `manifest.ts`, `responses.ts`, `types.ts`)
- Replace generic 401 response example with three distinct error codes (`MISSING_TOKEN`, `TOKEN_EXPIRED`, `INVALID_TOKEN`) in auth-and-publish.md

Closes #180

## Test plan
- Verified all changes are documentation-only (markdown files)
- Confirmed documentation now matches actual code in `registry/lib/auth.ts`
- Confirmed file structure diagram matches actual `registry/lib/` directory listing

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>