### PR TITLE
docs: add --list-registries usage and credential troubleshooting

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -571,6 +571,81 @@ ai-dossier verify ../examples/security/validate-project-config.ds.md
 
 ---
 
+## Troubleshooting
+
+### "insecure permissions" warning
+
+```
+⚠️  Warning: ~/.dossier/credentials.json has insecure permissions (644). Expected 0600. Credentials may have been compromised. Fixing permissions.
+```
+
+**What it means**: The credentials file is readable by other users on the system. The CLI expects `0600` (owner read/write only) to protect your authentication tokens.
+
+**How to fix**:
+
+```bash
+chmod 600 ~/.dossier/credentials.json
+```
+
+The CLI will also attempt to fix permissions automatically when it detects this issue.
+
+**Common causes**:
+- Manually creating or editing the file with a text editor
+- Copying the file from another system without preserving permissions
+- Running the CLI as a different user than the file owner
+
+### "Failed to save credentials"
+
+```
+Failed to save credentials to ~/.dossier/credentials.json: <reason>
+```
+
+**What it means**: The CLI could not write to the credentials file after `dossier login` or a token refresh.
+
+**How to fix**:
+
+1. **Check directory exists**: The config directory `~/.dossier/` must exist. The CLI creates it automatically, but if creation failed:
+   ```bash
+   mkdir -p ~/.dossier
+   chmod 700 ~/.dossier
+   ```
+
+2. **Check write permissions**: Ensure your user owns the directory and file:
+   ```bash
+   ls -la ~/.dossier/
+   # If ownership is wrong:
+   sudo chown -R $(whoami) ~/.dossier
+   ```
+
+3. **Check disk space**: Ensure the filesystem has available space.
+
+4. **Check for read-only filesystem**: In some container or CI environments, the home directory may be read-only. Use the `DOSSIER_REGISTRY_TOKEN` environment variable instead:
+   ```bash
+   export DOSSIER_REGISTRY_TOKEN=<your-token>
+   ```
+
+### "Registry not found"
+
+```
+Registry 'myregistry' not found. Available: public. Run 'dossier config --list-registries' to see configured registries.
+```
+
+**What it means**: The `--registry` flag references a registry name that isn't configured.
+
+**How to fix**:
+
+1. List configured registries to see what's available:
+   ```bash
+   dossier config --list-registries
+   ```
+
+2. Add the missing registry:
+   ```bash
+   dossier config --add-registry myregistry --url https://dossier.example.com
+   ```
+
+---
+
 ## FAQ
 
 ### Q: Why a separate CLI tool?

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -280,6 +280,20 @@ ai-dossier login                      # default registry
 ai-dossier login --registry internal  # named registry
 ```
 
+### Viewing Configured Registries
+
+Use `--list-registries` to see which registries are configured and which is the default:
+
+```bash
+# Human-readable output
+dossier config --list-registries
+
+# Machine-readable JSON (useful for scripts and agents)
+dossier config --list-registries --json
+```
+
+This is helpful when an error message says a registry was not found — run `--list-registries` to see what's available and verify the name.
+
 See the [CLI README](../../cli/README.md#registry-configuration) for full registry configuration details.
 
 ---
@@ -403,6 +417,36 @@ defined in PROTOCOL.md. This includes:
 "Check the Troubleshooting section of the dossier and
 diagnose the issue. Then propose a fix."
 ```
+
+### "insecure permissions" warning on credentials
+
+The CLI stores authentication tokens in `~/.dossier/credentials.json` with restricted permissions (`0600`). If the file permissions are loosened, you'll see:
+
+```
+⚠️  Warning: ~/.dossier/credentials.json has insecure permissions (644). Expected 0600. Credentials may have been compromised. Fixing permissions.
+```
+
+Fix by running:
+```bash
+chmod 600 ~/.dossier/credentials.json
+```
+
+The CLI will also attempt to fix this automatically.
+
+### "Failed to save credentials"
+
+This means the CLI couldn't write to the credentials file after login. Common fixes:
+
+1. Ensure `~/.dossier/` exists and is writable:
+   ```bash
+   mkdir -p ~/.dossier && chmod 700 ~/.dossier
+   ```
+2. In containers or CI where the home directory is read-only, use an environment variable instead:
+   ```bash
+   export DOSSIER_REGISTRY_TOKEN=<your-token>
+   ```
+
+See the [CLI README troubleshooting](../../cli/README.md#troubleshooting) for more details.
 
 ---
 


### PR DESCRIPTION
## Summary
- Documents `dossier config --list-registries` flag in the user-facing getting-started guide with usage examples
- Adds troubleshooting sections for insecure file permissions warnings, credential save failures, and registry-not-found errors to the CLI README
- Adds condensed troubleshooting for credentials issues to getting-started guide with cross-reference to CLI docs

Closes #265

## Test plan
- [ ] Verify documented error messages match actual CLI output (`cli/src/credentials.ts`, `cli/src/config.ts`)
- [ ] Verify `dossier config --list-registries` command works as documented
- [ ] Confirm cross-reference links between docs are valid

Co-Authored-By: Claude <noreply@anthropic.com>