### PR TITLE
docs(cli): add registry commands to README and quick start

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -148,6 +148,98 @@ safe-run-dossier https://example.com/dossier.ds.md cursor
 
 ---
 
+## Registry Commands
+
+### Search
+
+Search for dossiers across all configured registries:
+
+```bash
+# Basic search
+ai-dossier search "deployment"
+
+# Filter by category
+ai-dossier search "ci" --category devops
+
+# Search dossier body content (-c is short for --content)
+ai-dossier search "docker" -c
+
+# Limit total results
+ai-dossier search "setup" --limit 50
+
+# Paginate results
+ai-dossier search "setup" --page 2 --per-page 10
+
+# JSON output
+ai-dossier search "auth" --json
+```
+
+### List
+
+List dossiers from the registry, a local directory, or a GitHub repo:
+
+```bash
+# List all registry dossiers
+ai-dossier list --source registry
+
+# List with JSON output
+ai-dossier list --source registry --json
+
+# Paginate registry results
+ai-dossier list --source registry --page 2 --per-page 10
+
+# Filter by category (registry mode)
+ai-dossier list --source registry --category security
+
+# List local dossiers (-r is short for --recursive)
+ai-dossier list .
+ai-dossier list ./dossiers -r
+
+# List from a GitHub repo
+ai-dossier list github:owner/repo
+
+# Filter local/GitHub results by risk level or signed status
+ai-dossier list . --risk high
+ai-dossier list . --signed-only
+```
+
+### Pull
+
+Download dossiers from the registry to the local cache (`~/.dossier/cache/`):
+
+```bash
+# Pull a dossier (latest version)
+ai-dossier pull org/my-dossier
+
+# Pull a specific version
+ai-dossier pull org/my-dossier@1.2.0
+
+# Pull multiple dossiers
+ai-dossier pull org/dossier-a org/dossier-b
+
+# Force re-download
+ai-dossier pull org/my-dossier --force
+```
+
+Pulled dossiers are cached locally with checksum verification. Subsequent `pull` calls skip the download if the version is already cached (use `--force` to override).
+
+### Export
+
+Download a dossier and save it to a local file:
+
+```bash
+# Export to default filename (org-name.ds.md)
+ai-dossier export org/my-dossier
+
+# Export to a specific file
+ai-dossier export org/my-dossier -o ./local-copy.ds.md
+
+# Print to stdout (for piping)
+ai-dossier export org/my-dossier --stdout
+```
+
+---
+
 ## Multi-Registry Resolution
 
 The CLI queries all configured registries in parallel when resolving dossiers (e.g., `dossier get`, `dossier run`, `dossier pull`). This uses `Promise.allSettled()` so a single registry failure does not block results from other registries.

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -54,6 +54,9 @@ program
     `Quick Start:
   $ ai-dossier init                    Set up ~/.dossier/ directory
   $ ai-dossier search <query>          Find dossiers in the registry
+  $ ai-dossier list --source registry  List all registry dossiers
+  $ ai-dossier pull <name>             Download a dossier to local cache
+  $ ai-dossier export <name>           Save a dossier to a local file
   $ ai-dossier run <file-or-name>      Verify and execute a dossier
   $ ai-dossier create [file]           Create a new dossier
 

--- a/cli/src/commands/export.ts
+++ b/cli/src/commands/export.ts
@@ -5,6 +5,7 @@ import { printRegistryErrors } from '../helpers';
 import { multiRegistryGetContent } from '../multi-registry';
 import { parseNameVersion } from '../registry-client';
 
+/** Registers the `export` command — downloads a dossier and saves it to a local file. */
 export function registerExportCommand(program: Command): void {
   program
     .command('export')

--- a/cli/src/commands/list.ts
+++ b/cli/src/commands/list.ts
@@ -14,6 +14,7 @@ import {
 } from '../helpers';
 import { multiRegistryList } from '../multi-registry';
 
+/** Registers the `list` command — lists dossiers from registry, directory, or GitHub repo. */
 export function registerListCommand(program: Command): void {
   program
     .command('list')

--- a/cli/src/commands/pull.ts
+++ b/cli/src/commands/pull.ts
@@ -7,6 +7,7 @@ import { printRegistryErrors, safeDossierPath } from '../helpers';
 import { multiRegistryGetContent, multiRegistryGetDossier } from '../multi-registry';
 import { parseNameVersion } from '../registry-client';
 
+/** Registers the `pull` command — downloads dossiers from the registry to local cache. */
 export function registerPullCommand(program: Command): void {
   program
     .command('pull')

--- a/cli/src/commands/search.ts
+++ b/cli/src/commands/search.ts
@@ -6,6 +6,7 @@ import type { LabeledDossierListItem } from '../multi-registry';
 import { multiRegistryList } from '../multi-registry';
 import { getClientForRegistry } from '../registry-client';
 
+/** Registers the `search` command — searches for dossiers across all configured registries. */
 export function registerSearchCommand(program: Command): void {
   program
     .command('search')


### PR DESCRIPTION
## Summary
- Add documentation for `search`, `list`, `pull`, and `export` commands to cli/README.md with usage examples and all options
- Add `list`, `pull`, `export` to quick start help text in `cli/src/cli.ts`
- Add JSDoc to `registerSearchCommand`, `registerListCommand`, `registerExportCommand`, `registerPullCommand`

Closes #278

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 142 tests pass (`npm test`)
- [x] Lint clean (`npx biome check --write .`)
- [x] Documented options match actual CLI flags in source code

Co-Authored-By: Claude <noreply@anthropic.com>