### PR TITLE
fix(cli): address supportability findings in CLI commands

### DIFF
--- a/cli/src/__tests__/commands/export.test.ts
+++ b/cli/src/__tests__/commands/export.test.ts
@@ -15,6 +15,8 @@ describe('export command', () => {
   beforeEach(() => {
     vi.mocked(registryClient.parseNameVersion).mockImplementation(parseNameVersionImpl);
     mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.writeFileSync.mockReset();
+    mockedFs.mkdirSync.mockReset();
   });
 
   it('should export dossier to file', async () => {
@@ -77,6 +79,26 @@ describe('export command', () => {
     ).rejects.toThrow();
 
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Not found'));
+  });
+
+  it('should exit 1 with message on file write error', async () => {
+    vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
+      result: { content: '# Dossier content', digest: null, _registry: 'public' },
+      errors: [],
+    });
+    mockedFs.writeFileSync.mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    const program = createTestProgram();
+    registerExportCommand(program);
+
+    await expect(program.parseAsync(['node', 'dossier', 'export', 'my-dossier'])).rejects.toThrow();
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Failed to write file'));
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('EACCES: permission denied')
+    );
   });
 
   it('should use custom output path with -o', async () => {

--- a/cli/src/__tests__/commands/list.test.ts
+++ b/cli/src/__tests__/commands/list.test.ts
@@ -88,6 +88,34 @@ describe('list command', () => {
       expect(jsonCalls.length).toBeGreaterThan(0);
     });
 
+    it('should show partial results warning when some registries fail', async () => {
+      vi.mocked(config.resolveRegistries).mockReturnValue([
+        { name: 'public', url: 'https://public.registry.com' },
+        { name: 'private', url: 'https://private.registry.com' },
+      ]);
+      vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
+        dossiers: [
+          { name: 'test', version: '1.0.0', title: 'Test', category: 'dev', _registry: 'public' },
+        ] as any,
+        total: 1,
+        errors: [{ registry: 'private', error: 'connection refused' }],
+      });
+
+      const program = createTestProgram();
+      registerListCommand(program);
+
+      await expect(
+        program.parseAsync(['node', 'dossier', 'list', '--source', 'registry'])
+      ).rejects.toThrow();
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining("Registry 'private': connection refused")
+      );
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Showing partial results (1/2 registries responded)')
+      );
+    });
+
     it('should show empty message for registry', async () => {
       vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
         dossiers: [],

--- a/cli/src/__tests__/commands/pull.test.ts
+++ b/cli/src/__tests__/commands/pull.test.ts
@@ -93,6 +93,33 @@ describe('pull command', () => {
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('not found'));
   });
 
+  it('should log error and continue on cache write failure', async () => {
+    vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
+      result: { version: '1.0.0', _registry: 'public' },
+      errors: [],
+    } as any);
+    vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
+      result: { content: '# Dossier', digest: null, _registry: 'public' },
+      errors: [],
+    });
+    mockedFs.existsSync.mockReturnValue(false);
+    mockedFs.mkdirSync.mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    const program = createTestProgram();
+    registerPullCommand(program);
+
+    await program.parseAsync(['node', 'dossier', 'pull', 'org/my-dossier']);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('failed to write cache files')
+    );
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('EACCES: permission denied')
+    );
+  });
+
   it('should pull specific version', async () => {
     vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
       result: { content: '# Content', digest: null, _registry: 'public' },

--- a/cli/src/__tests__/commands/search.test.ts
+++ b/cli/src/__tests__/commands/search.test.ts
@@ -140,7 +140,7 @@ describe('search command', () => {
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('deploy-app'));
   });
 
-  it('should exit 1 on API error', async () => {
+  it('should exit 1 on API error with registry context', async () => {
     vi.mocked(multiRegistry.multiRegistryList).mockRejectedValue(new Error('Network error'));
 
     const program = createTestProgram();
@@ -148,6 +148,42 @@ describe('search command', () => {
 
     await expect(program.parseAsync(['node', 'dossier', 'search', 'test'])).rejects.toThrow();
 
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Search failed'));
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Search failed across registries [public]')
+    );
+  });
+
+  it('should log warning when content fetch fails for a dossier', async () => {
+    vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
+      dossiers: [
+        {
+          name: 'fail-dossier',
+          title: 'Fail',
+          description: 'will fail content fetch',
+          category: 'test',
+          tags: ['fail'],
+          version: '1.0.0',
+          _registry: 'public',
+        },
+      ] as any,
+      total: 1,
+      errors: [],
+    });
+
+    const mockClient = {
+      getDossierContent: vi.fn().mockRejectedValue(new Error('connection refused')),
+    };
+    vi.mocked(registryClient.getClientForRegistry).mockReturnValue(mockClient as any);
+
+    const program = createTestProgram();
+    registerSearchCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'dossier', 'search', 'fail', '--content'])
+    ).rejects.toThrow();
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to fetch content for 'fail-dossier' from 'public'")
+    );
   });
 });

--- a/cli/src/commands/export.ts
+++ b/cli/src/commands/export.ts
@@ -48,11 +48,19 @@ export function registerExportCommand(program: Command): void {
       const outputPath = options.output || `${dossierName.replace(/\//g, '-')}.ds.md`;
       const outputDir = path.dirname(path.resolve(outputPath));
 
-      if (!fs.existsSync(outputDir)) {
-        fs.mkdirSync(outputDir, { recursive: true });
-      }
+      try {
+        if (!fs.existsSync(outputDir)) {
+          fs.mkdirSync(outputDir, { recursive: true });
+        }
 
-      fs.writeFileSync(path.resolve(outputPath), content, 'utf8');
+        fs.writeFileSync(path.resolve(outputPath), content, 'utf8');
+      } catch (writeErr: unknown) {
+        console.error(
+          `\n❌ Failed to write file '${path.resolve(outputPath)}': ${(writeErr as Error).message}\n`
+        );
+        process.exit(1);
+        return;
+      }
 
       console.log(`\n✅ Exported: ${outputPath}`);
       console.log(`   Source: ${dossierName}${version ? `@${version}` : ''}`);

--- a/cli/src/commands/list.ts
+++ b/cli/src/commands/list.ts
@@ -76,6 +76,11 @@ Multi-registry note:
               for (const e of result.errors) {
                 console.error(`⚠️  Registry '${e.registry}': ${e.error}`);
               }
+              const totalRegistries = resolveRegistries().length;
+              const failed = result.errors.length;
+              console.error(
+                `⚠️  Showing partial results (${totalRegistries - failed}/${totalRegistries} registries responded)\n`
+              );
             }
 
             const dossiers = result.dossiers;

--- a/cli/src/commands/pull.ts
+++ b/cli/src/commands/pull.ts
@@ -66,21 +66,28 @@ export function registerPullCommand(program: Command): void {
             }
           }
 
-          fs.mkdirSync(dossierDir, { recursive: true, mode: 0o700 });
-          fs.writeFileSync(contentFile, content, 'utf8');
-          fs.writeFileSync(
-            metaFile,
-            JSON.stringify(
-              {
-                cached_at: new Date().toISOString(),
-                version,
-                source_registry: result._registry,
-              },
-              null,
-              2
-            ),
-            'utf8'
-          );
+          try {
+            fs.mkdirSync(dossierDir, { recursive: true, mode: 0o700 });
+            fs.writeFileSync(contentFile, content, 'utf8');
+            fs.writeFileSync(
+              metaFile,
+              JSON.stringify(
+                {
+                  cached_at: new Date().toISOString(),
+                  version,
+                  source_registry: result._registry,
+                },
+                null,
+                2
+              ),
+              'utf8'
+            );
+          } catch (writeErr: unknown) {
+            console.error(
+              `❌ ${dossierName}@${version}: failed to write cache files to '${dossierDir}': ${(writeErr as Error).message}`
+            );
+            continue;
+          }
 
           const status = options.force ? 'updated' : 'downloaded';
           console.log(`✅ ${dossierName}@${version} (${status}) [${result._registry}]`);

--- a/cli/src/commands/search.ts
+++ b/cli/src/commands/search.ts
@@ -51,7 +51,12 @@ export function registerSearchCommand(program: Command): void {
 
           allDossiers = result.dossiers;
         } catch (err: unknown) {
-          console.error(`\n❌ Search failed: ${(err as Error).message}\n`);
+          const registryNames = resolveRegistries()
+            .map((r) => r.name)
+            .join(', ');
+          console.error(
+            `\n❌ Search failed across registries [${registryNames}]: ${(err as Error).message}\n`
+          );
           process.exit(1);
           return;
         }
@@ -103,8 +108,10 @@ export function registerSearchCommand(program: Command): void {
                       (end < content.length ? '...' : '');
                     contentMatches?.set(d.name, snippet);
                   }
-                } catch {
-                  // Skip dossiers that fail to fetch
+                } catch (fetchErr: unknown) {
+                  console.error(
+                    `⚠️  Failed to fetch content for '${d.name}' from '${d._registry}': ${(fetchErr as Error).message}`
+                  );
                 }
               })
             );


### PR DESCRIPTION
## Summary
- **search.ts**: Log warnings when content fetch fails instead of silently suppressing errors; include registry names in failure messages for debugging context
- **list.ts**: Show explicit "partial results" warning when some registries fail, so users know they may be seeing incomplete data
- **export.ts/pull.ts**: Wrap file I/O operations in try/catch with actionable error messages including file paths

Closes #227

## Test plan
- [x] Added test: search logs warning on content fetch failure
- [x] Added test: search error includes registry names
- [x] Added test: list shows partial results warning
- [x] Added test: export shows file write error with path
- [x] Added test: pull shows cache write error and continues
- [x] All 369 CLI tests pass
- [x] All 104 registry tests pass
- [x] Build passes

Co-Authored-By: Claude <noreply@anthropic.com>