### PR TITLE
fix(registry): normalize CORS origins for case-insensitive matching

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -101,7 +101,7 @@ registry/
 
 The registry enforces origin-based CORS with CSRF protection:
 
-- **Allowed origins**: `https://dossier.imboard.ai`, `https://registry.dossier.dev` (default). Override with the `CORS_ALLOWED_ORIGINS` environment variable (comma-separated list).
+- **Allowed origins**: `https://dossier.imboard.ai`, `https://registry.dossier.dev` (default). Override with the `CORS_ALLOWED_ORIGINS` environment variable (comma-separated list). Origins are normalized before comparison: hostnames are lowercased, default ports (80/443) are stripped, and trailing slashes are removed.
 - **Read-only requests** (`GET`, `HEAD`): allowed from any origin.
 - **Mutating requests** (`POST`, `PUT`, `PATCH`, `DELETE`): blocked with `403 ORIGIN_NOT_ALLOWED` if the browser origin is not on the allowlist.
 - **Non-browser clients** (no `Origin` header): always allowed through.

--- a/registry/docs/planning/registry-api-design.md
+++ b/registry/docs/planning/registry-api-design.md
@@ -516,6 +516,8 @@ Vary: Origin
 Default allowed origins: `https://dossier.imboard.ai`, `https://registry.dossier.dev`.
 Override via `CORS_ALLOWED_ORIGINS` env var (comma-separated).
 
+**Origin normalization:** Both request origins and allowlist entries are normalized before comparison using the URL API. This lowercases the protocol and hostname, strips default ports (80 for HTTP, 443 for HTTPS), and removes trailing slashes. For example, `https://DOSSIER.IMBOARD.AI:443/` is normalized to `https://dossier.imboard.ai`.
+
 ### CSRF Protection
 
 Mutating requests (`POST`, `PUT`, `PATCH`, `DELETE`) from browser origins not on the allowlist are rejected with:

--- a/registry/lib/cors.ts
+++ b/registry/lib/cors.ts
@@ -6,6 +6,20 @@ const log = createLogger('cors');
 
 const DEFAULT_ALLOWED_ORIGINS = ['https://dossier.imboard.ai', 'https://registry.dossier.dev'];
 
+/**
+ * Normalizes an origin string for case-insensitive, port-aware comparison.
+ * Uses the URL API which lowercases protocol/hostname, strips default ports
+ * (80 for http, 443 for https), and removes trailing slashes.
+ */
+function normalizeOrigin(origin: string): string {
+  try {
+    return new URL(origin).origin;
+  } catch {
+    log.warn('Failed to parse origin as URL, falling back to lowercase', { origin });
+    return origin.toLowerCase();
+  }
+}
+
 function getAllowedOrigins(): string[] {
   const envOrigins = process.env.CORS_ALLOWED_ORIGINS;
   if (envOrigins) {
@@ -17,9 +31,9 @@ function getAllowedOrigins(): string[] {
         filtered: filtered.length,
       });
     }
-    return filtered;
+    return filtered.map(normalizeOrigin);
   }
-  return DEFAULT_ALLOWED_ORIGINS;
+  return DEFAULT_ALLOWED_ORIGINS.map(normalizeOrigin);
 }
 
 /**
@@ -31,18 +45,20 @@ function getAllowedOrigins(): string[] {
 export function setCorsHeaders(
   req: VercelRequest,
   res: VercelResponse,
-  allowedOrigins?: string[]
+  allowedOrigins?: string[],
+  preNormalizedOrigin?: string
 ): void {
   const origin = req.headers.origin;
   const allowed = allowedOrigins ?? getAllowedOrigins();
+  const normalizedOrigin = preNormalizedOrigin ?? (origin ? normalizeOrigin(origin) : undefined);
 
-  if (origin && allowed.includes(origin)) {
-    res.setHeader('Access-Control-Allow-Origin', origin);
+  if (normalizedOrigin && allowed.includes(normalizedOrigin)) {
+    res.setHeader('Access-Control-Allow-Origin', normalizedOrigin);
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS, HEAD');
     res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type, Accept');
     res.setHeader('Vary', 'Origin');
   } else if (origin) {
-    log.warn('Rejected origin', { origin });
+    log.warn('Rejected origin', { origin, normalizedOrigin });
   }
 }
 
@@ -63,8 +79,10 @@ const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
  *   since CSRF is a browser-only attack vector.
  */
 export function handleCors(req: VercelRequest, res: VercelResponse): boolean {
+  const origin = req.headers.origin;
+  const normalizedOrigin = origin ? normalizeOrigin(origin) : undefined;
   const allowedOrigins = getAllowedOrigins();
-  setCorsHeaders(req, res, allowedOrigins);
+  setCorsHeaders(req, res, allowedOrigins, normalizedOrigin);
 
   if (req.method === 'OPTIONS') {
     res.status(HTTP_STATUS.NO_CONTENT).end();
@@ -75,9 +93,16 @@ export function handleCors(req: VercelRequest, res: VercelResponse): boolean {
   // GET/HEAD are read-only so they pass regardless of origin. Requests without
   // an Origin header come from non-browser clients (curl, CLI) which are not
   // susceptible to CSRF, so they are also allowed through.
-  const origin = req.headers.origin;
-  if (origin && MUTATING_METHODS.has(req.method ?? '') && !allowedOrigins.includes(origin)) {
-    log.warn('Blocked mutating request from disallowed origin', { method: req.method, origin });
+  if (
+    normalizedOrigin &&
+    MUTATING_METHODS.has(req.method ?? '') &&
+    !allowedOrigins.includes(normalizedOrigin)
+  ) {
+    log.warn('Blocked mutating request from disallowed origin', {
+      method: req.method,
+      origin,
+      normalizedOrigin,
+    });
     res.status(HTTP_STATUS.FORBIDDEN).json({
       error: { code: 'ORIGIN_NOT_ALLOWED', message: 'Origin not allowed for mutating requests' },
     });

--- a/registry/tests/security.test.ts
+++ b/registry/tests/security.test.ts
@@ -380,6 +380,83 @@ describe('changelog sanitization', () => {
   });
 });
 
+describe('CORS origin normalization', () => {
+  it('matches case-insensitive origins (blocks bypass via uppercase)', async () => {
+    const { setCorsHeaders } = await import('../lib/cors');
+    const { headers, req, res } = createCorsReqRes('https://DOSSIER.IMBOARD.AI');
+
+    setCorsHeaders(req, res);
+
+    expect(headers['Access-Control-Allow-Origin']).toBe('https://dossier.imboard.ai');
+  });
+
+  it('matches origins with default port 443 stripped', async () => {
+    const { setCorsHeaders } = await import('../lib/cors');
+    const { headers, req, res } = createCorsReqRes('https://dossier.imboard.ai:443');
+
+    setCorsHeaders(req, res);
+
+    expect(headers['Access-Control-Allow-Origin']).toBe('https://dossier.imboard.ai');
+  });
+
+  it('matches origins with trailing slash stripped', async () => {
+    const { setCorsHeaders } = await import('../lib/cors');
+    const { headers, req, res } = createCorsReqRes('https://dossier.imboard.ai/');
+
+    setCorsHeaders(req, res);
+
+    expect(headers['Access-Control-Allow-Origin']).toBe('https://dossier.imboard.ai');
+  });
+
+  it('rejects origin with non-default port', async () => {
+    const { setCorsHeaders } = await import('../lib/cors');
+    const { headers, req, res } = createCorsReqRes('https://dossier.imboard.ai:8443');
+
+    setCorsHeaders(req, res);
+
+    expect(headers['Access-Control-Allow-Origin']).toBeUndefined();
+  });
+
+  function createCorsHandlerReqRes(method: string, origin: string) {
+    let statusCode = 0;
+    const resHeaders: Record<string, string> = {};
+    const req = createMockReq({ method, headers: { origin } });
+    const res = {
+      setHeader: (key: string, value: string) => {
+        resHeaders[key] = value;
+      },
+      status: (code: number) => {
+        statusCode = code;
+        return { json: () => {}, end: () => {} };
+      },
+    };
+    return { req, res, getStatus: () => statusCode, resHeaders };
+  }
+
+  it('allows case-insensitive POST from allowed origin (CSRF bypass prevention)', async () => {
+    const { handleCors } = await import('../lib/cors');
+    const { req, res, getStatus } = createCorsHandlerReqRes('POST', 'https://DOSSIER.IMBOARD.AI');
+
+    const handled = handleCors(req, res);
+
+    expect(handled).toBe(false);
+    expect(getStatus()).toBe(0);
+  });
+
+  it('allows POST from origin with default port (port bypass prevention)', async () => {
+    const { handleCors } = await import('../lib/cors');
+    const { req, res, getStatus } = createCorsHandlerReqRes(
+      'POST',
+      'https://dossier.imboard.ai:443'
+    );
+
+    const handled = handleCors(req, res);
+
+    expect(handled).toBe(false);
+    expect(getStatus()).toBe(0);
+  });
+});
+
 describe('CORS headers not leaked to disallowed origins', () => {
   it('does not set Allow-Methods or Allow-Headers for rejected origins', async () => {
     const { setCorsHeaders } = await import('../lib/cors');


### PR DESCRIPTION
## Summary
- Adds `normalizeOrigin()` using the URL API to lowercase hostnames, strip default ports (80/443), and remove trailing slashes before CORS origin comparison
- Prevents case-insensitive origin bypass (`https://DOSSIER.IMBOARD.AI`) and default-port bypass (`https://dossier.imboard.ai:443`)
- Enhances rejection logs with both raw and normalized origin values for easier debugging

Closes #267

## Test plan
- [x] 6 new tests covering case-insensitive matching, default port stripping, trailing slash removal, non-default port rejection, and CSRF bypass prevention for both case and port variants
- [x] All 826 existing tests pass (no regressions)
- [x] Biome lint passes

Co-Authored-By: Claude <noreply@anthropic.com>