### PR TITLE
fix(registry): add request_id to error responses and wrap authorizePublish

### DIFF
--- a/registry/api/v1/dossiers/[...name].ts
+++ b/registry/api/v1/dossiers/[...name].ts
@@ -38,7 +38,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const namespaceCheck = validateNamespace(dossierName);
   if (!namespaceCheck.valid) {
-    return badRequest(res, 'INVALID_NAMESPACE', namespaceCheck.error);
+    return badRequest(res, 'INVALID_NAMESPACE', namespaceCheck.error, requestId);
   }
 
   if (req.method === 'DELETE') {
@@ -61,14 +61,15 @@ async function handleGet(
     const dossierEntry = manifest.dossiers.find((d) => d.name === dossierName);
 
     if (!dossierEntry) {
-      return notFound(res, 'DOSSIER_NOT_FOUND', `Dossier '${dossierName}' not found`);
+      return notFound(res, 'DOSSIER_NOT_FOUND', `Dossier '${dossierName}' not found`, requestId);
     }
 
     if (version && dossierEntry.version !== version) {
       return notFound(
         res,
         'VERSION_NOT_FOUND',
-        `Dossier '${dossierName}' version '${version}' not found (latest: ${dossierEntry.version})`
+        `Dossier '${dossierName}' version '${version}' not found (latest: ${dossierEntry.version})`,
+        requestId
       );
     }
 
@@ -77,7 +78,12 @@ async function handleGet(
       const fileContent = await github.getFileContent(dossierEntry.path);
 
       if (!fileContent) {
-        return notFound(res, 'CONTENT_NOT_FOUND', `Content for dossier '${dossierName}' not found`);
+        return notFound(
+          res,
+          'CONTENT_NOT_FOUND',
+          `Content for dossier '${dossierName}' not found`,
+          requestId
+        );
       }
 
       const digest = sha256Hex(fileContent.content);
@@ -115,22 +121,23 @@ async function handleDelete(
   version: string | undefined,
   requestId: string
 ) {
-  const authorized = await authorizePublish(req, res, dossierName);
-  if (!authorized) return;
-
   try {
+    const authorized = await authorizePublish(req, res, dossierName);
+    if (!authorized) return;
+
     log.info('Deleting dossier', { requestId, dossier: dossierName, version });
     const result = await github.deleteDossier(dossierName, version || null);
 
     if (!result.found) {
-      return notFound(res, 'DOSSIER_NOT_FOUND', `Dossier '${dossierName}' not found`);
+      return notFound(res, 'DOSSIER_NOT_FOUND', `Dossier '${dossierName}' not found`, requestId);
     }
 
     if (result.versionMismatch) {
       return notFound(
         res,
         'VERSION_NOT_FOUND',
-        `Version '${result.requestedVersion}' not found. Current version is '${result.currentVersion}'`
+        `Version '${result.requestedVersion}' not found. Current version is '${result.currentVersion}'`,
+        requestId
       );
     }
 

--- a/registry/api/v1/dossiers/index.ts
+++ b/registry/api/v1/dossiers/index.ts
@@ -69,29 +69,41 @@ async function handlePublish(req: VercelRequest, res: VercelResponse, requestId:
       res,
       HTTP_STATUS.UNSUPPORTED_MEDIA_TYPE,
       'UNSUPPORTED_MEDIA_TYPE',
-      `Content-Type must be application/json, received: ${contentType || '(none)'}`
+      `Content-Type must be application/json, received: ${contentType || '(none)'}`,
+      requestId
     );
   }
 
   const { namespace, content, changelog } = req.body || {};
 
   if (!namespace || typeof namespace !== 'string') {
-    return badRequest(res, 'MISSING_FIELD', 'Missing required field: namespace (must be a string)');
+    return badRequest(
+      res,
+      'MISSING_FIELD',
+      'Missing required field: namespace (must be a string)',
+      requestId
+    );
   }
 
   if (!content || typeof content !== 'string') {
-    return badRequest(res, 'MISSING_FIELD', 'Missing required field: content (must be a string)');
+    return badRequest(
+      res,
+      'MISSING_FIELD',
+      'Missing required field: content (must be a string)',
+      requestId
+    );
   }
 
   if (changelog !== undefined && typeof changelog !== 'string') {
-    return badRequest(res, 'INVALID_FIELD', 'Field changelog must be a string');
+    return badRequest(res, 'INVALID_FIELD', 'Field changelog must be a string', requestId);
   }
 
   if (typeof changelog === 'string' && changelog.length > MAX_CHANGELOG_LENGTH) {
     return badRequest(
       res,
       'CHANGELOG_TOO_LONG',
-      `Changelog exceeds maximum length of ${MAX_CHANGELOG_LENGTH} characters`
+      `Changelog exceeds maximum length of ${MAX_CHANGELOG_LENGTH} characters`,
+      requestId
     );
   }
 
@@ -100,39 +112,44 @@ async function handlePublish(req: VercelRequest, res: VercelResponse, requestId:
       res,
       HTTP_STATUS.CONTENT_TOO_LARGE,
       'CONTENT_TOO_LARGE',
-      `Content exceeds maximum size of ${MAX_CONTENT_SIZE / 1024}KB`
+      `Content exceeds maximum size of ${MAX_CONTENT_SIZE / 1024}KB`,
+      requestId
     );
   }
 
   const namespaceValidation = dossier.validateNamespace(namespace);
   if (!namespaceValidation.valid) {
-    return badRequest(res, 'INVALID_NAMESPACE', namespaceValidation.error);
+    return badRequest(res, 'INVALID_NAMESPACE', namespaceValidation.error, requestId);
   }
-
-  const authorized = await authorizePublish(req, res, namespace);
-  if (!authorized) return;
-
-  let parsed: ReturnType<typeof dossier.parseFrontmatter>;
-  try {
-    parsed = dossier.parseFrontmatter(content);
-  } catch (err) {
-    return badRequest(res, 'INVALID_CONTENT', err instanceof Error ? err.message : String(err));
-  }
-
-  const validation = dossier.validateDossier(parsed.frontmatter);
-  if (!validation.valid) {
-    return badRequest(res, 'INVALID_CONTENT', validation.errors.join('; '));
-  }
-
-  const fullPath = dossier.buildFullName(namespace, parsed.frontmatter.name as string);
-  // Strip control characters (except space) to prevent git commit message injection
-  const sanitizedChangelog = changelog ? changelog.replace(CONTROL_CHARS, '').trim() : '';
-  if (changelog && sanitizedChangelog !== changelog) {
-    log.warn('Stripped control characters from changelog', { requestId, namespace });
-  }
-  const changelogMessage = sanitizedChangelog || 'No changelog provided';
 
   try {
+    const authorized = await authorizePublish(req, res, namespace);
+    if (!authorized) return;
+
+    let parsed: ReturnType<typeof dossier.parseFrontmatter>;
+    try {
+      parsed = dossier.parseFrontmatter(content);
+    } catch (err) {
+      return badRequest(
+        res,
+        'INVALID_CONTENT',
+        err instanceof Error ? err.message : String(err),
+        requestId
+      );
+    }
+
+    const validation = dossier.validateDossier(parsed.frontmatter);
+    if (!validation.valid) {
+      return badRequest(res, 'INVALID_CONTENT', validation.errors.join('; '), requestId);
+    }
+
+    const fullPath = dossier.buildFullName(namespace, parsed.frontmatter.name as string);
+    // Strip control characters (except space) to prevent git commit message injection
+    const sanitizedChangelog = changelog ? changelog.replace(CONTROL_CHARS, '').trim() : '';
+    if (changelog && sanitizedChangelog !== changelog) {
+      log.warn('Stripped control characters from changelog', { requestId, namespace });
+    }
+    const changelogMessage = sanitizedChangelog || 'No changelog provided';
     await github.publishDossier(
       fullPath,
       content,
@@ -164,7 +181,7 @@ async function handlePublish(req: VercelRequest, res: VercelResponse, requestId:
       code: 'PUBLISH_ERROR',
       message: 'Failed to publish dossier',
       requestId,
-      context: { namespace, path: fullPath },
+      context: { namespace },
     });
   }
 }

--- a/registry/api/v1/search.ts
+++ b/registry/api/v1/search.ts
@@ -20,14 +20,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const perPageStr = queryString(req.query.per_page);
 
   if (!q || !q.trim()) {
-    return badRequest(res, 'MISSING_QUERY', 'Query parameter "q" is required');
+    return badRequest(res, 'MISSING_QUERY', 'Query parameter "q" is required', requestId);
   }
 
   if (q.length > MAX_QUERY_LENGTH) {
     return badRequest(
       res,
       'QUERY_TOO_LONG',
-      `Query exceeds maximum length of ${MAX_QUERY_LENGTH} characters`
+      `Query exceeds maximum length of ${MAX_QUERY_LENGTH} characters`,
+      requestId
     );
   }
 

--- a/registry/lib/responses.ts
+++ b/registry/lib/responses.ts
@@ -15,24 +15,37 @@ export function generateErrorRef(): string {
   return crypto.randomBytes(ERROR_REF_BYTES).toString('hex');
 }
 
-/** Returns a JSON error response with the standard `{ error: { code, message } }` shape. */
+/** Returns a JSON error response with the standard `{ error: { code, message, request_id? } }` shape. */
 export function jsonError(
   res: VercelResponse,
   status: number,
   code: string,
-  message: string
+  message: string,
+  requestId?: string
 ): VercelResponse {
-  return res.status(status).json({ error: { code, message } });
+  const error: Record<string, string> = { code, message };
+  if (requestId) error.request_id = requestId;
+  return res.status(status).json({ error });
 }
 
 /** Returns a 400 Bad Request JSON error response. */
-export function badRequest(res: VercelResponse, code: string, message: string): VercelResponse {
-  return jsonError(res, HTTP_STATUS.BAD_REQUEST, code, message);
+export function badRequest(
+  res: VercelResponse,
+  code: string,
+  message: string,
+  requestId?: string
+): VercelResponse {
+  return jsonError(res, HTTP_STATUS.BAD_REQUEST, code, message, requestId);
 }
 
 /** Returns a 404 Not Found JSON error response. */
-export function notFound(res: VercelResponse, code: string, message: string): VercelResponse {
-  return jsonError(res, HTTP_STATUS.NOT_FOUND, code, message);
+export function notFound(
+  res: VercelResponse,
+  code: string,
+  message: string,
+  requestId?: string
+): VercelResponse {
+  return jsonError(res, HTTP_STATUS.NOT_FOUND, code, message, requestId);
 }
 
 function formatAllowed(methods: string[]): string {
@@ -81,7 +94,7 @@ export function invalidPathError(
   identifier: string
 ): VercelResponse {
   log.warn('Path traversal detected', { requestId, identifier });
-  return badRequest(res, 'INVALID_PATH', 'Path traversal is not allowed');
+  return badRequest(res, 'INVALID_PATH', 'Path traversal is not allowed', requestId);
 }
 
 /** Returns a structured JSON error response with logging, request tracing, and a configurable status code (defaults to 502). */

--- a/registry/tests/responses.test.ts
+++ b/registry/tests/responses.test.ts
@@ -199,7 +199,11 @@ describe('invalidPathError', () => {
 
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith({
-      error: { code: 'INVALID_PATH', message: 'Path traversal is not allowed' },
+      error: {
+        code: 'INVALID_PATH',
+        message: 'Path traversal is not allowed',
+        request_id: 'req-abc',
+      },
     });
 
     const loggedJson = JSON.parse(warnSpy.mock.calls[0][0] as string);
@@ -254,6 +258,15 @@ describe('jsonError', () => {
       error: { code: 'TEAPOT', message: 'I am a teapot' },
     });
   });
+
+  it('includes request_id when provided', () => {
+    const res = createViMockRes();
+    jsonError(res, 400, 'BAD', 'bad request', 'req-123');
+
+    expect(res.json).toHaveBeenCalledWith({
+      error: { code: 'BAD', message: 'bad request', request_id: 'req-123' },
+    });
+  });
 });
 
 describe('badRequest', () => {
@@ -266,6 +279,15 @@ describe('badRequest', () => {
       error: { code: 'MISSING_FIELD', message: 'name is required' },
     });
   });
+
+  it('includes request_id when provided', () => {
+    const res = createViMockRes();
+    badRequest(res, 'MISSING_FIELD', 'name is required', 'req-456');
+
+    expect(res.json).toHaveBeenCalledWith({
+      error: { code: 'MISSING_FIELD', message: 'name is required', request_id: 'req-456' },
+    });
+  });
 });
 
 describe('notFound', () => {
@@ -276,6 +298,19 @@ describe('notFound', () => {
     expect(res.status).toHaveBeenCalledWith(404);
     expect(res.json).toHaveBeenCalledWith({
       error: { code: 'DOSSIER_NOT_FOUND', message: "Dossier 'foo' not found" },
+    });
+  });
+
+  it('includes request_id when provided', () => {
+    const res = createViMockRes();
+    notFound(res, 'DOSSIER_NOT_FOUND', "Dossier 'foo' not found", 'req-789');
+
+    expect(res.json).toHaveBeenCalledWith({
+      error: {
+        code: 'DOSSIER_NOT_FOUND',
+        message: "Dossier 'foo' not found",
+        request_id: 'req-789',
+      },
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add `request_id` to all validation and 404 error responses via the shared `jsonError`/`badRequest`/`notFound` helpers for consistent client-to-log correlation
- Add `request_id` to the `invalidPathError` helper response
- Wrap `authorizePublish()` calls in try/catch in both `handleDelete` and `handlePublish` to prevent uncaught exceptions from bypassing requestId-correlated error handling
- Add tests for `request_id` inclusion in `jsonError`, `badRequest`, `notFound`, and `invalidPathError`

Closes #244

## Test plan
- [x] 3 new tests for `request_id` in `jsonError`, `badRequest`, `notFound` helpers
- [x] Updated `invalidPathError` test to verify `request_id` inclusion
- [x] All 125 existing tests pass
- [x] Build passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>