### PR TITLE
docs(registry): add error response documentation

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -31,6 +31,34 @@ This package (`@ai-dossier/registry`) is an npm workspace within the [ai-dossier
 
 **Production**: https://dossier-registry.vercel.app
 
+### Error Responses
+
+All endpoints return errors in a consistent JSON format:
+
+```json
+{
+  "error": {
+    "code": "ERROR_CODE",
+    "message": "Human-readable description"
+  }
+}
+```
+
+Common error codes:
+
+| Status | Code | Description |
+|--------|------|-------------|
+| 400 | `INVALID_NAMESPACE` | Dossier name fails validation (invalid characters, depth, or length) |
+| 400 | `INVALID_PATH` | Path traversal attempt detected |
+| 400 | `MISSING_FIELD` | Required field missing from request body |
+| 404 | `DOSSIER_NOT_FOUND` | Dossier does not exist in the manifest |
+| 404 | `VERSION_NOT_FOUND` | Requested version does not match current version |
+| 404 | `CONTENT_NOT_FOUND` | Dossier entry exists but content file is missing |
+| 405 | `METHOD_NOT_ALLOWED` | HTTP method not supported for this endpoint |
+| 502 | `UPSTREAM_ERROR` | CDN or GitHub API request failed (network error, timeout, malformed response) |
+
+Server errors (5xx) include a `request_id` for correlating with server logs. See [Error Observability](#error-observability) for tracing details.
+
 ## Development
 
 ```bash

--- a/registry/docs/planning/mvp0-implementation.md
+++ b/registry/docs/planning/mvp0-implementation.md
@@ -160,6 +160,47 @@ dossier-content/
 
 **Production API:** https://dossier-registry.vercel.app
 
+### Error Responses
+
+All error responses return JSON with a consistent structure:
+
+```json
+{
+  "error": {
+    "code": "ERROR_CODE",
+    "message": "Human-readable description"
+  }
+}
+```
+
+Server errors (5xx) also include a `request_id` field for log correlation.
+
+#### `GET /api/v1/dossiers` (List)
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 502 | `UPSTREAM_ERROR` | Manifest fetch failed — CDN unreachable, network timeout, HTTP error from jsDelivr, or malformed JSON (missing `dossiers` array) |
+| 405 | `METHOD_NOT_ALLOWED` | Unsupported HTTP method |
+
+#### `GET /api/v1/dossiers/{name}` (Metadata)
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 400 | `INVALID_NAMESPACE` | Dossier name fails validation (invalid characters, exceeds depth/length limits) |
+| 400 | `INVALID_PATH` | Path traversal detected (e.g., `../` segments) |
+| 404 | `DOSSIER_NOT_FOUND` | No dossier with that name exists in the manifest |
+| 404 | `VERSION_NOT_FOUND` | Requested `?version=` does not match the current version |
+| 502 | `UPSTREAM_ERROR` | GitHub API error when fetching manifest |
+| 405 | `METHOD_NOT_ALLOWED` | Unsupported HTTP method |
+
+#### `GET /api/v1/dossiers/{name}/content`
+
+Same errors as the metadata endpoint above, plus:
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 404 | `CONTENT_NOT_FOUND` | Dossier exists in manifest but content file is missing from the content repo |
+
 ---
 
 ## 7. Lessons Learned


### PR DESCRIPTION
## Summary
- Added error response documentation to `registry/docs/planning/mvp0-implementation.md` covering all read-only API endpoints (list, metadata, content)
- Added common error codes table to `registry/README.md` with HTTP status codes and descriptions
- Documented the consistent JSON error response format used across all endpoints

Closes #221

## Test plan
- [x] All 114 existing tests pass
- [x] Changes are docs-only (markdown files) — no code impact
- [x] Error codes verified against actual API handler implementations

Co-Authored-By: Claude <noreply@anthropic.com>