### PR TITLE
fix(cli): add input validation for export paths and pagination bounds

### DIFF
--- a/cli/src/__tests__/commands/export.test.ts
+++ b/cli/src/__tests__/commands/export.test.ts
@@ -110,12 +110,63 @@ describe('export command', () => {
     const program = createTestProgram();
     registerExportCommand(program);
 
-    await program.parseAsync(['node', 'dossier', 'export', 'my-dossier', '-o', '/tmp/out.ds.md']);
+    await program.parseAsync(['node', 'dossier', 'export', 'my-dossier', '-o', 'output/out.ds.md']);
 
     expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
       expect.stringContaining('out.ds.md'),
       'content',
       'utf8'
     );
+  });
+
+  it('should reject absolute output paths', async () => {
+    vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
+      result: { content: 'content', digest: null, _registry: 'public' },
+      errors: [],
+    });
+
+    const program = createTestProgram();
+    registerExportCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'dossier', 'export', 'my-dossier', '-o', '/tmp/out.ds.md'])
+    ).rejects.toThrow();
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('must be relative'));
+    expect(mockedFs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should reject path traversal in output path', async () => {
+    vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
+      result: { content: 'content', digest: null, _registry: 'public' },
+      errors: [],
+    });
+
+    const program = createTestProgram();
+    registerExportCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'dossier', 'export', 'my-dossier', '-o', '../../../etc/out.md'])
+    ).rejects.toThrow();
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('must not contain ".."'));
+    expect(mockedFs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should reject embedded path traversal', async () => {
+    vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
+      result: { content: 'content', digest: null, _registry: 'public' },
+      errors: [],
+    });
+
+    const program = createTestProgram();
+    registerExportCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'dossier', 'export', 'my-dossier', '-o', 'foo/../bar/out.md'])
+    ).rejects.toThrow();
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('must not contain ".."'));
+    expect(mockedFs.writeFileSync).not.toHaveBeenCalled();
   });
 });

--- a/cli/src/__tests__/commands/list.test.ts
+++ b/cli/src/__tests__/commands/list.test.ts
@@ -8,7 +8,19 @@ import { createTestProgram } from '../helpers/test-utils';
 
 vi.mock('node:fs');
 vi.mock('../../multi-registry');
-vi.mock('../../helpers');
+vi.mock('../../helpers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../helpers')>();
+  return {
+    ...actual,
+    parseListSource: vi.fn(),
+    formatTable: vi.fn(),
+    findDossierFilesLocal: vi.fn(),
+    parseDossierMetadataLocal: vi.fn(),
+    findDossierFilesGitHub: vi.fn(),
+    fetchDossierMetadata: vi.fn(),
+    printRegistryErrors: vi.fn(),
+  };
+});
 vi.mock('../../config');
 
 const mockedFs = vi.mocked(fs);
@@ -115,6 +127,70 @@ describe('list command', () => {
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining('Showing partial results (1/2 registries responded)')
       );
+    });
+
+    it('should clamp page to minimum of 1', async () => {
+      vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
+        dossiers: [
+          {
+            name: 'test',
+            version: '1.0.0',
+            title: 'Test',
+            category: 'devops',
+            _registry: 'public',
+          },
+        ] as any,
+        total: 1,
+        errors: [],
+      });
+
+      const program = createTestProgram();
+      registerListCommand(program);
+
+      await expect(
+        program.parseAsync(['node', 'dossier', 'list', '--source', 'registry', '--page', '-5'])
+      ).rejects.toThrow();
+
+      expect(multiRegistry.multiRegistryList).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1 })
+      );
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Page'));
+    });
+
+    it('should clamp perPage to maximum of 1000', async () => {
+      vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
+        dossiers: [
+          {
+            name: 'test',
+            version: '1.0.0',
+            title: 'Test',
+            category: 'devops',
+            _registry: 'public',
+          },
+        ] as any,
+        total: 1,
+        errors: [],
+      });
+
+      const program = createTestProgram();
+      registerListCommand(program);
+
+      await expect(
+        program.parseAsync([
+          'node',
+          'dossier',
+          'list',
+          '--source',
+          'registry',
+          '--per-page',
+          '99999',
+        ])
+      ).rejects.toThrow();
+
+      expect(multiRegistry.multiRegistryList).toHaveBeenCalledWith(
+        expect.objectContaining({ perPage: 1000 })
+      );
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Per-page'));
     });
 
     it('should show empty message for registry', async () => {

--- a/cli/src/__tests__/commands/search.test.ts
+++ b/cli/src/__tests__/commands/search.test.ts
@@ -153,6 +153,78 @@ describe('search command', () => {
     );
   });
 
+  it('should clamp page to minimum of 1', async () => {
+    vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
+      dossiers: [
+        {
+          name: 'test',
+          title: 'Test',
+          description: 'test dossier',
+          tags: ['test'],
+          _registry: 'public',
+        },
+      ] as any,
+      total: 1,
+      errors: [],
+    });
+
+    const program = createTestProgram();
+    registerSearchCommand(program);
+
+    await program.parseAsync(['node', 'dossier', 'search', 'test', '--page', '-5']);
+
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Page'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Found 1'));
+  });
+
+  it('should clamp perPage to maximum of 1000', async () => {
+    vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
+      dossiers: [
+        {
+          name: 'test',
+          title: 'Test',
+          description: 'test dossier',
+          tags: ['test'],
+          _registry: 'public',
+        },
+      ] as any,
+      total: 1,
+      errors: [],
+    });
+
+    const program = createTestProgram();
+    registerSearchCommand(program);
+
+    await program.parseAsync(['node', 'dossier', 'search', 'test', '--per-page', '99999']);
+
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Per-page'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Found 1'));
+  });
+
+  it('should clamp perPage to minimum of 1', async () => {
+    vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
+      dossiers: [
+        {
+          name: 'test',
+          title: 'Test',
+          description: 'test dossier',
+          tags: ['test'],
+          _registry: 'public',
+        },
+      ] as any,
+      total: 1,
+      errors: [],
+    });
+
+    const program = createTestProgram();
+    registerSearchCommand(program);
+
+    await program.parseAsync(['node', 'dossier', 'search', 'test', '--per-page', '0']);
+
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Per-page'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Found 1'));
+  });
+
   it('should log warning when content fetch fails for a dossier', async () => {
     vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
       dossiers: [

--- a/cli/src/__tests__/helpers/setup.ts
+++ b/cli/src/__tests__/helpers/setup.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, vi } from 'vitest';
 beforeEach(() => {
   vi.spyOn(console, 'log').mockImplementation(() => {});
   vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
 });
 
 afterEach(() => {

--- a/cli/src/commands/export.ts
+++ b/cli/src/commands/export.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { Command } from 'commander';
-import { printRegistryErrors } from '../helpers';
+import { printRegistryErrors, validateRelativePath } from '../helpers';
 import { multiRegistryGetContent } from '../multi-registry';
 import { parseNameVersion } from '../registry-client';
 
@@ -45,6 +45,15 @@ export function registerExportCommand(program: Command): void {
       }
 
       const outputPath = options.output || `${dossierName.replace(/\//g, '-')}.ds.md`;
+
+      try {
+        validateRelativePath(outputPath);
+      } catch (err: unknown) {
+        console.error(`\n❌ ${(err as Error).message}\n`);
+        process.exit(1);
+        return;
+      }
+
       const outputDir = path.dirname(path.resolve(outputPath));
 
       try {

--- a/cli/src/commands/list.ts
+++ b/cli/src/commands/list.ts
@@ -10,6 +10,7 @@ import {
   formatTable,
   parseDossierMetadataLocal,
   parseListSource,
+  parsePaginationParams,
   printRegistryErrors,
 } from '../helpers';
 import { multiRegistryList } from '../multi-registry';
@@ -62,8 +63,7 @@ Multi-registry note:
         }
 
         if (options.source === 'registry') {
-          const page = parseInt(options.page || '1', 10) || 1;
-          const perPage = parseInt(options.perPage || '20', 10) || 20;
+          const { page, perPage } = parsePaginationParams(options.page, options.perPage);
           const showRegistryLabel = resolveRegistries().length > 1;
 
           try {

--- a/cli/src/commands/search.ts
+++ b/cli/src/commands/search.ts
@@ -1,7 +1,7 @@
 import type { Command } from 'commander';
 import { resolveRegistries } from '../config';
 import { loadCredentials } from '../credentials';
-import { printRegistryErrors } from '../helpers';
+import { parsePaginationParams, printRegistryErrors } from '../helpers';
 import type { LabeledDossierListItem } from '../multi-registry';
 import { multiRegistryList } from '../multi-registry';
 import { getClientForRegistry } from '../registry-client';
@@ -32,9 +32,8 @@ export function registerSearchCommand(program: Command): void {
           content?: boolean;
         }
       ) => {
-        const page = parseInt(options.page, 10) || 1;
-        const perPage = parseInt(options.perPage, 10) || 20;
-        const limit = options.limit ? parseInt(options.limit, 10) : undefined;
+        const { page, perPage } = parsePaginationParams(options.page, options.perPage);
+        const limit = options.limit ? Math.max(1, parseInt(options.limit, 10) || 1) : undefined;
 
         let allDossiers: LabeledDossierListItem[];
         try {

--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -45,6 +45,9 @@ export const OFFICIAL_KMS_KEYS = [
 // Re-export validation constants from core (single source of truth)
 export { RECOMMENDED_FIELDS, REQUIRED_FIELDS, VALID_RISK_LEVELS, VALID_STATUSES };
 
+/** Maximum results per page for CLI pagination commands. */
+export const MAX_PER_PAGE = 1000;
+
 // ============================================================================
 // TypeScript interfaces
 // ============================================================================
@@ -99,6 +102,46 @@ export interface GitHubFile {
 // ============================================================================
 // Security helpers
 // ============================================================================
+
+/**
+ * Validate that a path is relative and contains no ".." traversal.
+ * @throws Error if the path is absolute or contains path traversal.
+ */
+export function validateRelativePath(filePath: string): void {
+  if (path.isAbsolute(filePath)) {
+    throw new Error(`Path '${filePath}' must be relative (absolute paths are not allowed)`);
+  }
+  if (filePath.split(path.sep).includes('..') || filePath.split('/').includes('..')) {
+    throw new Error(`Path '${filePath}' must not contain ".." (path traversal is not allowed)`);
+  }
+}
+
+/**
+ * Parse and clamp pagination options from CLI string arguments.
+ * Logs a warning when values are clamped.
+ */
+export function parsePaginationParams(
+  pageStr: string | undefined,
+  perPageStr: string | undefined,
+  defaults: { page: number; perPage: number } = { page: 1, perPage: 20 }
+): { page: number; perPage: number } {
+  const parsedPage = parseInt(pageStr || String(defaults.page), 10);
+  const rawPage = Number.isNaN(parsedPage) ? defaults.page : parsedPage;
+  const parsedPerPage = parseInt(perPageStr || String(defaults.perPage), 10);
+  const rawPerPage = Number.isNaN(parsedPerPage) ? defaults.perPage : parsedPerPage;
+
+  const page = Math.max(1, rawPage);
+  const perPage = Math.min(MAX_PER_PAGE, Math.max(1, rawPerPage));
+
+  if (rawPage !== page) {
+    console.warn(`⚠️  Page ${rawPage} clamped to ${page} (minimum 1)`);
+  }
+  if (rawPerPage !== perPage) {
+    console.warn(`⚠️  Per-page ${rawPerPage} clamped to ${perPage} (range 1–${MAX_PER_PAGE})`);
+  }
+
+  return { page, perPage };
+}
 
 /**
  * Validate a dossier name to prevent path traversal attacks.


### PR DESCRIPTION
## Summary
- Reject absolute paths and `..` path traversal in `export --output` using a shared `validateRelativePath` helper
- Clamp `--page` (min 1) and `--per-page` (1–1000) in `list` and `search` commands via shared `parsePaginationParams` helper with user-facing warnings
- Extract `MAX_PER_PAGE` constant and reusable validation/pagination utilities into `cli/src/helpers.ts`

Closes #277

## Test plan
- [x] 28 tests for changed commands (export, list, search) — all passing
- [x] 400 total CLI tests — no regressions
- [x] Path traversal: absolute paths, `..` sequences, embedded traversal all rejected
- [x] Pagination: negative page, zero per-page, and oversized per-page all clamped with warnings

Co-Authored-By: Claude <noreply@anthropic.com>