### PR TITLE
fix: address maintainability findings (#189)

### DIFF
--- a/registry/api/auth/callback.ts
+++ b/registry/api/auth/callback.ts
@@ -1,9 +1,12 @@
 import crypto from 'node:crypto';
 import * as auth from '../../lib/auth';
 import config from '../../lib/config';
-import { OAUTH_STATE_COOKIE } from '../../lib/constants';
+import { HTTP_STATUS, OAUTH_STATE_COOKIE } from '../../lib/constants';
+import createLogger from '../../lib/logger';
 import { methodNotAllowed } from '../../lib/responses';
 import type { VercelRequest, VercelResponse } from '../../lib/types';
+
+const log = createLogger('auth/callback');
 
 function parseCookie(req: VercelRequest, name: string): string | undefined {
   const header = req.headers.cookie;
@@ -32,12 +35,15 @@ function validateOAuthState(
     crypto.timingSafeEqual(Buffer.from(state), Buffer.from(expectedState));
 
   if (!valid) {
-    console.warn(
-      '[auth/callback] State validation failed:',
-      !state ? 'missing query state' : !expectedState ? 'missing cookie state' : 'state mismatch'
-    );
+    log.warn('State validation failed', {
+      reason: !state
+        ? 'missing query state'
+        : !expectedState
+          ? 'missing cookie state'
+          : 'state mismatch',
+    });
     res
-      .status(403)
+      .status(HTTP_STATUS.FORBIDDEN)
       .send(
         renderErrorPage(
           'Invalid State',
@@ -54,22 +60,22 @@ function queryString(value: string | string[] | undefined): string | undefined {
 }
 
 async function exchangeCodeAndRenderSuccess(res: VercelResponse, code: string): Promise<void> {
-  console.log('[auth/callback] Exchanging OAuth code for access token');
+  log.info('Exchanging OAuth code for access token');
   const accessToken = await auth.exchangeGitHubCode(code);
 
-  console.log('[auth/callback] Fetching user info and orgs');
+  log.info('Fetching user info and orgs');
   const [user, orgs] = await Promise.all([
     auth.fetchGitHubUser(accessToken),
     auth.fetchGitHubOrgs(accessToken),
   ]);
-  console.log(`[auth/callback] User: ${user.login}, orgs: [${orgs.join(', ')}]`);
+  log.info('User authenticated', { user: user.login, orgs });
 
   const token = auth.signJwt({ sub: user.login, email: user.email || null, orgs });
   const displayCode = auth.encodeAsDisplayCode(token);
   const clientId = config.auth.github.clientId;
 
-  console.log(`[auth/callback] Login complete for ${user.login}`);
-  res.status(200).send(renderSuccessPage(user.login, orgs, displayCode, clientId));
+  log.info('Login complete', { user: user.login });
+  res.status(HTTP_STATUS.OK).send(renderSuccessPage(user.login, orgs, displayCode, clientId));
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -83,9 +89,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const state = queryString(req.query.state);
 
   if (error) {
-    console.warn('[auth/callback] OAuth provider error:', error, errorDescription);
+    log.warn('OAuth provider error', { error, errorDescription });
     return res
-      .status(400)
+      .status(HTTP_STATUS.BAD_REQUEST)
       .send(renderErrorPage('Authentication Failed', errorDescription || error));
   }
 
@@ -94,9 +100,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   if (!code) {
-    console.warn('[auth/callback] Missing authorization code in callback');
+    log.warn('Missing authorization code in callback');
     return res
-      .status(400)
+      .status(HTTP_STATUS.BAD_REQUEST)
       .send(
         renderErrorPage(
           'Missing Code',
@@ -110,13 +116,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   } catch (err) {
     const caughtError = err instanceof Error ? err : new Error(String(err));
     const errorRef = crypto.randomBytes(4).toString('hex');
-    console.error(
-      `[auth/callback] OAuth callback failed (ref=${errorRef}):`,
-      caughtError.message,
-      caughtError.stack
-    );
+    log.error(`OAuth callback failed (ref=${errorRef})`, {
+      error: caughtError.message,
+      stack: caughtError.stack,
+    });
     return res
-      .status(500)
+      .status(HTTP_STATUS.INTERNAL_SERVER_ERROR)
       .send(
         renderErrorPage(
           'Authentication Error',

--- a/registry/api/auth/login.ts
+++ b/registry/api/auth/login.ts
@@ -1,8 +1,11 @@
 import crypto from 'node:crypto';
 import config from '../../lib/config';
-import { OAUTH_STATE_COOKIE, OAUTH_STATE_MAX_AGE } from '../../lib/constants';
+import { HTTP_STATUS, OAUTH_STATE_COOKIE, OAUTH_STATE_MAX_AGE } from '../../lib/constants';
+import createLogger from '../../lib/logger';
 import { methodNotAllowed } from '../../lib/responses';
 import type { VercelRequest, VercelResponse } from '../../lib/types';
+
+const log = createLogger('auth/login');
 
 export default function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET') {
@@ -24,17 +27,16 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
       `${OAUTH_STATE_COOKIE}=${state}; HttpOnly; Secure; SameSite=Lax; Path=/auth; Max-Age=${OAUTH_STATE_MAX_AGE}`
     );
 
-    console.log(`[auth/login] Redirecting to GitHub OAuth`);
+    log.info('Redirecting to GitHub OAuth');
     res.redirect(`https://github.com/login/oauth/authorize?${params}`);
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
     const errorRef = crypto.randomBytes(4).toString('hex');
-    console.error(
-      `[auth/login] Failed to initiate login redirect (ref=${errorRef}):`,
-      error.message,
-      error.stack
-    );
-    return res.status(500).json({
+    log.error(`Failed to initiate login redirect (ref=${errorRef})`, {
+      error: error.message,
+      stack: error.stack,
+    });
+    return res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({
       error: {
         code: 'LOGIN_ERROR',
         message: 'Failed to initiate login. Please try again.',

--- a/registry/api/v1/docs.ts
+++ b/registry/api/v1/docs.ts
@@ -1,4 +1,5 @@
 import config from '../../lib/config';
+import { HTTP_STATUS } from '../../lib/constants';
 import { handleCors } from '../../lib/cors';
 import { methodNotAllowed } from '../../lib/responses';
 import type { VercelRequest, VercelResponse } from '../../lib/types';
@@ -210,7 +211,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const baseUrl = `https://${req.headers.host}`;
 
-  return res.status(200).json({
+  return res.status(HTTP_STATUS.OK).json({
     name: 'Dossier Registry API',
     version: config.apiVersion,
     baseUrl,

--- a/registry/api/v1/dossiers/[...name].ts
+++ b/registry/api/v1/dossiers/[...name].ts
@@ -1,11 +1,15 @@
 import { sha256Hex } from '@ai-dossier/core';
 import { authorizePublish } from '../../../lib/auth';
 import config from '../../../lib/config';
+import { HTTP_STATUS } from '../../../lib/constants';
 import { handleCors } from '../../../lib/cors';
 import { validateNamespace } from '../../../lib/dossier';
 import * as github from '../../../lib/github';
+import createLogger from '../../../lib/logger';
 import { getRequestId, methodNotAllowed, serverError } from '../../../lib/responses';
 import type { VercelRequest, VercelResponse } from '../../../lib/types';
+
+const log = createLogger('dossiers/[name]');
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleCors(req, res)) return;
@@ -26,7 +30,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const namespaceCheck = validateNamespace(dossierName);
   if (!namespaceCheck.valid) {
-    return res.status(400).json({
+    return res.status(HTTP_STATUS.BAD_REQUEST).json({
       error: { code: 'INVALID_NAMESPACE', message: namespaceCheck.error },
     });
   }
@@ -46,14 +50,12 @@ async function handleGet(
   requestId: string
 ) {
   try {
-    console.log(
-      JSON.stringify({ level: 'info', requestId, op: 'getManifest', dossier: dossierName })
-    );
+    log.info('Getting manifest', { requestId, dossier: dossierName });
     const manifest = await github.getManifest();
     const dossierEntry = manifest.dossiers.find((d) => d.name === dossierName);
 
     if (!dossierEntry) {
-      return res.status(404).json({
+      return res.status(HTTP_STATUS.NOT_FOUND).json({
         error: {
           code: 'DOSSIER_NOT_FOUND',
           message: `Dossier '${dossierName}' not found`,
@@ -62,7 +64,7 @@ async function handleGet(
     }
 
     if (version && dossierEntry.version !== version) {
-      return res.status(404).json({
+      return res.status(HTTP_STATUS.NOT_FOUND).json({
         error: {
           code: 'VERSION_NOT_FOUND',
           message: `Dossier '${dossierName}' version '${version}' not found (latest: ${dossierEntry.version})`,
@@ -71,13 +73,11 @@ async function handleGet(
     }
 
     if (isContentRequest) {
-      console.log(
-        JSON.stringify({ level: 'info', requestId, op: 'getFileContent', path: dossierEntry.path })
-      );
+      log.info('Getting file content', { requestId, path: dossierEntry.path });
       const fileContent = await github.getFileContent(dossierEntry.path);
 
       if (!fileContent) {
-        return res.status(404).json({
+        return res.status(HTTP_STATUS.NOT_FOUND).json({
           error: {
             code: 'CONTENT_NOT_FOUND',
             message: `Content for dossier '${dossierName}' not found`,
@@ -89,10 +89,10 @@ async function handleGet(
 
       res.setHeader('Content-Type', 'text/markdown');
       res.setHeader('X-Dossier-Digest', `sha256:${digest}`);
-      return res.status(200).send(fileContent.content);
+      return res.status(HTTP_STATUS.OK).send(fileContent.content);
     }
 
-    return res.status(200).json({
+    return res.status(HTTP_STATUS.OK).json({
       name: dossierEntry.name,
       title: dossierEntry.title,
       version: dossierEntry.version,
@@ -101,10 +101,8 @@ async function handleGet(
     });
   } catch (error) {
     if (error instanceof github.PathTraversalError) {
-      console.warn(
-        JSON.stringify({ level: 'warn', event: 'path_traversal', requestId, dossier: dossierName })
-      );
-      return res.status(400).json({
+      log.warn('Path traversal detected', { requestId, dossier: dossierName });
+      return res.status(HTTP_STATUS.BAD_REQUEST).json({
         error: { code: 'INVALID_PATH', message: 'Path traversal is not allowed' },
       });
     }
@@ -129,19 +127,11 @@ async function handleDelete(
   if (!authorized) return;
 
   try {
-    console.log(
-      JSON.stringify({
-        level: 'info',
-        requestId,
-        op: 'deleteDossier',
-        dossier: dossierName,
-        version,
-      })
-    );
+    log.info('Deleting dossier', { requestId, dossier: dossierName, version });
     const result = await github.deleteDossier(dossierName, version || null);
 
     if (!result.found) {
-      return res.status(404).json({
+      return res.status(HTTP_STATUS.NOT_FOUND).json({
         error: {
           code: 'DOSSIER_NOT_FOUND',
           message: `Dossier '${dossierName}' not found`,
@@ -150,7 +140,7 @@ async function handleDelete(
     }
 
     if (result.versionMismatch) {
-      return res.status(404).json({
+      return res.status(HTTP_STATUS.NOT_FOUND).json({
         error: {
           code: 'VERSION_NOT_FOUND',
           message: `Version '${result.requestedVersion}' not found. Current version is '${result.currentVersion}'`,
@@ -167,13 +157,11 @@ async function handleDelete(
       response.version = version;
     }
 
-    return res.status(200).json(response);
+    return res.status(HTTP_STATUS.OK).json(response);
   } catch (err) {
     if (err instanceof github.PathTraversalError) {
-      console.warn(
-        JSON.stringify({ level: 'warn', event: 'path_traversal', requestId, dossier: dossierName })
-      );
-      return res.status(400).json({
+      log.warn('Path traversal detected', { requestId, dossier: dossierName });
+      return res.status(HTTP_STATUS.BAD_REQUEST).json({
         error: { code: 'INVALID_PATH', message: 'Path traversal is not allowed' },
       });
     }

--- a/registry/api/v1/dossiers/index.ts
+++ b/registry/api/v1/dossiers/index.ts
@@ -1,12 +1,15 @@
 import { authorizePublish } from '../../../lib/auth';
 import config from '../../../lib/config';
-import { MAX_CONTENT_SIZE } from '../../../lib/constants';
+import { HTTP_STATUS, MAX_CONTENT_SIZE } from '../../../lib/constants';
 import { handleCors } from '../../../lib/cors';
 import * as dossier from '../../../lib/dossier';
 import * as github from '../../../lib/github';
+import createLogger from '../../../lib/logger';
 import { fetchManifestDossiers, normalizeDossier } from '../../../lib/manifest';
 import { getRequestId, methodNotAllowed, serverError } from '../../../lib/responses';
 import type { ManifestDossier, VercelRequest, VercelResponse } from '../../../lib/types';
+
+const log = createLogger('dossiers/index');
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleCors(req, res)) return;
@@ -30,7 +33,7 @@ async function handleList(_req: VercelRequest, res: VercelResponse, requestId: s
     const raw = await fetchManifestDossiers();
     const dossiers = raw.map(normalizeDossier);
 
-    return res.status(200).json({
+    return res.status(HTTP_STATUS.OK).json({
       dossiers,
       pagination: {
         page: 1,
@@ -52,7 +55,7 @@ async function handleList(_req: VercelRequest, res: VercelResponse, requestId: s
 async function handlePublish(req: VercelRequest, res: VercelResponse, requestId: string) {
   const contentType = req.headers['content-type'];
   if (!contentType || !contentType.includes('application/json')) {
-    return res.status(415).json({
+    return res.status(HTTP_STATUS.UNSUPPORTED_MEDIA_TYPE).json({
       error: { code: 'UNSUPPORTED_MEDIA_TYPE', message: 'Content-Type must be application/json' },
     });
   }
@@ -60,7 +63,7 @@ async function handlePublish(req: VercelRequest, res: VercelResponse, requestId:
   const { namespace, content, changelog } = req.body || {};
 
   if (!namespace || typeof namespace !== 'string') {
-    return res.status(400).json({
+    return res.status(HTTP_STATUS.BAD_REQUEST).json({
       error: {
         code: 'MISSING_FIELD',
         message: 'Missing required field: namespace (must be a string)',
@@ -69,7 +72,7 @@ async function handlePublish(req: VercelRequest, res: VercelResponse, requestId:
   }
 
   if (!content || typeof content !== 'string') {
-    return res.status(400).json({
+    return res.status(HTTP_STATUS.BAD_REQUEST).json({
       error: {
         code: 'MISSING_FIELD',
         message: 'Missing required field: content (must be a string)',
@@ -78,13 +81,13 @@ async function handlePublish(req: VercelRequest, res: VercelResponse, requestId:
   }
 
   if (changelog !== undefined && typeof changelog !== 'string') {
-    return res.status(400).json({
+    return res.status(HTTP_STATUS.BAD_REQUEST).json({
       error: { code: 'INVALID_FIELD', message: 'Field changelog must be a string' },
     });
   }
 
   if (content.length > MAX_CONTENT_SIZE) {
-    return res.status(413).json({
+    return res.status(HTTP_STATUS.CONTENT_TOO_LARGE).json({
       error: {
         code: 'CONTENT_TOO_LARGE',
         message: `Content exceeds maximum size of ${MAX_CONTENT_SIZE / 1024}KB`,
@@ -94,7 +97,7 @@ async function handlePublish(req: VercelRequest, res: VercelResponse, requestId:
 
   const namespaceValidation = dossier.validateNamespace(namespace);
   if (!namespaceValidation.valid) {
-    return res.status(400).json({
+    return res.status(HTTP_STATUS.BAD_REQUEST).json({
       error: { code: 'INVALID_NAMESPACE', message: namespaceValidation.error },
     });
   }
@@ -106,14 +109,14 @@ async function handlePublish(req: VercelRequest, res: VercelResponse, requestId:
   try {
     parsed = dossier.parseFrontmatter(content);
   } catch (err) {
-    return res.status(400).json({
+    return res.status(HTTP_STATUS.BAD_REQUEST).json({
       error: { code: 'INVALID_CONTENT', message: err instanceof Error ? err.message : String(err) },
     });
   }
 
   const validation = dossier.validateDossier(parsed.frontmatter);
   if (!validation.valid) {
-    return res.status(400).json({
+    return res.status(HTTP_STATUS.BAD_REQUEST).json({
       error: { code: 'INVALID_CONTENT', message: validation.errors.join('; ') },
     });
   }
@@ -129,7 +132,7 @@ async function handlePublish(req: VercelRequest, res: VercelResponse, requestId:
       changelogMessage
     );
 
-    return res.status(201).json({
+    return res.status(HTTP_STATUS.CREATED).json({
       name: fullPath,
       version: parsed.frontmatter.version,
       title: parsed.frontmatter.title,
@@ -138,10 +141,8 @@ async function handlePublish(req: VercelRequest, res: VercelResponse, requestId:
     });
   } catch (err) {
     if (err instanceof github.PathTraversalError) {
-      console.warn(
-        JSON.stringify({ level: 'warn', event: 'path_traversal', requestId, namespace })
-      );
-      return res.status(400).json({
+      log.warn('Path traversal detected', { requestId, namespace });
+      return res.status(HTTP_STATUS.BAD_REQUEST).json({
         error: { code: 'INVALID_PATH', message: 'Path traversal is not allowed' },
       });
     }

--- a/registry/api/v1/health.ts
+++ b/registry/api/v1/health.ts
@@ -1,11 +1,12 @@
 import config from '../../lib/config';
+import { HTTP_STATUS } from '../../lib/constants';
 import { handleCors } from '../../lib/cors';
 import type { VercelRequest, VercelResponse } from '../../lib/types';
 
 export default function handler(req: VercelRequest, res: VercelResponse) {
   if (handleCors(req, res)) return;
 
-  res.status(200).json({
+  res.status(HTTP_STATUS.OK).json({
     status: 'OK',
     service: 'Dossier Registry API',
     version: config.apiVersion,

--- a/registry/api/v1/me.ts
+++ b/registry/api/v1/me.ts
@@ -1,4 +1,5 @@
 import { authenticateRequest } from '../../lib/auth';
+import { HTTP_STATUS } from '../../lib/constants';
 import { handleCors } from '../../lib/cors';
 import { methodNotAllowed } from '../../lib/responses';
 import type { VercelRequest, VercelResponse } from '../../lib/types';
@@ -17,7 +18,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const orgs = payload.orgs || [];
   const canPublishTo = [`${username}/*`, ...orgs.map((org) => `${org}/*`)];
 
-  return res.status(200).json({
+  return res.status(HTTP_STATUS.OK).json({
     username,
     email: payload.email || null,
     orgs,

--- a/registry/api/v1/search.ts
+++ b/registry/api/v1/search.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_PER_PAGE, MAX_PER_PAGE } from '../../lib/constants';
+import { DEFAULT_PER_PAGE, HTTP_STATUS, MAX_PER_PAGE } from '../../lib/constants';
 import { handleCors } from '../../lib/cors';
 import { fetchManifestDossiers, normalizeDossier } from '../../lib/manifest';
 import { methodNotAllowed, serverError } from '../../lib/responses';
@@ -16,7 +16,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const perPageStr = Array.isArray(req.query.per_page) ? req.query.per_page[0] : req.query.per_page;
 
   if (!q || !q.trim()) {
-    return res.status(400).json({
+    return res.status(HTTP_STATUS.BAD_REQUEST).json({
       error: { code: 'MISSING_QUERY', message: 'Query parameter "q" is required' },
     });
   }
@@ -48,7 +48,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const dossiers = paged.map(normalizeDossier);
 
-    return res.status(200).json({
+    return res.status(HTTP_STATUS.OK).json({
       dossiers,
       pagination: { page, per_page: perPage, total },
     });

--- a/registry/lib/auth.ts
+++ b/registry/lib/auth.ts
@@ -1,8 +1,11 @@
 import jwt from 'jsonwebtoken';
 import config from './config';
-import { JWT_EXPIRY_SECONDS, USER_AGENT } from './constants';
+import { HTTP_STATUS, JWT_EXPIRY_SECONDS, USER_AGENT } from './constants';
+import createLogger from './logger';
 import { canPublishTo } from './permissions';
 import type { JwtPayload, VercelRequest, VercelResponse } from './types';
+
+const log = createLogger('auth');
 
 export function signJwt(payload: Omit<JwtPayload, 'iat' | 'exp'>): string {
   return jwt.sign(payload, config.auth.jwt.secret, {
@@ -20,15 +23,8 @@ export async function authenticateRequest(
 ): Promise<JwtPayload | null> {
   const token = extractBearerToken(req);
   if (!token) {
-    console.warn(
-      JSON.stringify({
-        level: 'warn',
-        event: 'auth.missing_token',
-        method: req.method,
-        url: req.url,
-      })
-    );
-    res.status(401).json({
+    log.warn('Missing token', { event: 'auth.missing_token', method: req.method, url: req.url });
+    res.status(HTTP_STATUS.UNAUTHORIZED).json({
       error: {
         code: 'MISSING_TOKEN',
         message: 'Authorization header required. Use: Bearer <token>',
@@ -42,20 +38,17 @@ export async function authenticateRequest(
   } catch (err) {
     const code =
       err instanceof Error && err.name === 'TokenExpiredError' ? 'TOKEN_EXPIRED' : 'INVALID_TOKEN';
-    console.warn(
-      JSON.stringify({
-        level: 'warn',
-        event: `auth.${code.toLowerCase()}`,
-        method: req.method,
-        url: req.url,
-      })
-    );
+    log.warn(code === 'TOKEN_EXPIRED' ? 'Token expired' : 'Invalid token', {
+      event: `auth.${code.toLowerCase()}`,
+      method: req.method,
+      url: req.url,
+    });
     if (code === 'TOKEN_EXPIRED') {
-      res.status(401).json({
+      res.status(HTTP_STATUS.UNAUTHORIZED).json({
         error: { code, message: 'Token has expired. Please login again.' },
       });
     } else {
-      res.status(401).json({
+      res.status(HTTP_STATUS.UNAUTHORIZED).json({
         error: { code, message: 'Invalid token. Please login again.' },
       });
     }
@@ -154,16 +147,13 @@ export async function authorizePublish(
 
   const permission = canPublishTo(jwtPayload, namespace);
   if (!permission.allowed) {
-    console.warn(
-      JSON.stringify({
-        level: 'warn',
-        event: 'auth.forbidden',
-        user: jwtPayload.sub,
-        namespace,
-        reason: permission.reason,
-      })
-    );
-    res.status(403).json({
+    log.warn('Forbidden', {
+      event: 'auth.forbidden',
+      user: jwtPayload.sub,
+      namespace,
+      reason: permission.reason,
+    });
+    res.status(HTTP_STATUS.FORBIDDEN).json({
       error: { code: 'FORBIDDEN', message: permission.reason },
     });
     return false;

--- a/registry/lib/constants.ts
+++ b/registry/lib/constants.ts
@@ -1,3 +1,19 @@
+/** HTTP status codes used across API handlers. */
+export const HTTP_STATUS = {
+  OK: 200,
+  CREATED: 201,
+  NO_CONTENT: 204,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  METHOD_NOT_ALLOWED: 405,
+  CONTENT_TOO_LARGE: 413,
+  UNSUPPORTED_MEDIA_TYPE: 415,
+  INTERNAL_SERVER_ERROR: 500,
+  BAD_GATEWAY: 502,
+} as const;
+
 /** Default fields for dossier list/search responses. */
 export const DOSSIER_DEFAULTS = {
   description: null,

--- a/registry/lib/cors.ts
+++ b/registry/lib/cors.ts
@@ -1,4 +1,8 @@
+import { HTTP_STATUS } from './constants';
+import createLogger from './logger';
 import type { VercelRequest, VercelResponse } from './types';
+
+const log = createLogger('cors');
 
 const DEFAULT_ALLOWED_ORIGINS = ['https://dossier.imboard.ai', 'https://registry.dossier.dev'];
 
@@ -18,7 +22,7 @@ export function setCorsHeaders(req: VercelRequest, res: VercelResponse): void {
     res.setHeader('Access-Control-Allow-Origin', origin);
     res.setHeader('Vary', 'Origin');
   } else if (origin) {
-    console.warn(`[cors] Rejected origin: ${origin}`);
+    log.warn('Rejected origin', { origin });
   }
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS, HEAD');
   res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type, Accept');
@@ -30,7 +34,7 @@ export function handleCors(req: VercelRequest, res: VercelResponse): boolean {
   setCorsHeaders(req, res);
 
   if (req.method === 'OPTIONS') {
-    res.status(204).end();
+    res.status(HTTP_STATUS.NO_CONTENT).end();
     return true;
   }
 
@@ -38,8 +42,8 @@ export function handleCors(req: VercelRequest, res: VercelResponse): boolean {
   // GET/HEAD allowed from any origin (read-only). No Origin header allowed (non-browser clients).
   const origin = req.headers.origin;
   if (origin && MUTATING_METHODS.has(req.method ?? '') && !getAllowedOrigins().includes(origin)) {
-    console.warn(`[cors] Blocked mutating ${req.method} from origin: ${origin}`);
-    res.status(403).json({
+    log.warn('Blocked mutating request from disallowed origin', { method: req.method, origin });
+    res.status(HTTP_STATUS.FORBIDDEN).json({
       error: { code: 'ORIGIN_NOT_ALLOWED', message: 'Origin not allowed for mutating requests' },
     });
     return true;

--- a/registry/lib/github.ts
+++ b/registry/lib/github.ts
@@ -1,7 +1,10 @@
 import path from 'node:path';
 import config from './config';
 import { DOSSIER_DEFAULTS, GITHUB_API_VERSION, USER_AGENT } from './constants';
+import createLogger from './logger';
 import type { DeleteResult, FileContent, Manifest, ManifestDossier } from './types';
+
+const log = createLogger('github');
 
 export class PathTraversalError extends Error {
   constructor(filePath: string) {
@@ -39,9 +42,12 @@ async function githubRequest(endpoint: string, options: RequestInit = {}): Promi
   }
 
   if (!response.ok) {
-    console.error(
-      `GitHub API request failed: ${options.method || 'GET'} ${endpoint} → ${response.status} ${response.statusText}`
-    );
+    log.error('GitHub API request failed', {
+      method: options.method || 'GET',
+      endpoint,
+      status: response.status,
+      statusText: response.statusText,
+    });
   }
 
   return response;
@@ -203,16 +209,16 @@ export async function publishDossier(
     ? `Update ${metadata.name} to v${metadata.version}: ${changelog}`
     : `Publish ${metadata.name} v${metadata.version}: ${changelog}`;
 
-  console.log(`[publish] Step 1/2: Writing content file ${filePath}`);
+  log.info('Writing content file', { step: '1/2', filePath });
   const fileResult = await createOrUpdateFile(
     filePath,
     content,
     fileMessage,
     existing?.sha ?? null
   );
-  console.log(`[publish] Step 1/2 complete: content file written`);
+  log.info('Content file written', { step: '1/2' });
 
-  console.log(`[publish] Step 2/2: Updating manifest for ${metadata.name}`);
+  log.info('Updating manifest', { step: '2/2', dossier: metadata.name });
   const manifest = await getManifest();
 
   const OPTIONAL_MANIFEST_FIELDS = Object.keys(DOSSIER_DEFAULTS) as Array<
@@ -237,13 +243,13 @@ export async function publishDossier(
     manifestResult = await updateManifest(manifest, dossierEntry);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error(
-      `[publish] CRITICAL: File ${filePath} written but manifest update failed. Orphaned file needs cleanup.`,
-      message
-    );
+    log.error('File written but manifest update failed — orphaned file needs cleanup', {
+      filePath,
+      error: message,
+    });
     throw err;
   }
-  console.log(`[publish] Step 2/2 complete: manifest updated for ${metadata.name}`);
+  log.info('Manifest updated', { step: '2/2', dossier: metadata.name });
 
   return { file: fileResult, manifest: manifestResult };
 }
@@ -281,27 +287,27 @@ export async function deleteDossier(
     };
   }
 
-  console.log(`[delete] Step 1/2: Deleting content file ${filePath}`);
+  log.info('Deleting content file', { step: '1/2', filePath });
   const fileResult = await deleteFile(
     filePath,
     `Delete ${dossierName} v${dossierEntry.version}`,
     existing.sha
   );
-  console.log(`[delete] Step 1/2 complete: content file deleted`);
+  log.info('Content file deleted', { step: '1/2' });
 
-  console.log(`[delete] Step 2/2: Removing ${dossierName} from manifest`);
+  log.info('Removing from manifest', { step: '2/2', dossier: dossierName });
   let manifestResult: unknown;
   try {
     manifestResult = await removeFromManifest(manifest, dossierName);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error(
-      `[delete] CRITICAL: File ${filePath} deleted but manifest update failed. Manual cleanup required.`,
-      message
-    );
+    log.error('File deleted but manifest update failed — manual cleanup required', {
+      filePath,
+      error: message,
+    });
     throw err;
   }
-  console.log(`[delete] Step 2/2 complete: manifest updated`);
+  log.info('Manifest updated', { step: '2/2' });
 
   return {
     found: true,

--- a/registry/lib/logger.ts
+++ b/registry/lib/logger.ts
@@ -1,0 +1,41 @@
+type LogLevel = 'info' | 'warn' | 'error';
+
+interface LogEntry {
+  level: LogLevel;
+  context: string;
+  message: string;
+  [key: string]: unknown;
+}
+
+function emit(entry: LogEntry): void {
+  const output = JSON.stringify(entry);
+  if (entry.level === 'error') {
+    console.error(output);
+  } else if (entry.level === 'warn') {
+    console.warn(output);
+  } else {
+    console.log(output);
+  }
+}
+
+/**
+ * Create a structured JSON logger scoped to a module context.
+ *
+ * Each log entry is emitted as a single-line JSON string to stdout (info)
+ * or stderr (warn/error), compatible with Vercel's log ingestion.
+ */
+function createLogger(context: string) {
+  return {
+    info(message: string, extra?: Record<string, unknown>) {
+      emit({ level: 'info', context, message, ...extra });
+    },
+    warn(message: string, extra?: Record<string, unknown>) {
+      emit({ level: 'warn', context, message, ...extra });
+    },
+    error(message: string, extra?: Record<string, unknown>) {
+      emit({ level: 'error', context, message, ...extra });
+    },
+  };
+}
+
+export default createLogger;

--- a/registry/lib/responses.ts
+++ b/registry/lib/responses.ts
@@ -1,5 +1,9 @@
 import crypto from 'node:crypto';
+import { HTTP_STATUS } from './constants';
+import createLogger from './logger';
 import type { VercelRequest, VercelResponse } from './types';
+
+const log = createLogger('responses');
 
 function formatAllowed(methods: string[]): string {
   if (methods.length === 1) return methods[0];
@@ -14,7 +18,7 @@ export function getRequestId(req: VercelRequest): string {
 }
 
 export function methodNotAllowed(res: VercelResponse, ...allowed: string[]): VercelResponse {
-  return res.status(405).json({
+  return res.status(HTTP_STATUS.METHOD_NOT_ALLOWED).json({
     error: {
       code: 'METHOD_NOT_ALLOWED',
       message: `Only ${formatAllowed(allowed)} ${allowed.length === 1 ? 'is' : 'are'} allowed`,
@@ -36,17 +40,13 @@ export function serverError(
   const requestId = opts.requestId || crypto.randomUUID();
   const errorMessage = opts.error instanceof Error ? opts.error.message : String(opts.error);
   const errorType = opts.error instanceof Error ? opts.error.name : typeof opts.error;
-  console.error(
-    JSON.stringify({
-      level: 'error',
-      operation: opts.operation,
-      requestId,
-      errorType,
-      error: errorMessage,
-      stack: opts.error instanceof Error ? opts.error.stack : undefined,
-    })
-  );
-  return res.status(opts.status ?? 502).json({
+  log.error(opts.operation, {
+    requestId,
+    errorType,
+    error: errorMessage,
+    stack: opts.error instanceof Error ? opts.error.stack : undefined,
+  });
+  return res.status(opts.status ?? HTTP_STATUS.BAD_GATEWAY).json({
     error: {
       code: opts.code,
       message: opts.message,

--- a/registry/tests/responses.test.ts
+++ b/registry/tests/responses.test.ts
@@ -55,7 +55,8 @@ describe('serverError', () => {
 
     const loggedJson = JSON.parse(consoleSpy.mock.calls[0][0] as string);
     expect(loggedJson.level).toBe('error');
-    expect(loggedJson.operation).toBe('dossier.list');
+    expect(loggedJson.context).toBe('responses');
+    expect(loggedJson.message).toBe('dossier.list');
     expect(loggedJson.requestId).toBe(jsonArg.error.request_id);
     expect(loggedJson.errorType).toBe('Error');
     expect(loggedJson.error).toBe('upstream timeout');


### PR DESCRIPTION
## Summary
- Add `HTTP_STATUS` named constants to replace magic HTTP status codes across all registry API handlers
- Create `registry/lib/logger.ts` structured logging module, replacing scattered `console.*` calls with `createLogger(context)` factory that emits JSON
- Replace `as any` type assertions in test mocks with proper `Pick<VercelRequest/VercelResponse>` typed mocks

Closes #189

## Test plan
- [x] All 86 existing tests pass
- [x] Biome lint/format passes
- [x] Build passes
- [x] Updated test expectations in `supportability.test.ts` and `github.test.ts` to match structured logger output

Co-Authored-By: Claude <noreply@anthropic.com>