### PR TITLE
refactor(cli): extract shared registry error-logging helper

### DIFF
--- a/cli/src/__tests__/commands/list.test.ts
+++ b/cli/src/__tests__/commands/list.test.ts
@@ -108,8 +108,9 @@ describe('list command', () => {
         program.parseAsync(['node', 'dossier', 'list', '--source', 'registry'])
       ).rejects.toThrow();
 
-      expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining("Registry 'private': connection refused")
+      expect(helpers.printRegistryErrors).toHaveBeenCalledWith(
+        [{ registry: 'private', error: 'connection refused' }],
+        'warning'
       );
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining('Showing partial results (1/2 registries responded)')

--- a/cli/src/__tests__/helpers.test.ts
+++ b/cli/src/__tests__/helpers.test.ts
@@ -15,6 +15,7 @@ import {
   formatTable,
   parseDossierMetadataFromContent,
   parseListSource,
+  printRegistryErrors,
   RECOMMENDED_FIELDS,
   REQUIRED_FIELDS,
   VALID_RISK_LEVELS,
@@ -279,5 +280,44 @@ describe('findDossierFilesLocal', () => {
     });
 
     expect(findDossierFilesLocal('/no/access')).toEqual([]);
+  });
+});
+
+describe('printRegistryErrors', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('should print errors in indent style by default', () => {
+    const errors = [
+      { registry: 'main', error: 'Not found' },
+      { registry: 'backup', error: 'Timeout' },
+    ];
+
+    printRegistryErrors(errors);
+
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalledWith('   main: Not found');
+    expect(errorSpy).toHaveBeenCalledWith('   backup: Timeout');
+  });
+
+  it('should print errors in warning style', () => {
+    const errors = [{ registry: 'cdn', error: 'Connection refused' }];
+
+    printRegistryErrors(errors, 'warning');
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith("⚠️  Registry 'cdn': Connection refused");
+  });
+
+  it('should handle empty errors array', () => {
+    printRegistryErrors([]);
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 });

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import type { Command } from 'commander';
 import * as config from '../config';
-import { detectLlm } from '../helpers';
+import { detectLlm, printRegistryErrors } from '../helpers';
 import { multiRegistryGetContent, multiRegistryGetDossier } from '../multi-registry';
 import { parseNameVersion } from '../registry-client';
 
@@ -92,9 +92,7 @@ export function registerCreateCommand(program: Command): void {
                 console.error(
                   '   Check the template name or use --template to specify a different one'
                 );
-                for (const e of contentErrors) {
-                  console.error(`   ${e.registry}: ${e.error}`);
-                }
+                printRegistryErrors(contentErrors);
                 console.error('');
                 process.exit(2);
               }

--- a/cli/src/commands/export.ts
+++ b/cli/src/commands/export.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { Command } from 'commander';
+import { printRegistryErrors } from '../helpers';
 import { multiRegistryGetContent } from '../multi-registry';
 import { parseNameVersion } from '../registry-client';
 
@@ -20,9 +21,7 @@ export function registerExportCommand(program: Command): void {
         const { result, errors } = await multiRegistryGetContent(dossierName, version || null);
         if (!result) {
           console.error(`\n❌ Not found: ${name}`);
-          for (const e of errors) {
-            console.error(`   ${e.registry}: ${e.error}`);
-          }
+          printRegistryErrors(errors);
           console.error('');
           process.exit(1);
           return;

--- a/cli/src/commands/get.ts
+++ b/cli/src/commands/get.ts
@@ -1,5 +1,6 @@
 import type { Command } from 'commander';
 import { resolveRegistries } from '../config';
+import { printRegistryErrors } from '../helpers';
 import { multiRegistryGetDossier } from '../multi-registry';
 import type { DossierInfo } from '../registry-client';
 import { parseNameVersion } from '../registry-client';
@@ -20,9 +21,7 @@ export function registerGetCommand(program: Command): void {
         const { result, errors } = await multiRegistryGetDossier(dossierName, version || null);
         if (!result) {
           console.error(`\n❌ Not found in any registry: ${nameArg}`);
-          for (const e of errors) {
-            console.error(`   ${e.registry}: ${e.error}`);
-          }
+          printRegistryErrors(errors);
           console.error('');
           process.exit(1);
         }

--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { parseDossierContent } from '@ai-dossier/core';
 import type { Command } from 'commander';
 import { resolveRegistries } from '../config';
+import { printRegistryErrors } from '../helpers';
 import { multiRegistryGetDossier } from '../multi-registry';
 import type { DossierInfo } from '../registry-client';
 import { parseNameVersion } from '../registry-client';
@@ -44,9 +45,7 @@ export function registerInfoCommand(program: Command): void {
           if (!meta) {
             console.error(`\n❌ Not found: ${fileOrName}`);
             console.error('   Not a local file and not found in any registry');
-            for (const e of metaErrors) {
-              console.error(`   ${e.registry}: ${e.error}`);
-            }
+            printRegistryErrors(metaErrors);
             console.error('');
             process.exit(1);
           }

--- a/cli/src/commands/list.ts
+++ b/cli/src/commands/list.ts
@@ -10,6 +10,7 @@ import {
   formatTable,
   parseDossierMetadataLocal,
   parseListSource,
+  printRegistryErrors,
 } from '../helpers';
 import { multiRegistryList } from '../multi-registry';
 
@@ -73,9 +74,7 @@ Multi-registry note:
             });
 
             if (result.errors.length > 0) {
-              for (const e of result.errors) {
-                console.error(`⚠️  Registry '${e.registry}': ${e.error}`);
-              }
+              printRegistryErrors(result.errors, 'warning');
               const totalRegistries = resolveRegistries().length;
               const failed = result.errors.length;
               console.error(

--- a/cli/src/commands/pull.ts
+++ b/cli/src/commands/pull.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { Command } from 'commander';
-import { safeDossierPath } from '../helpers';
+import { printRegistryErrors, safeDossierPath } from '../helpers';
 import { multiRegistryGetContent, multiRegistryGetDossier } from '../multi-registry';
 import { parseNameVersion } from '../registry-client';
 
@@ -26,9 +26,7 @@ export function registerPullCommand(program: Command): void {
             const { result: meta, errors: metaErrors } = await multiRegistryGetDossier(dossierName);
             if (!meta) {
               console.error(`❌ ${nameArg}: not found in any registry`);
-              for (const e of metaErrors) {
-                console.error(`   ${e.registry}: ${e.error}`);
-              }
+              printRegistryErrors(metaErrors);
               continue;
             }
             version = meta.version || 'latest';
@@ -50,9 +48,7 @@ export function registerPullCommand(program: Command): void {
           );
           if (!result) {
             console.error(`❌ ${nameArg}: not found in any registry`);
-            for (const e of contentErrors) {
-              console.error(`   ${e.registry}: ${e.error}`);
-            }
+            printRegistryErrors(contentErrors);
             continue;
           }
           const content = result.content;

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -9,6 +9,7 @@ import {
   buildLlmCommand,
   detectLlm,
   downloadUrlToTempFile,
+  printRegistryErrors,
   runVerification,
   safeDossierPath,
 } from '../helpers';
@@ -92,9 +93,7 @@ export function registerRunCommand(program: Command): void {
                 if (!meta) {
                   console.error(`\n❌ Not found: ${file}`);
                   console.error('   Not a local file and not found in any registry');
-                  for (const e of metaErrors) {
-                    console.error(`   ${e.registry}: ${e.error}`);
-                  }
+                  printRegistryErrors(metaErrors);
                   console.error('');
                   process.exit(1);
                 }
@@ -107,9 +106,7 @@ export function registerRunCommand(program: Command): void {
               if (!result) {
                 console.error(`\n❌ Not found: ${file}`);
                 console.error('   Not a local file and not found in any registry');
-                for (const e of contentErrors) {
-                  console.error(`   ${e.registry}: ${e.error}`);
-                }
+                printRegistryErrors(contentErrors);
                 console.error('');
                 process.exit(1);
               }

--- a/cli/src/commands/search.ts
+++ b/cli/src/commands/search.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'commander';
 import { resolveRegistries } from '../config';
 import { loadCredentials } from '../credentials';
+import { printRegistryErrors } from '../helpers';
 import type { LabeledDossierListItem } from '../multi-registry';
 import { multiRegistryList } from '../multi-registry';
 import { getClientForRegistry } from '../registry-client';
@@ -44,9 +45,7 @@ export function registerSearchCommand(program: Command): void {
           });
 
           if (result.errors.length > 0) {
-            for (const e of result.errors) {
-              console.error(`⚠️  Registry '${e.registry}': ${e.error}`);
-            }
+            printRegistryErrors(result.errors, 'warning');
           }
 
           allDossiers = result.dossiers;

--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -587,3 +587,20 @@ export function formatTable(dossiers: DossierMetadata[], showPath = false): stri
 
   return output;
 }
+
+/**
+ * Print registry errors to stderr in a consistent format.
+ * Used across commands when multi-registry lookups partially or fully fail.
+ */
+export function printRegistryErrors(
+  errors: ReadonlyArray<{ registry: string; error: string }>,
+  style: 'indent' | 'warning' = 'indent'
+): void {
+  for (const e of errors) {
+    if (style === 'warning') {
+      console.error(`⚠️  Registry '${e.registry}': ${e.error}`);
+    } else {
+      console.error(`   ${e.registry}: ${e.error}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Extracted `printRegistryErrors()` helper in `cli/src/helpers.ts` to replace 10 duplicated error-printing loops across 8 command files
- Supports both `indent` style (fatal errors) and `warning` style (partial failures in list/search)
- Added unit tests for the new helper and updated the existing list command test

Closes #233

## Test plan
- [x] All 480 tests pass (372 CLI + 108 registry)
- [x] Build succeeds
- [x] Biome lint passes

Co-Authored-By: Claude <noreply@anthropic.com>