### PR TITLE
docs: add external reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ https://raw.githubusercontent.com/imboard-ai/ai-dossier/main/examples/git-projec
 
 - Use the CLI tool (`ai-dossier verify`) to verify checksums/signatures before execution
 - Prefer MCP mode for sandboxed, permissioned operations
+- **External reference declaration**: Dossiers that fetch or link to external URLs must declare them in `external_references` with trust levels. The linter flags undeclared URLs, and the MCP server's `read_dossier` tool returns `security_notices` for any undeclared external URLs found in the body. This mitigates transitive trust risks from unvetted external content.
 - See [SECURITY_STATUS.md](./SECURITY_STATUS.md) for current guarantees and limitations
 
 ---

--- a/docs/guides/dossier-guide.md
+++ b/docs/guides/dossier-guide.md
@@ -109,6 +109,13 @@ Dossiers support **structured JSON metadata** via frontmatter, providing determi
 - `outputs.files`: Files created/modified
 - `outputs.artifacts`: Generated scripts, logs, reports
 
+### External References
+
+- `content_scope`: Whether the body is `"self-contained"` or `"references-external"`
+- `external_references`: Manifest of external URLs with `type`, `trust_level`, and `required` status
+  - Linter rule `external-references-declared` enforces that all body URLs are declared
+  - Scripts with `trust_level: "unknown"` require explicit user approval
+
 ### Validation & Safety
 
 - `risk_level`: Risk assessment (`low`, `medium`, `high`, `critical`)

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -211,6 +211,54 @@ Dossier Schema metadata is embedded at the **top of the Markdown file** using JS
 
 ---
 
+### External References
+
+#### `content_scope`
+- **Type**: Enum
+- **Values**: `"self-contained"`, `"references-external"`
+- **Description**: Whether the dossier body is self-contained or references external URLs. Set to `"references-external"` when the body contains any external URLs (the linter enforces this).
+
+#### `external_references`
+- **Type**: Array of objects
+- **Description**: Manifest of all external resources referenced in the dossier body. Required when `content_scope` is `"references-external"`.
+- **Fields**:
+  - `url` (required): URL or URL prefix of the external resource
+  - `description` (required): What this external resource is used for
+  - `type` (required): Type of resource — `"download"`, `"api"`, `"documentation"`, `"script"`, `"config"`, `"image"`, `"dossier"`, or `"other"`
+  - `trust_level` (required): Trust level — `"trusted"`, `"user-verified"`, or `"unknown"`
+  - `required` (required): Whether this external resource is required for execution
+
+**Example**:
+```json
+"content_scope": "references-external",
+"external_references": [
+  {
+    "url": "https://registry.npmjs.org",
+    "description": "NPM registry for package installation",
+    "type": "download",
+    "trust_level": "trusted",
+    "required": true
+  },
+  {
+    "url": "https://raw.githubusercontent.com/org/repo/main/setup.sh",
+    "description": "Bootstrap script fetched during setup",
+    "type": "script",
+    "trust_level": "user-verified",
+    "required": false
+  }
+]
+```
+
+**Linter rule**: `external-references-declared` (default severity: `error`) scans the body for URLs and cross-references them against declared `external_references`. Placeholder URLs (`example.com`, `localhost`, `${VAR}`) are automatically excluded. URLs from `tools_required[].install_url`, `homepage`, `repository`, and `authors[].url` are auto-exempt.
+
+**Recommended agent behavior** (see [PROTOCOL.md](../../PROTOCOL.md) for full details):
+- URLs declared in `external_references` → Proceed (author has acknowledged the dependency)
+- URLs with `type: "script"` and `trust_level: "unknown"` → Require explicit user approval
+- URLs NOT declared in `external_references` → Warn user (URL is not in the trust chain)
+- `content_scope` is `"self-contained"` but body has URLs → Treat as configuration error
+
+---
+
 ### Risk & Duration
 
 #### `risk_level`

--- a/examples/security/external-references-example.ds.md
+++ b/examples/security/external-references-example.ds.md
@@ -1,0 +1,71 @@
+---dossier
+{
+  "dossier_schema_version": "1.0.0",
+  "title": "External References Example",
+  "version": "1.0.0",
+  "protocol_version": "1.0",
+  "status": "Stable",
+  "objective": "Demonstrate how to properly declare external references in a dossier",
+  "category": ["security"],
+  "tags": ["external-references", "trust", "example"],
+  "risk_level": "low",
+  "content_scope": "references-external",
+  "external_references": [
+    {
+      "url": "https://raw.githubusercontent.com/imboard-ai/ai-dossier/main/README.md",
+      "description": "Project README fetched for validation",
+      "type": "documentation",
+      "trust_level": "trusted",
+      "required": true
+    },
+    {
+      "url": "https://registry.npmjs.org/@ai-dossier/cli",
+      "description": "NPM registry metadata for version check",
+      "type": "api",
+      "trust_level": "trusted",
+      "required": false
+    }
+  ]
+}
+---
+
+# External References Example
+
+This example dossier demonstrates how to properly declare external references when your dossier body links to or fetches external URLs.
+
+## Why Declare External References?
+
+When a dossier body contains external URLs, those URLs represent a **transitive trust risk** — the dossier's checksum and signature verify the *instructions*, but not the content at those URLs. Declaring external references makes this explicit:
+
+1. **Transparency**: Readers can see all external dependencies at a glance
+2. **Trust chain**: Each URL has an explicit trust level
+3. **Linting**: The `external-references-declared` linter rule catches undeclared URLs
+4. **Agent behavior**: LLM agents can make informed decisions about fetching external content
+
+## Schema Fields
+
+Set `content_scope` to `"references-external"` and declare each URL in `external_references` with its type, trust level, and whether it's required. See the [schema reference](../../docs/reference/schema.md#external-references) for full field documentation.
+
+## Actions to Perform
+
+### Step 1: Verify External References
+
+Fetch the README from the project repository:
+https://raw.githubusercontent.com/imboard-ai/ai-dossier/main/README.md
+
+Confirm it contains the expected project description.
+
+### Step 2: Check NPM Registry (Optional)
+
+Query the NPM registry for the latest CLI version:
+https://registry.npmjs.org/@ai-dossier/cli
+
+## Validation
+
+- [ ] All external URLs in the body are declared in `external_references`
+- [ ] `content_scope` is set to `"references-external"`
+
+## Notes
+
+- URL prefix matching is supported: declaring `https://registry.npmjs.org` covers `https://registry.npmjs.org/@ai-dossier/cli`
+- See [PROTOCOL.md](../../PROTOCOL.md) for linter rule details and auto-exempt URL patterns

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -41,7 +41,7 @@ LLM:  "Found project-init dossier v1.0.0. Analyzing prerequisites..."
 ### 🛠️ Tools
 
 - **`list_dossiers`** - Discover available dossiers
-- **`read_dossier`** - Get dossier content and metadata
+- **`read_dossier`** - Get dossier content and metadata. Returns `security_notices` when undeclared external URLs are detected in the body.
 - **`get_registry`** - Understand dossier relationships
 - **`validate_dossier`** - Check specification compliance
 - **`verify_dossier`** - 🔒 Verify integrity and authenticity (security)


### PR DESCRIPTION
## Summary
- Add `content_scope` and `external_references` field documentation to schema reference (`docs/reference/schema.md`)
- Add external references section to dossier guide (`docs/guides/dossier-guide.md`)
- Document `security_notices` output in `read_dossier` tool description (`mcp-server/README.md`)
- Add external reference declaration mention to README security section
- Add example dossier demonstrating proper `external_references` usage (`examples/security/external-references-example.ds.md`)

Closes #261

## Test plan
- All 122 existing tests pass (docs-only change, no code modified)
- Verify Markdown renders correctly on GitHub
- Verify JSON examples in schema.md are valid

Co-Authored-By: Claude <noreply@anthropic.com>