### PR TITLE
docs(registry): add CORS/CSRF documentation and JSDoc

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -60,6 +60,17 @@ registry/
 └── tsconfig.json
 ```
 
+## CORS & Security
+
+The registry enforces origin-based CORS with CSRF protection:
+
+- **Allowed origins**: `https://dossier.imboard.ai`, `https://registry.dossier.dev` (default). Override with the `CORS_ALLOWED_ORIGINS` environment variable (comma-separated list).
+- **Read-only requests** (`GET`, `HEAD`): allowed from any origin.
+- **Mutating requests** (`POST`, `PUT`, `PATCH`, `DELETE`): blocked with `403 ORIGIN_NOT_ALLOWED` if the browser origin is not on the allowlist.
+- **Non-browser clients** (no `Origin` header): always allowed through.
+
+See [`lib/cors.ts`](lib/cors.ts) for the implementation and the [API design doc](docs/planning/registry-api-design.md#cors-configuration) for the full specification.
+
 ## Design Docs
 
 - [MVP0 Implementation](docs/planning/mvp0-implementation.md) — read-only registry architecture

--- a/registry/docs/planning/registry-api-design.md
+++ b/registry/docs/planning/registry-api-design.md
@@ -505,6 +505,22 @@ Vary: Origin
 Default allowed origins: `https://dossier.imboard.ai`, `https://registry.dossier.dev`.
 Override via `CORS_ALLOWED_ORIGINS` env var (comma-separated).
 
+### CSRF Protection
+
+Mutating requests (`POST`, `PUT`, `PATCH`, `DELETE`) from browser origins not on the allowlist are rejected with:
+
+```json
+{
+  "error": {
+    "code": "ORIGIN_NOT_ALLOWED",
+    "message": "Origin not allowed for mutating requests"
+  }
+}
+```
+**HTTP status:** `403 Forbidden`
+
+Read-only methods (`GET`, `HEAD`) are allowed from any origin. Requests without an `Origin` header (non-browser clients such as `curl` or the CLI) are also allowed, since CSRF is a browser-only attack vector.
+
 ---
 
 ## Version Immutability

--- a/registry/lib/cors.ts
+++ b/registry/lib/cors.ts
@@ -14,6 +14,12 @@ function getAllowedOrigins(): string[] {
   return DEFAULT_ALLOWED_ORIGINS;
 }
 
+/**
+ * Sets CORS response headers based on the request origin.
+ * If the origin is in the allowlist, reflects it in Access-Control-Allow-Origin.
+ * Unknown origins receive no Allow-Origin header but still get the allowed methods/headers
+ * so preflight responses are well-formed.
+ */
 export function setCorsHeaders(req: VercelRequest, res: VercelResponse): void {
   const origin = req.headers.origin;
   const allowed = getAllowedOrigins();
@@ -30,6 +36,20 @@ export function setCorsHeaders(req: VercelRequest, res: VercelResponse): void {
 
 const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
+/**
+ * Handles CORS preflight and enforces origin-based CSRF protection.
+ *
+ * Returns `true` if the request was fully handled (preflight 204, or blocked 403)
+ * and the caller should stop processing. Returns `false` if the request should
+ * continue to the main handler.
+ *
+ * Security model:
+ * - OPTIONS preflight: responds 204 with CORS headers, always handled.
+ * - GET/HEAD: allowed from any origin (read-only, no CSRF risk).
+ * - POST/PUT/PATCH/DELETE from an unknown origin: blocked with 403 ORIGIN_NOT_ALLOWED.
+ * - No Origin header (non-browser clients like curl/CLI): allowed through,
+ *   since CSRF is a browser-only attack vector.
+ */
 export function handleCors(req: VercelRequest, res: VercelResponse): boolean {
   setCorsHeaders(req, res);
 
@@ -38,8 +58,10 @@ export function handleCors(req: VercelRequest, res: VercelResponse): boolean {
     return true;
   }
 
-  // Reject mutating requests from disallowed origins (CSRF protection).
-  // GET/HEAD allowed from any origin (read-only). No Origin header allowed (non-browser clients).
+  // CSRF protection: reject mutating requests from unknown browser origins.
+  // GET/HEAD are read-only so they pass regardless of origin. Requests without
+  // an Origin header come from non-browser clients (curl, CLI) which are not
+  // susceptible to CSRF, so they are also allowed through.
   const origin = req.headers.origin;
   if (origin && MUTATING_METHODS.has(req.method ?? '') && !getAllowedOrigins().includes(origin)) {
     log.warn('Blocked mutating request from disallowed origin', { method: req.method, origin });


### PR DESCRIPTION
## Summary
- Add JSDoc to `setCorsHeaders()` and `handleCors()` explaining their behavior and security model
- Document 403 `ORIGIN_NOT_ALLOWED` error and CSRF rationale in the API design doc
- Add CORS & Security section to the registry README covering allowed origins, CSRF protection, and configuration

Closes #225

## Test plan
- [x] All 91 existing tests pass
- [x] TypeScript typecheck passes
- [x] Documentation-only changes — no runtime behavior modified

Co-Authored-By: Claude <noreply@anthropic.com>