### PR TITLE
docs: add multi-registry exit codes and failure modes (#283)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,6 +49,18 @@ The CLI supports multiple configured registries and queries them in parallel usi
 
 This allows partial failures to be surfaced without blocking successful results from other registries. See `docs/architecture/overview.md` for architectural details and `cli/src/multi-registry.ts` for implementation.
 
+### Multi-Registry Failure Modes
+
+| Scenario | Behavior | User-Facing Output |
+|----------|----------|-------------------|
+| **All registries timeout** | All `Promise.allSettled()` results are rejected. `get`/`run` exit 1 with per-registry errors. `list`/`search` exit 0 with empty results and per-registry warnings. | `❌ Not found in any registry` or per-registry error details |
+| **Network partition** | Same as timeout — unreachable registries produce rejected promises. Reachable registries return normally. | Partial results with `⚠️  Showing partial results (N/M registries responded)` |
+| **Auth failure across registries** | Registry returns 401/403. Caught as `RegistryError` and included in the `errors` array. Other registries still queried. | `⚠️  Registry 'name': unauthorized` or similar per-registry error |
+| **Invalid response format** | JSON parse failure caught in `RegistryClient`. Falls back to HTTP status text. Treated as a registry error. | `⚠️  Registry 'name': <HTTP status text>` |
+| **No registries configured** | CLI falls back to hardcoded public registry. Commands proceed normally. | No error — transparent fallback |
+
+See [cli/README.md](cli/README.md#exit-codes) for per-command exit codes.
+
 ## File Format
 
 Dossiers are Markdown files with JSON frontmatter using the `---dossier` delimiter:

--- a/cli/README.md
+++ b/cli/README.md
@@ -152,6 +152,30 @@ safe-run-dossier https://example.com/dossier.ds.md cursor
 
 The CLI queries all configured registries in parallel when resolving dossiers (e.g., `dossier get`, `dossier run`, `dossier pull`). This uses `Promise.allSettled()` so a single registry failure does not block results from other registries.
 
+### Exit Codes
+
+Multi-registry commands use the following exit codes:
+
+| Command | `0` (Success) | `1` (Failure) | `2` (Config/Runtime Error) |
+|---------|---------------|---------------|---------------------------|
+| `get` | Dossier found | Not found in any registry, or all registries failed | — |
+| `list --source registry` | Results returned, including when all registries fail (empty list + warnings) | Unexpected runtime error | — |
+| `search` | Results returned, including when all registries fail (no matches + warnings) | Unexpected runtime error | — |
+| `pull` | Always exits 0. Per-item errors are printed but do not affect the exit code. | — | — |
+| `run` | Dossier executed successfully | Not found, fetch failed, or verification failed | No LLM detected, unknown LLM, or execution failed |
+
+**Partial failures**: When some registries fail but at least one succeeds, `list` returns exit `0` with a warning showing which registries failed:
+```
+⚠️  Registry 'internal': connection timeout
+⚠️  Showing partial results (1/2 registries responded)
+```
+
+When **all** registries fail, `list` and `search` still exit `0` but display per-registry error warnings and report no results found.
+
+### No Registries Configured
+
+If no registries are configured (no user config, no project `.dossierrc.json`, no `DOSSIER_REGISTRY_URL` env var), the CLI falls back to the hardcoded public registry (`https://dossier-registry.vercel.app`). Commands proceed normally — there is no error or special exit code for this scenario.
+
 ### Error Handling
 
 All multi-registry operations return structured errors alongside results:
@@ -164,7 +188,7 @@ $ dossier get org/my-dossier
 
 When **all registries fail**, the CLI displays per-registry error details showing which registry failed and why. When at least one registry succeeds, the result is returned without surfacing errors from other registries.
 
-This means you can configure multiple registries for redundancy — the CLI will succeed as long as at least one registry can serve the requested dossier. Registries are queried in the order they appear in your configuration; the first successful response is used.
+This means you can configure multiple registries for redundancy — the CLI will succeed as long as at least one registry can serve the requested dossier. Registries are queried in parallel; for `get` and `run`, the first successful result (by configuration order) is used.
 
 ### Configuration
 


### PR DESCRIPTION
## Summary
- Add exit code table for multi-registry commands (`get`, `list`, `search`, `pull`, `run`) to `cli/README.md`
- Document "no registries configured" fallback behavior (transparent fallback to public registry)
- Add multi-registry failure modes table to `ARCHITECTURE.md` covering timeouts, network partitions, auth failures, and invalid response formats
- Fix misleading "queried in order" phrasing to clarify parallel queries with config-order priority

Closes #283

## Test plan
- [x] Verified exit codes against CLI source (`cli/src/commands/*.ts`)
- [x] Confirmed `list`/`search` exit 0 (not 1) when all registries fail via `Promise.allSettled`
- [x] All 142 existing tests pass
- [x] Lint check clean

Co-Authored-By: Claude <noreply@anthropic.com>