### PR TITLE
fix(registry): improve error context for supportability

### DIFF
--- a/registry/api/v1/dossiers/index.ts
+++ b/registry/api/v1/dossiers/index.ts
@@ -59,7 +59,10 @@ async function handlePublish(req: VercelRequest, res: VercelResponse, requestId:
   const contentType = req.headers['content-type'];
   if (!contentType || !contentType.includes('application/json')) {
     return res.status(HTTP_STATUS.UNSUPPORTED_MEDIA_TYPE).json({
-      error: { code: 'UNSUPPORTED_MEDIA_TYPE', message: 'Content-Type must be application/json' },
+      error: {
+        code: 'UNSUPPORTED_MEDIA_TYPE',
+        message: `Content-Type must be application/json, received: ${contentType || '(none)'}`,
+      },
     });
   }
 
@@ -169,6 +172,7 @@ async function handlePublish(req: VercelRequest, res: VercelResponse, requestId:
       code: 'PUBLISH_ERROR',
       message: 'Failed to publish dossier',
       requestId,
+      context: { namespace, path: fullPath },
     });
   }
 }

--- a/registry/api/v1/search.ts
+++ b/registry/api/v1/search.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_PER_PAGE, HTTP_STATUS, MAX_PER_PAGE, MAX_QUERY_LENGTH } from '../../lib/constants';
 import { handleCors } from '../../lib/cors';
 import { fetchManifestDossiers, normalizeDossier } from '../../lib/manifest';
-import { methodNotAllowed, serverError } from '../../lib/responses';
+import { getRequestId, methodNotAllowed, serverError } from '../../lib/responses';
 import type { VercelRequest, VercelResponse } from '../../lib/types';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -10,6 +10,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET') {
     return methodNotAllowed(req, res, 'GET');
   }
+
+  const requestId = getRequestId(req);
+  res.setHeader('X-Request-Id', requestId);
 
   const q = Array.isArray(req.query.q) ? req.query.q[0] : req.query.q;
   const pageStr = Array.isArray(req.query.page) ? req.query.page[0] : req.query.page;
@@ -67,6 +70,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       error,
       code: 'UPSTREAM_ERROR',
       message: 'Failed to search dossiers',
+      requestId,
+      context: { query: q },
     });
   }
 }

--- a/registry/lib/manifest.ts
+++ b/registry/lib/manifest.ts
@@ -17,7 +17,9 @@ export async function fetchManifestDossiers(): Promise<ManifestDossier[]> {
   }
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch manifest from ${manifestUrl}: HTTP ${response.status}`);
+    throw new Error(
+      `Failed to fetch manifest from ${manifestUrl}: HTTP ${response.status} ${response.statusText}`
+    );
   }
 
   const manifest = (await response.json()) as { dossiers?: ManifestDossier[] };

--- a/registry/lib/responses.ts
+++ b/registry/lib/responses.ts
@@ -54,6 +54,7 @@ export function serverError(
     message: string;
     status?: number;
     requestId?: string;
+    context?: Record<string, unknown>;
   }
 ): VercelResponse {
   const requestId = opts.requestId || crypto.randomUUID();
@@ -64,6 +65,7 @@ export function serverError(
     errorType,
     error: errorMessage,
     stack: opts.error instanceof Error ? opts.error.stack : undefined,
+    ...opts.context,
   });
   return res.status(opts.status ?? HTTP_STATUS.BAD_GATEWAY).json({
     error: {

--- a/registry/tests/manifest.test.ts
+++ b/registry/tests/manifest.test.ts
@@ -31,11 +31,14 @@ describe('fetchManifestDossiers', () => {
     expect(result).toEqual(mockDossiers);
   });
 
-  it('throws on non-ok response with URL', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+  it('throws on non-ok response with URL and statusText', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 500, statusText: 'Internal Server Error' })
+    );
 
     await expect(fetchManifestDossiers()).rejects.toThrow(
-      'Failed to fetch manifest from https://raw.githubusercontent.com/org/repo/main/index.json: HTTP 500'
+      'Failed to fetch manifest from https://raw.githubusercontent.com/org/repo/main/index.json: HTTP 500 Internal Server Error'
     );
   });
 

--- a/registry/tests/responses.test.ts
+++ b/registry/tests/responses.test.ts
@@ -137,6 +137,27 @@ describe('serverError', () => {
     consoleSpy.mockRestore();
   });
 
+  it('includes context fields in log output', () => {
+    const res = createViMockRes();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    serverError(res, {
+      operation: 'dossier.publish',
+      error: new Error('GitHub API error'),
+      code: 'PUBLISH_ERROR',
+      message: 'Failed to publish dossier',
+      requestId: 'req-123',
+      context: { namespace: 'my-org', path: 'my-org/my-dossier' },
+    });
+
+    const loggedJson = JSON.parse(consoleSpy.mock.calls[0][0] as string);
+    expect(loggedJson.namespace).toBe('my-org');
+    expect(loggedJson.path).toBe('my-org/my-dossier');
+    expect(loggedJson.requestId).toBe('req-123');
+
+    consoleSpy.mockRestore();
+  });
+
   it('includes errorType in log but not in response', () => {
     const res = createViMockRes();
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- Add `statusText` to manifest fetch error for clearer HTTP failure diagnostics
- Include received `Content-Type` in 415 error response so callers know what they sent
- Add `namespace`/`path` context to publish error logs for faster incident triage
- Add search `query` and `requestId` to search error logs
- Add optional `context` parameter to `serverError()` for structured log enrichment

Closes #224

## Test plan
- [x] Updated manifest test to verify `statusText` is included in error
- [x] Added `serverError` test for `context` field propagation to logs
- [x] Full test suite passes (105 tests, 10 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)