### PR TITLE
docs: add config command docs, registry type JSDoc, and security context

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,27 @@ https://raw.githubusercontent.com/imboard-ai/ai-dossier/main/examples/git-projec
 
 ---
 
+## Registry & Multi-Registry Support
+
+The CLI supports multiple registries for discovering, publishing, and sharing dossiers across teams and organizations.
+
+- **Multi-registry**: Configure multiple registries (public, internal, mirrors) queried in parallel
+- **HTTPS enforcement**: All registry URLs must use HTTPS to protect credentials in transit
+- **Per-registry credentials**: Each registry has isolated authentication — a compromised token cannot access other registries
+- **Project-level config**: Add a `.dossierrc.json` to your project for team-shared registry settings
+
+```bash
+# Add a private registry
+dossier config --add-registry internal --url https://dossier.company.com
+
+# List configured registries
+dossier config --list-registries
+```
+
+See the [CLI documentation](./cli/README.md#config-command) for full registry management options.
+
+---
+
 ## Adopter Playbooks
 
 - **Solo Dev**: paste a `.ds.md` into your LLM and run via MCP or CLI

--- a/cli/README.md
+++ b/cli/README.md
@@ -172,6 +172,74 @@ See `dossier config` for managing registry URLs. Multiple registries are queried
 
 ---
 
+## Config Command
+
+Manage CLI settings and registry configuration.
+
+### General Settings
+
+```bash
+# List all configuration
+dossier config --list
+
+# Get a setting
+dossier config defaultLlm
+
+# Set a setting
+dossier config defaultLlm claude-code
+
+# Reset to defaults (preserves registry settings)
+dossier config --reset
+```
+
+### Registry Management
+
+All registry URLs **must use HTTPS** to protect credentials in transit.
+
+```bash
+# List configured registries
+dossier config --list-registries
+dossier config --list-registries --json
+
+# Add a registry
+dossier config --add-registry internal --url https://dossier.company.com
+
+# Add as default + read-only
+dossier config --add-registry mirror --url https://mirror.example.com --default --readonly
+
+# Remove a registry
+dossier config --remove-registry mirror
+
+# Change the default registry
+dossier config --set-default-registry internal
+```
+
+### Project-Level Config (`.dossierrc.json`)
+
+Place a `.dossierrc.json` in your project root for team-shared registry settings:
+
+```json
+{
+  "registries": {
+    "internal": { "url": "https://dossier.company.com" }
+  },
+  "defaultRegistry": "internal"
+}
+```
+
+Project registries are merged with user registries. User-configured registries take precedence on name conflicts to prevent credential exfiltration.
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `DOSSIER_REGISTRY_URL` | Override/add a registry URL (creates virtual "env" registry) |
+| `DOSSIER_REGISTRY_TOKEN` | Auth token for the virtual "env" registry (ephemeral, never persisted to disk). Recommended for CI/CD and agent contexts. |
+| `DOSSIER_REGISTRY_USER` | Username for registry authentication |
+| `DOSSIER_REGISTRY_ORGS` | Comma-separated org scopes for registry queries |
+
+---
+
 ## What It Checks
 
 ### 1. Integrity (Checksum)
@@ -312,11 +380,9 @@ claude-run-dossier https://example.com/dossier.ds.md
 
 ## Registry Configuration
 
-The CLI supports multiple registries for discovering, pulling, and publishing dossiers.
+The CLI supports multiple registries for discovering, pulling, and publishing dossiers. Use `dossier config` to manage registries — see [Config Command](#config-command) for CLI usage.
 
 ### Configuration File (`~/.dossier/config.json`)
-
-Configure registries in your user config:
 
 ```json
 {
@@ -337,34 +403,7 @@ Configure registries in your user config:
 }
 ```
 
-### Project-Level Config (`.dossierrc.json`)
-
-Place a `.dossierrc.json` in your project root to add project-specific registries:
-
-```json
-{
-  "registries": {
-    "team": {
-      "url": "https://dossier.myteam.example.com"
-    }
-  },
-  "defaultRegistry": "team"
-}
-```
-
-Project registries are merged with user registries. User-configured registries take precedence on name conflicts to prevent credential exfiltration.
-
-### Environment Variable
-
-Set `DOSSIER_REGISTRY_URL` to add a virtual `env` registry:
-
-```bash
-export DOSSIER_REGISTRY_URL=https://custom-registry.example.com
-```
-
 ### Resolution Priority
-
-When resolving registries, the CLI follows this priority:
 
 1. `--registry` flag on the command
 2. `DOSSIER_REGISTRY_URL` environment variable

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -8,6 +8,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+/**
+ * A single registry entry in the user or project configuration.
+ * URLs must use HTTPS to protect credentials in transit — the CLI
+ * rejects non-HTTPS URLs when adding registries via `dossier config --add-registry`.
+ */
 export interface RegistryEntry {
   url: string;
   default?: boolean;
@@ -23,6 +28,12 @@ export interface DossierConfig {
   [key: string]: unknown;
 }
 
+/**
+ * A registry after resolution from all config sources (user, project, env).
+ * Each resolved registry is isolated: credentials are stored per-registry
+ * in ~/.dossier/credentials.json, and project-level configs cannot override
+ * user-configured registry URLs to prevent credential exfiltration.
+ */
 export interface ResolvedRegistry {
   name: string;
   url: string;

--- a/cli/src/credentials.ts
+++ b/cli/src/credentials.ts
@@ -1,7 +1,15 @@
 /**
  * Credential storage for Dossier registry authentication.
- * Stores per-registry credentials at ~/.dossier/credentials.json with secure file permissions.
+ * Stores per-registry credentials at ~/.dossier/credentials.json with secure file permissions (0600).
  * Auto-migrates old flat format to keyed-by-registry format.
+ *
+ * Security model:
+ * - **HTTPS enforcement**: Registry URLs must use HTTPS (enforced in config.ts when adding
+ *   registries) so credentials are never sent over plain HTTP.
+ * - **Per-registry isolation**: Each registry has its own credential entry. A compromised
+ *   registry token cannot be used to authenticate against other registries.
+ * - **Environment variable override**: DOSSIER_REGISTRY_TOKEN creates a virtual "env"
+ *   credential entry for CI/CD contexts; it is never persisted to disk.
  */
 
 import fs from 'node:fs';


### PR DESCRIPTION
## Summary
- Add `dossier config` command documentation to cli/README.md covering registry management, project-level config, and environment variables
- Add JSDoc to `RegistryEntry` and `ResolvedRegistry` interfaces explaining HTTPS enforcement and per-registry credential isolation
- Add security model documentation to `credentials.ts` file header
- Add Registry & Multi-Registry Support section to main README.md
- Consolidate duplicate Registry Configuration section in cli/README.md

Closes #215

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 114 tests pass (`npm test`)
- [x] Biome lint clean (`npx biome check --write .`)
- [x] Documentation-only changes — no runtime behavior affected

Co-Authored-By: Claude <noreply@anthropic.com>