### PR TITLE
fix(registry): address maintainability findings from fix/189

### DIFF
--- a/registry/api/v1/dossiers/index.ts
+++ b/registry/api/v1/dossiers/index.ts
@@ -14,7 +14,7 @@ import {
   methodNotAllowed,
   serverError,
 } from '../../../lib/responses';
-import type { ManifestDossier, VercelRequest, VercelResponse } from '../../../lib/types';
+import type { VercelRequest, VercelResponse } from '../../../lib/types';
 
 const log = createLogger('dossiers/index');
 
@@ -133,12 +133,7 @@ async function handlePublish(req: VercelRequest, res: VercelResponse, requestId:
   const changelogMessage = sanitizedChangelog || 'No changelog provided';
 
   try {
-    await github.publishDossier(
-      fullPath,
-      content,
-      parsed.frontmatter as unknown as ManifestDossier,
-      changelogMessage
-    );
+    await github.publishDossier(fullPath, content, parsed.frontmatter, changelogMessage);
 
     log.info('Dossier published', {
       requestId,

--- a/registry/lib/cors.ts
+++ b/registry/lib/cors.ts
@@ -20,9 +20,13 @@ function getAllowedOrigins(): string[] {
  * Unknown origins receive no Allow-Origin header but still get the allowed methods/headers
  * so preflight responses are well-formed.
  */
-export function setCorsHeaders(req: VercelRequest, res: VercelResponse): void {
+export function setCorsHeaders(
+  req: VercelRequest,
+  res: VercelResponse,
+  allowedOrigins?: string[]
+): void {
   const origin = req.headers.origin;
-  const allowed = getAllowedOrigins();
+  const allowed = allowedOrigins ?? getAllowedOrigins();
 
   if (origin && allowed.includes(origin)) {
     res.setHeader('Access-Control-Allow-Origin', origin);
@@ -51,7 +55,8 @@ const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
  *   since CSRF is a browser-only attack vector.
  */
 export function handleCors(req: VercelRequest, res: VercelResponse): boolean {
-  setCorsHeaders(req, res);
+  const allowedOrigins = getAllowedOrigins();
+  setCorsHeaders(req, res, allowedOrigins);
 
   if (req.method === 'OPTIONS') {
     res.status(HTTP_STATUS.NO_CONTENT).end();
@@ -63,7 +68,7 @@ export function handleCors(req: VercelRequest, res: VercelResponse): boolean {
   // an Origin header come from non-browser clients (curl, CLI) which are not
   // susceptible to CSRF, so they are also allowed through.
   const origin = req.headers.origin;
-  if (origin && MUTATING_METHODS.has(req.method ?? '') && !getAllowedOrigins().includes(origin)) {
+  if (origin && MUTATING_METHODS.has(req.method ?? '') && !allowedOrigins.includes(origin)) {
     log.warn('Blocked mutating request from disallowed origin', { method: req.method, origin });
     res.status(HTTP_STATUS.FORBIDDEN).json({
       error: { code: 'ORIGIN_NOT_ALLOWED', message: 'Origin not allowed for mutating requests' },

--- a/registry/lib/github.ts
+++ b/registry/lib/github.ts
@@ -1,8 +1,16 @@
 import path from 'node:path';
+import type { DossierFrontmatter } from '@ai-dossier/core';
+import { getErrorMessage } from '@ai-dossier/core';
 import config from './config';
 import { DOSSIER_DEFAULTS, GITHUB_API_VERSION, USER_AGENT } from './constants';
 import createLogger from './logger';
-import type { DeleteResult, FileContent, Manifest, ManifestDossier } from './types';
+import type {
+  DeleteResult,
+  FileContent,
+  GitHubCommitResponse,
+  Manifest,
+  ManifestDossier,
+} from './types';
 
 const log = createLogger('github');
 
@@ -21,6 +29,17 @@ function sanitizePath(filePath: string): string {
   return normalized;
 }
 
+async function throwGitHubApiError(response: Response): Promise<never> {
+  let errorMessage: string;
+  try {
+    const data = (await response.json()) as { message?: string };
+    errorMessage = data.message || JSON.stringify(data);
+  } catch {
+    errorMessage = await response.text().catch(() => 'unknown error');
+  }
+  throw new Error(`GitHub API error: ${response.status} - ${errorMessage}`);
+}
+
 async function githubRequest(endpoint: string, options: RequestInit = {}): Promise<Response> {
   const url = endpoint.startsWith('http') ? endpoint : `${config.auth.github.apiUrl}${endpoint}`;
 
@@ -37,8 +56,7 @@ async function githubRequest(endpoint: string, options: RequestInit = {}): Promi
       },
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`GitHub API request failed for ${url}: ${message}`);
+    throw new Error(`GitHub API request failed for ${url}: ${getErrorMessage(err)}`);
   }
 
   if (!response.ok) {
@@ -74,7 +92,11 @@ export async function getFileContent(filePath: string): Promise<FileContent | nu
   };
 }
 
-export async function deleteFile(filePath: string, message: string, sha: string): Promise<unknown> {
+export async function deleteFile(
+  filePath: string,
+  message: string,
+  sha: string
+): Promise<GitHubCommitResponse> {
   const safePath = sanitizePath(filePath);
   const { org, repo } = config.content;
 
@@ -84,17 +106,10 @@ export async function deleteFile(filePath: string, message: string, sha: string)
   });
 
   if (!response.ok) {
-    let errorMessage: string;
-    try {
-      const data = (await response.json()) as { message?: string };
-      errorMessage = data.message || JSON.stringify(data);
-    } catch {
-      errorMessage = await response.text().catch(() => 'unknown error');
-    }
-    throw new Error(`GitHub API error: ${response.status} - ${errorMessage}`);
+    await throwGitHubApiError(response);
   }
 
-  return response.json();
+  return response.json() as Promise<GitHubCommitResponse>;
 }
 
 export async function createOrUpdateFile(
@@ -102,7 +117,7 @@ export async function createOrUpdateFile(
   content: string,
   message: string,
   sha: string | null = null
-): Promise<unknown> {
+): Promise<GitHubCommitResponse> {
   const safePath = sanitizePath(filePath);
   const { org, repo } = config.content;
   const body: Record<string, string> = {
@@ -120,17 +135,10 @@ export async function createOrUpdateFile(
   });
 
   if (!response.ok) {
-    let errorMessage: string;
-    try {
-      const data = (await response.json()) as { message?: string };
-      errorMessage = data.message || JSON.stringify(data);
-    } catch {
-      errorMessage = await response.text().catch(() => 'unknown error');
-    }
-    throw new Error(`GitHub API error: ${response.status} - ${errorMessage}`);
+    await throwGitHubApiError(response);
   }
 
-  return response.json();
+  return response.json() as Promise<GitHubCommitResponse>;
 }
 
 export async function getManifest(): Promise<Manifest> {
@@ -144,8 +152,7 @@ export async function getManifest(): Promise<Manifest> {
   try {
     manifest = JSON.parse(result.content);
   } catch (e) {
-    const message = e instanceof Error ? e.message : String(e);
-    throw new Error(`Failed to parse manifest (index.json): ${message}`);
+    throw new Error(`Failed to parse manifest (index.json): ${getErrorMessage(e)}`);
   }
   return { ...manifest, sha: result.sha };
 }
@@ -153,7 +160,7 @@ export async function getManifest(): Promise<Manifest> {
 export async function updateManifest(
   currentManifest: Manifest,
   dossierEntry: ManifestDossier
-): Promise<unknown> {
+): Promise<GitHubCommitResponse> {
   const { sha, ...manifest } = currentManifest;
 
   const existingIndex = manifest.dossiers.findIndex((d) => d.name === dossierEntry.name);
@@ -178,7 +185,7 @@ export async function updateManifest(
 export async function removeFromManifest(
   currentManifest: Manifest,
   dossierName: string
-): Promise<unknown> {
+): Promise<GitHubCommitResponse> {
   const { sha, ...manifest } = currentManifest;
 
   const existingIndex = manifest.dossiers.findIndex((d) => d.name === dossierName);
@@ -198,9 +205,9 @@ export async function removeFromManifest(
 export async function publishDossier(
   fullPath: string,
   content: string,
-  metadata: ManifestDossier,
+  metadata: DossierFrontmatter,
   changelog: string
-): Promise<{ file: unknown; manifest: unknown }> {
+): Promise<{ file: GitHubCommitResponse; manifest: GitHubCommitResponse }> {
   const filePath = `${fullPath}.ds.md`;
 
   const existing = await getFileContent(filePath);
@@ -238,14 +245,13 @@ export async function publishDossier(
     }
   }
 
-  let manifestResult: unknown;
+  let manifestResult: GitHubCommitResponse;
   try {
     manifestResult = await updateManifest(manifest, dossierEntry);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
     log.error('File written but manifest update failed — orphaned file needs cleanup', {
       filePath,
-      error: message,
+      error: getErrorMessage(err),
     });
     throw err;
   }
@@ -296,14 +302,13 @@ export async function deleteDossier(
   log.info('Content file deleted', { step: '1/2' });
 
   log.info('Removing from manifest', { step: '2/2', dossier: dossierName });
-  let manifestResult: unknown;
+  let manifestResult: GitHubCommitResponse;
   try {
     manifestResult = await removeFromManifest(manifest, dossierName);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
     log.error('File deleted but manifest update failed — manual cleanup required', {
       filePath,
-      error: message,
+      error: getErrorMessage(err),
     });
     throw err;
   }

--- a/registry/lib/types.ts
+++ b/registry/lib/types.ts
@@ -48,12 +48,17 @@ export interface Manifest {
   sha: string | null;
 }
 
+export interface GitHubCommitResponse {
+  content: { name: string; path: string; sha: string } | null;
+  commit: { sha: string; message: string };
+}
+
 export interface DeleteResult {
   found: boolean;
   version?: string | null;
   versionMismatch?: boolean;
   currentVersion?: string;
   requestedVersion?: string;
-  file?: unknown;
-  manifest?: unknown;
+  file?: GitHubCommitResponse;
+  manifest?: GitHubCommitResponse;
 }

--- a/registry/tests/helpers/mocks.ts
+++ b/registry/tests/helpers/mocks.ts
@@ -3,16 +3,18 @@ import type { VercelRequest, VercelResponse } from '../../lib/types';
 
 type MockReqOverrides = Partial<{
   method: string;
-  query: Record<string, string>;
+  url: string;
+  query: Record<string, string | string[]>;
   headers: Record<string, string>;
   body: unknown;
 }>;
 
 export function createMockReq(
   overrides: MockReqOverrides = {}
-): Pick<VercelRequest, 'method' | 'query' | 'headers' | 'body'> {
+): Pick<VercelRequest, 'method' | 'url' | 'query' | 'headers' | 'body'> {
   return {
     method: overrides.method ?? 'GET',
+    url: overrides.url,
     query: overrides.query ?? {},
     headers: overrides.headers ?? {},
     body: overrides.body ?? undefined,
@@ -54,6 +56,23 @@ export function createMockRes() {
     getBody: () => body,
     headers,
   };
+}
+
+type SpyInstance = ReturnType<typeof vi.spyOn>;
+
+export function findLogEntry(
+  spy: SpyInstance,
+  messageValue: string
+): Record<string, unknown> | undefined {
+  return spy.mock.calls
+    .map((call) => {
+      try {
+        return JSON.parse(call[0] as string) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    })
+    .find((entry): entry is Record<string, unknown> => entry?.message === messageValue);
 }
 
 type ViMockRes = VercelResponse & {

--- a/registry/tests/supportability.test.ts
+++ b/registry/tests/supportability.test.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import { authenticateRequest } from '../lib/auth';
 import { OAUTH_STATE_COOKIE } from '../lib/constants';
+import { createMockReq, createMockRes, findLogEntry } from './helpers/mocks';
 
 describe('successful mutation logging', () => {
   it('logs successful publish with structured data', async () => {
@@ -42,7 +43,7 @@ describe('successful mutation logging', () => {
     const handlerModule = await import('../api/v1/dossiers/index');
     const handler = handlerModule.default;
 
-    const req = {
+    const req = createMockReq({
       method: 'POST',
       headers: {
         'content-type': 'application/json',
@@ -53,35 +54,15 @@ describe('successful mutation logging', () => {
         namespace: 'testorg',
         content: '---\nname: my-dossier\nversion: 1.0.0\n---\n# Hello',
       },
-    } as any;
+    });
 
-    let statusCode = 0;
-    let body: any = {};
-    const res = {
-      status: (code: number) => {
-        statusCode = code;
-        return {
-          json: (b: any) => {
-            body = b;
-          },
-        };
-      },
-      setHeader: () => {},
-    } as any;
+    const { res, getStatus } = createMockRes();
 
     await handler(req, res);
 
-    expect(statusCode).toBe(201);
+    expect(getStatus()).toBe(201);
 
-    const publishLog = consoleSpy.mock.calls
-      .map((call) => {
-        try {
-          return JSON.parse(call[0] as string);
-        } catch {
-          return null;
-        }
-      })
-      .find((entry) => entry?.message === 'Dossier published');
+    const publishLog = findLogEntry(consoleSpy, 'Dossier published');
 
     expect(publishLog).toBeDefined();
     expect(publishLog).toMatchObject({
@@ -127,39 +108,19 @@ describe('successful mutation logging', () => {
     const handlerModule = await import('../api/v1/dossiers/[...name]');
     const handler = handlerModule.default;
 
-    const req = {
+    const req = createMockReq({
       method: 'DELETE',
       query: { name: ['testorg', 'my-dossier'], version: '1.0.0' },
       headers: { authorization: 'Bearer valid-token', 'x-request-id': 'req-456' },
-    } as any;
+    });
 
-    let statusCode = 0;
-    let body: any = {};
-    const res = {
-      status: (code: number) => {
-        statusCode = code;
-        return {
-          json: (b: any) => {
-            body = b;
-          },
-        };
-      },
-      setHeader: () => {},
-    } as any;
+    const { res, getStatus } = createMockRes();
 
     await handler(req, res);
 
-    expect(statusCode).toBe(200);
+    expect(getStatus()).toBe(200);
 
-    const deleteLog = consoleSpy.mock.calls
-      .map((call) => {
-        try {
-          return JSON.parse(call[0] as string);
-        } catch {
-          return null;
-        }
-      })
-      .find((entry) => entry?.message === 'Dossier deleted');
+    const deleteLog = findLogEntry(consoleSpy, 'Dossier deleted');
 
     expect(deleteLog).toBeDefined();
     expect(deleteLog).toMatchObject({
@@ -197,27 +158,17 @@ describe('auth error response includes namespace', () => {
     const authModule = await import('../lib/auth');
     const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    const req = {
+    const req = createMockReq({
       headers: { authorization: 'Bearer valid-token' },
-    } as any;
+    });
 
-    let statusCode = 0;
-    let body: any = {};
-    const res = {
-      status: (code: number) => {
-        statusCode = code;
-        return {
-          json: (b: any) => {
-            body = b;
-          },
-        };
-      },
-    } as any;
+    const { res, getStatus, getBody } = createMockRes();
 
     const result = await authModule.authorizePublish(req, res, 'other-org/some-dossier');
 
     expect(result).toBe(false);
-    expect(statusCode).toBe(403);
+    expect(getStatus()).toBe(403);
+    const body = getBody() as { error: { namespace: string; code: string } };
     expect(body.error.namespace).toBe('other-org/some-dossier');
     expect(body.error.code).toBe('FORBIDDEN');
 
@@ -234,39 +185,25 @@ describe('error correlation IDs', () => {
 
     // Provide valid state so we reach the try/catch block (code exchange will fail)
     const state = crypto.randomBytes(32).toString('hex');
-    const req = {
+    const req = createMockReq({
       method: 'GET',
       query: { code: 'bad-code', state },
       headers: { cookie: `${OAUTH_STATE_COOKIE}=${state}` },
-    } as any;
+    });
 
-    let statusCode = 0;
-    let body = '';
-    const res = {
-      status: (code: number) => {
-        statusCode = code;
-        return {
-          send: (b: string) => {
-            body = b;
-          },
-          json: (b: any) => {
-            body = JSON.stringify(b);
-          },
-        };
-      },
-      setHeader: () => {},
-    } as any;
+    const { res, getStatus, getBody } = createMockRes();
 
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     await handler(req, res);
 
-    expect(statusCode).toBe(500);
+    expect(getStatus()).toBe(500);
 
     // Error page should contain a reference code (8 hex chars)
+    const body = getBody() as string;
     const refMatch = body.match(/Reference:\s*([a-f0-9]{8})/);
     expect(refMatch).not.toBeNull();
-    const errorRef = refMatch![1];
+    const errorRef = refMatch?.[1];
 
     // Console log should contain the same ref
     const logCall = consoleSpy.mock.calls.find((call) =>
@@ -307,28 +244,16 @@ describe('error correlation IDs', () => {
     const loginModule = await import('../api/auth/login');
     const handler = loginModule.default;
 
-    const req = { method: 'GET' } as any;
+    const req = createMockReq({ method: 'GET' });
 
-    let statusCode = 0;
-    let body: any = {};
-    const res = {
-      status: (code: number) => {
-        statusCode = code;
-        return {
-          json: (b: any) => {
-            body = b;
-          },
-        };
-      },
-      setHeader: () => {},
-      redirect: () => {},
-    } as any;
+    const { res, getStatus, getBody } = createMockRes();
 
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     handler(req, res);
 
-    expect(statusCode).toBe(500);
+    expect(getStatus()).toBe(500);
+    const body = getBody() as { error: { ref: string } };
     expect(body.error.ref).toMatch(/^[a-f0-9]{8}$/);
 
     // Console log should contain the same ref
@@ -350,18 +275,17 @@ describe('auth failure logging', () => {
   it('logs missing token attempts', async () => {
     const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    const req = { method: 'POST', url: '/api/v1/dossiers', headers: {} } as any;
-    let statusCode = 0;
-    const res = {
-      status: (code: number) => {
-        statusCode = code;
-        return { json: () => {} };
-      },
-    } as any;
+    const req = createMockReq({
+      method: 'POST',
+      url: '/api/v1/dossiers',
+      headers: {},
+    });
+
+    const { res, getStatus } = createMockRes();
 
     await authenticateRequest(req, res);
 
-    expect(statusCode).toBe(401);
+    expect(getStatus()).toBe(401);
     const loggedJson = JSON.parse(consoleSpy.mock.calls[0][0] as string);
     expect(loggedJson).toMatchObject({
       level: 'warn',
@@ -391,22 +315,17 @@ describe('auth failure logging', () => {
     const authModule = await import('../lib/auth');
     const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    const req = {
+    const req = createMockReq({
       method: 'DELETE',
       url: '/api/v1/dossiers/foo/bar',
       headers: { authorization: 'Bearer bad-token' },
-    } as any;
-    let statusCode = 0;
-    const res = {
-      status: (code: number) => {
-        statusCode = code;
-        return { json: () => {} };
-      },
-    } as any;
+    });
+
+    const { res, getStatus } = createMockRes();
 
     await authModule.authenticateRequest(req, res);
 
-    expect(statusCode).toBe(401);
+    expect(getStatus()).toBe(401);
     const loggedJson = JSON.parse(consoleSpy.mock.calls[0][0] as string);
     expect(loggedJson).toMatchObject({
       level: 'warn',


### PR DESCRIPTION
## Summary
- Replace broad `Promise<unknown>` return types with typed `GitHubCommitResponse` interface in `registry/lib/github.ts`
- Remove double type cast `as unknown as ManifestDossier` in dossiers handler — `publishDossier` now accepts `DossierFrontmatter` directly
- Cache `getAllowedOrigins()` result in `handleCors` to avoid redundant calls
- Replace all 14 `as any` casts in `supportability.test.ts` with `createMockReq`/`createMockRes` typed helpers
- Extract `throwGitHubApiError` helper and use `getErrorMessage()` from `@ai-dossier/core` to reduce DRY violations
- Add `findLogEntry` test helper to deduplicate JSON log-parsing pattern

## Test plan
- [x] All 122 registry tests pass
- [x] Biome lint clean (no warnings)
- [x] No changes to runtime behavior — all changes are type-level or internal refactors

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)