### PR TITLE
fix(core): improve type safety and readability in linter rules and url-scanner

### DIFF
--- a/packages/core/src/linter/rules/risk-level-consistency.ts
+++ b/packages/core/src/linter/rules/risk-level-consistency.ts
@@ -1,4 +1,4 @@
-import type { LintRule } from '../types';
+import type { LintDiagnostic, LintRule } from '../types';
 
 export const riskLevelConsistencyRule: LintRule = {
   id: 'risk-level-consistency',
@@ -8,7 +8,7 @@ export const riskLevelConsistencyRule: LintRule = {
   run(context) {
     const { risk_level, destructive_operations, external_references, risk_factors } =
       context.frontmatter;
-    const diagnostics = [];
+    const diagnostics: LintDiagnostic[] = [];
 
     if (
       risk_level === 'low' &&
@@ -17,7 +17,7 @@ export const riskLevelConsistencyRule: LintRule = {
     ) {
       diagnostics.push({
         ruleId: 'risk-level-consistency',
-        severity: 'warning' as const,
+        severity: 'warning',
         message: `risk_level is "low" but ${destructive_operations.length} destructive operation(s) declared — consider "medium" or higher`,
         field: 'risk_level',
       });
@@ -27,7 +27,7 @@ export const riskLevelConsistencyRule: LintRule = {
       if (!Array.isArray(risk_factors) || !risk_factors.includes('network_access')) {
         diagnostics.push({
           ruleId: 'risk-level-consistency',
-          severity: 'warning' as const,
+          severity: 'warning',
           message:
             'external_references declared but risk_factors does not include "network_access"',
           field: 'risk_factors',

--- a/packages/core/src/utils/url-scanner.ts
+++ b/packages/core/src/utils/url-scanner.ts
@@ -1,6 +1,13 @@
 import type { DossierFrontmatter, ExternalReference } from '../types';
 
+// Matches http/https URLs, stopping at whitespace and common delimiters
+// that typically surround URLs in markdown/text (quotes, angle brackets,
+// parentheses, commas, semicolons, backticks).
 const URL_REGEX = /https?:\/\/[^\s"'<>\])|,;`]+/g;
+
+// Strip trailing periods and closing parens that are often part of
+// surrounding prose rather than the URL itself (e.g. "see https://x.com).")
+const TRAILING_PUNCTUATION = /[.)]+$/;
 
 const PLACEHOLDER_PATTERNS = [
   /^https?:\/\/example\.(com|org|net)/,
@@ -19,7 +26,7 @@ export function isPlaceholderUrl(url: string): boolean {
 
 export function scanBodyForUrls(body: string): string[] {
   const matches = body.match(URL_REGEX) || [];
-  const cleaned = matches.map((url) => url.replace(/[.)]+$/, ''));
+  const cleaned = matches.map((url) => url.replace(TRAILING_PUNCTUATION, ''));
   const unique = [...new Set(cleaned)];
   return unique.filter((url) => !isPlaceholderUrl(url));
 }
@@ -42,11 +49,11 @@ export function collectDeclaredUrls(frontmatter: DossierFrontmatter): string[] {
   }
 
   if (typeof frontmatter.homepage === 'string') {
-    urls.push(frontmatter.homepage as string);
+    urls.push(frontmatter.homepage);
   }
 
   if (typeof frontmatter.repository === 'string') {
-    urls.push(frontmatter.repository as string);
+    urls.push(frontmatter.repository);
   }
 
   if (Array.isArray(frontmatter.authors)) {


### PR DESCRIPTION
## Summary
- Add explicit `LintDiagnostic[]` type annotation in `risk-level-consistency.ts` and remove redundant `as const` casts
- Document `URL_REGEX` character class choices and extract `TRAILING_PUNCTUATION` to a named module-level constant in `url-scanner.ts`
- Remove redundant `as string` casts where `typeof` narrowing already provides type safety

Closes #262

## Test plan
- All 800 existing tests pass (166 core + 120 mcp-server + 392 cli + 122 registry)
- Build compiles cleanly
- No behavioral changes — strictly type safety and readability improvements

Co-Authored-By: Claude <noreply@anthropic.com>