### PR TITLE
fix(registry): add search handler logging and filter empty CORS origins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
     },
     "cli": {
       "name": "@ai-dossier/cli",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ai-dossier/core": "^1.0.1",

--- a/registry/api/v1/search.ts
+++ b/registry/api/v1/search.ts
@@ -1,9 +1,12 @@
 import { DEFAULT_PER_PAGE, HTTP_STATUS, MAX_PER_PAGE, MAX_QUERY_LENGTH } from '../../lib/constants';
 import { handleCors } from '../../lib/cors';
+import createLogger from '../../lib/logger';
 import { fetchManifestDossiers, normalizeDossier } from '../../lib/manifest';
 import { queryString } from '../../lib/query';
 import { badRequest, getRequestId, methodNotAllowed, serverError } from '../../lib/responses';
 import type { VercelRequest, VercelResponse } from '../../lib/types';
+
+const log = createLogger('search');
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleCors(req, res)) return;
@@ -57,6 +60,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const paged = matched.slice(start, start + perPage);
 
     const dossiers = paged.map(normalizeDossier);
+
+    log.info('Search completed', { requestId, query: q, total, page, perPage });
 
     return res.status(HTTP_STATUS.OK).json({
       dossiers,

--- a/registry/lib/cors.ts
+++ b/registry/lib/cors.ts
@@ -9,7 +9,15 @@ const DEFAULT_ALLOWED_ORIGINS = ['https://dossier.imboard.ai', 'https://registry
 function getAllowedOrigins(): string[] {
   const envOrigins = process.env.CORS_ALLOWED_ORIGINS;
   if (envOrigins) {
-    return envOrigins.split(',').map((o) => o.trim());
+    const raw = envOrigins.split(',').map((o) => o.trim());
+    const filtered = raw.filter(Boolean);
+    if (filtered.length < raw.length) {
+      log.warn('CORS_ALLOWED_ORIGINS contains empty entries — filtered out', {
+        raw: raw.length,
+        filtered: filtered.length,
+      });
+    }
+    return filtered;
   }
   return DEFAULT_ALLOWED_ORIGINS;
 }

--- a/registry/tests/security.test.ts
+++ b/registry/tests/security.test.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { MAX_CHANGELOG_LENGTH, MAX_QUERY_LENGTH, OAUTH_STATE_COOKIE } from '../lib/constants';
 import { validateNamespace } from '../lib/dossier';
 import { createMockReq, createMockRes } from './helpers/mocks';
@@ -402,6 +402,67 @@ describe('CORS headers not leaked to disallowed origins', () => {
     expect(headers['Access-Control-Allow-Methods']).toBeDefined();
     expect(headers['Access-Control-Allow-Headers']).toBeDefined();
     expect(headers.Vary).toBe('Origin');
+  });
+});
+
+describe('CORS_ALLOWED_ORIGINS empty entry filtering', () => {
+  it('filters out empty entries from trailing commas', async () => {
+    const originalEnv = process.env.CORS_ALLOWED_ORIGINS;
+    process.env.CORS_ALLOWED_ORIGINS = 'https://a.example.com,,https://b.example.com,';
+
+    vi.resetModules();
+    const cors = await import('../lib/cors');
+    const { headers, req, res } = createCorsReqRes('https://a.example.com');
+
+    cors.setCorsHeaders(req, res);
+
+    expect(headers['Access-Control-Allow-Origin']).toBe('https://a.example.com');
+
+    // Empty string should NOT match
+    const { headers: emptyHeaders, req: emptyReq, res: emptyRes } = createCorsReqRes('');
+    cors.setCorsHeaders(emptyReq, emptyRes);
+    expect(emptyHeaders['Access-Control-Allow-Origin']).toBeUndefined();
+
+    if (originalEnv === undefined) {
+      delete process.env.CORS_ALLOWED_ORIGINS;
+    } else {
+      process.env.CORS_ALLOWED_ORIGINS = originalEnv;
+    }
+  });
+
+  it('logs warning when empty entries are present', async () => {
+    const originalEnv = process.env.CORS_ALLOWED_ORIGINS;
+    process.env.CORS_ALLOWED_ORIGINS = 'https://a.example.com,,';
+
+    vi.resetModules();
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const cors = await import('../lib/cors');
+    const { req, res } = createCorsReqRes('https://a.example.com');
+    cors.setCorsHeaders(req, res);
+
+    const warningLog = consoleSpy.mock.calls
+      .map((call) => {
+        try {
+          return JSON.parse(call[0] as string);
+        } catch {
+          return null;
+        }
+      })
+      .find(
+        (entry) => entry?.message === 'CORS_ALLOWED_ORIGINS contains empty entries — filtered out'
+      );
+
+    expect(warningLog).toBeDefined();
+    expect(warningLog.raw).toBe(3);
+    expect(warningLog.filtered).toBe(1);
+
+    consoleSpy.mockRestore();
+    if (originalEnv === undefined) {
+      delete process.env.CORS_ALLOWED_ORIGINS;
+    } else {
+      process.env.CORS_ALLOWED_ORIGINS = originalEnv;
+    }
   });
 });
 

--- a/registry/tests/supportability.test.ts
+++ b/registry/tests/supportability.test.ts
@@ -346,6 +346,71 @@ describe('error correlation IDs', () => {
   });
 });
 
+describe('search handler logging', () => {
+  it('logs search completed with structured data', async () => {
+    vi.resetModules();
+
+    vi.doMock('../lib/manifest', () => ({
+      fetchManifestDossiers: vi.fn().mockResolvedValue([
+        { name: 'test-dossier', title: 'Test Dossier', description: 'A test' },
+        { name: 'other-dossier', title: 'Other', description: 'Another' },
+      ]),
+      normalizeDossier: (d: any) => d,
+    }));
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const handlerModule = await import('../api/v1/search');
+    const handler = handlerModule.default;
+
+    const req = {
+      method: 'GET',
+      headers: { 'x-request-id': 'req-search-123' },
+      query: { q: 'test' },
+    } as any;
+
+    let statusCode = 0;
+    let body: any = {};
+    const res = {
+      status: (code: number) => {
+        statusCode = code;
+        return {
+          json: (b: any) => {
+            body = b;
+          },
+        };
+      },
+      setHeader: () => {},
+    } as any;
+
+    await handler(req, res);
+
+    expect(statusCode).toBe(200);
+
+    const searchLog = consoleSpy.mock.calls
+      .map((call) => {
+        try {
+          return JSON.parse(call[0] as string);
+        } catch {
+          return null;
+        }
+      })
+      .find((entry) => entry?.message === 'Search completed');
+
+    expect(searchLog).toBeDefined();
+    expect(searchLog).toMatchObject({
+      level: 'info',
+      context: 'search',
+      requestId: 'req-search-123',
+      query: 'test',
+      total: 1,
+    });
+
+    consoleSpy.mockRestore();
+    vi.doUnmock('../lib/manifest');
+  });
+});
+
 describe('auth failure logging', () => {
   it('logs missing token attempts', async () => {
     const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- Add structured logging to search handler via `createLogger('search')` — search operations are now visible in logs with requestId, query, total results, page, and perPage
- Filter empty strings from `CORS_ALLOWED_ORIGINS` env var (e.g. trailing commas like `a,b,,c,`) and log a warning when malformed entries are detected
- Note: Finding #1 from the issue (request tracing) was already fixed — search.ts already has `getRequestId`, `X-Request-Id` header, and passes `requestId` to `serverError()`

Closes #256

## Test plan
- [x] New test: search handler logs "Search completed" with structured data (supportability.test.ts)
- [x] New test: CORS empty entry filtering works correctly (security.test.ts)
- [x] New test: CORS empty entry filtering logs warning (security.test.ts)
- [x] Full test suite passes (125 tests, 11 files)

Co-Authored-By: Claude <noreply@anthropic.com>