### PR TITLE
docs: add CONTENT_ORG/CONTENT_REPO env vars to documentation

### DIFF
--- a/registry/docs/planning/auth-and-publish.md
+++ b/registry/docs/planning/auth-and-publish.md
@@ -155,9 +155,11 @@ The Registry API is a server-side service hosted on Vercel.
 | `JWT_SECRET` | Secret key to sign/verify JWTs |
 | `GITHUB_BOT_TOKEN` | Token to write to content repo |
 | `REGISTRY_BASE_URL` | Base URL for OAuth redirect (e.g., `https://registry.dossier.dev`) |
+| `CONTENT_ORG` | GitHub org owning the content repo (optional, defaults to `imboard-ai`) |
+| `CONTENT_REPO` | GitHub repo name for dossier content (optional, defaults to `dossier-content`) |
 | `CORS_ALLOWED_ORIGINS` | Comma-separated allowed CORS origins (optional, has defaults) |
 
-> **Note:** All variables except `CORS_ALLOWED_ORIGINS` are required. The Registry uses lazy validation — a missing variable causes a clear error (`Missing required environment variable: <name>`) on the first request that needs it.
+> **Note:** All variables except `CONTENT_ORG`, `CONTENT_REPO`, and `CORS_ALLOWED_ORIGINS` are required. The Registry uses lazy validation — a missing variable causes a clear error (`Missing required environment variable: <name>`) on the first request that needs it.
 
 ---
 

--- a/registry/docs/planning/mvp1-phase2-implementation.md
+++ b/registry/docs/planning/mvp1-phase2-implementation.md
@@ -83,8 +83,8 @@ Update `lib/config.js`:
 github: {
   botToken: process.env.GITHUB_BOT_TOKEN,
   contentRepo: {
-    owner: 'imboard-ai',
-    repo: 'dossier-content',
+    owner: 'imboard-ai',    // override with CONTENT_ORG env var
+    repo: 'dossier-content', // override with CONTENT_REPO env var
   },
 },
 ```


### PR DESCRIPTION
## Summary
- Added `CONTENT_ORG` and `CONTENT_REPO` to the environment variables table in `auth-and-publish.md`
- Updated the note about optional vs required variables to include the new entries
- Added inline comments in `mvp1-phase2-implementation.md` noting the env var overrides for hardcoded defaults

Closes #207

## Test plan
- Verified changes are documentation-only (no code impact)
- Confirmed `CONTENT_ORG` and `CONTENT_REPO` env vars exist in `registry/lib/config.ts` with the documented defaults

Co-Authored-By: Claude <noreply@anthropic.com>