### PR TITLE
refactor(registry): extract invalidNamespaceError to shared helper

### DIFF
--- a/registry/api/v1/dossiers/[...name].ts
+++ b/registry/api/v1/dossiers/[...name].ts
@@ -8,8 +8,8 @@ import * as github from '../../../lib/github';
 import createLogger from '../../../lib/logger';
 import { queryString } from '../../../lib/query';
 import {
-  badRequest,
   getRequestId,
+  invalidNamespaceError,
   invalidPathError,
   methodNotAllowed,
   notFound,
@@ -38,7 +38,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const namespaceCheck = validateNamespace(dossierName);
   if (!namespaceCheck.valid) {
-    return badRequest(res, 'INVALID_NAMESPACE', namespaceCheck.error);
+    return invalidNamespaceError(res, requestId, namespaceCheck.error);
   }
 
   if (req.method === 'DELETE') {

--- a/registry/api/v1/dossiers/index.ts
+++ b/registry/api/v1/dossiers/index.ts
@@ -9,6 +9,7 @@ import { fetchManifestDossiers, normalizeDossier } from '../../../lib/manifest';
 import {
   badRequest,
   getRequestId,
+  invalidNamespaceError,
   invalidPathError,
   jsonError,
   methodNotAllowed,
@@ -106,7 +107,7 @@ async function handlePublish(req: VercelRequest, res: VercelResponse, requestId:
 
   const namespaceValidation = dossier.validateNamespace(namespace);
   if (!namespaceValidation.valid) {
-    return badRequest(res, 'INVALID_NAMESPACE', namespaceValidation.error);
+    return invalidNamespaceError(res, requestId, namespaceValidation.error);
   }
 
   const authorized = await authorizePublish(req, res, namespace);

--- a/registry/lib/responses.ts
+++ b/registry/lib/responses.ts
@@ -84,6 +84,16 @@ export function invalidPathError(
   return badRequest(res, 'INVALID_PATH', 'Path traversal is not allowed');
 }
 
+/** Returns a 400 response for invalid namespace values, with a warning log. */
+export function invalidNamespaceError(
+  res: VercelResponse,
+  requestId: string,
+  message: string
+): VercelResponse {
+  log.warn('Invalid namespace', { requestId, detail: message });
+  return badRequest(res, 'INVALID_NAMESPACE', message);
+}
+
 /** Returns a structured JSON error response with logging, request tracing, and a configurable status code (defaults to 502). */
 export function serverError(
   res: VercelResponse,

--- a/registry/lib/types.ts
+++ b/registry/lib/types.ts
@@ -10,10 +10,7 @@ export interface JwtPayload {
   exp?: number;
 }
 
-export interface NamespaceValidation {
-  valid: boolean;
-  error: string | null;
-}
+export type NamespaceValidation = { valid: true; error: null } | { valid: false; error: string };
 
 export interface DossierValidation {
   valid: boolean;

--- a/registry/tests/responses.test.ts
+++ b/registry/tests/responses.test.ts
@@ -3,6 +3,7 @@ import {
   badRequest,
   generateErrorRef,
   getRequestId,
+  invalidNamespaceError,
   invalidPathError,
   jsonError,
   methodNotAllowed,
@@ -209,6 +210,41 @@ describe('invalidPathError', () => {
     expect(loggedJson.identifier).toBe('my-org/evil-dossier');
 
     warnSpy.mockRestore();
+  });
+});
+
+describe('invalidNamespaceError', () => {
+  it('returns 400 with INVALID_NAMESPACE code and logs warning', () => {
+    const res = createViMockRes();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    invalidNamespaceError(res, 'req-123', 'Namespace is required');
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: { code: 'INVALID_NAMESPACE', message: 'Namespace is required' },
+    });
+
+    const loggedJson = JSON.parse(warnSpy.mock.calls[0][0] as string);
+    expect(loggedJson.level).toBe('warn');
+    expect(loggedJson.message).toBe('Invalid namespace');
+    expect(loggedJson.requestId).toBe('req-123');
+    expect(loggedJson.detail).toBe('Namespace is required');
+
+    warnSpy.mockRestore();
+  });
+
+  it('passes through the error message', () => {
+    const res = createViMockRes();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    invalidNamespaceError(res, 'req-456', 'Invalid namespace segment: UPPER');
+
+    expect(res.json).toHaveBeenCalledWith({
+      error: { code: 'INVALID_NAMESPACE', message: 'Invalid namespace segment: UPPER' },
+    });
+
+    vi.restoreAllMocks();
   });
 });
 


### PR DESCRIPTION
## Summary
- Extract duplicated namespace validation error response into `invalidNamespaceError()` helper in `registry/lib/responses.ts`
- Add warning log with `requestId` for observability parity with sibling helpers (`invalidPathError`, `methodNotAllowed`)
- Convert `NamespaceValidation` type to discriminated union, eliminating unsafe `as string` casts

Closes #222

## Test plan
- [x] 2 new tests added to `registry/tests/responses.test.ts` (status code, error code, log output)
- [x] All 116 existing tests pass
- [x] Biome lint clean

Co-Authored-By: Claude <noreply@anthropic.com>