### PR TITLE
docs(registry): fix documentation findings from PR #282

### DIFF
--- a/registry/docs/planning/auth-and-publish.md
+++ b/registry/docs/planning/auth-and-publish.md
@@ -306,7 +306,8 @@ Same three distinct error codes as `GET /api/v1/me` above (`MISSING_TOKEN`, `TOK
 {
   "error": {
     "code": "FORBIDDEN",
-    "message": "You don't have permission to delete from 'other-org/*'"
+    "message": "Cannot publish to namespace 'other-org/some-dossier'",
+    "namespace": "other-org/some-dossier"
   }
 }
 ```

--- a/registry/docs/planning/mvp1-phase2-implementation.md
+++ b/registry/docs/planning/mvp1-phase2-implementation.md
@@ -45,7 +45,7 @@ Content-Type: application/json
 ```json
 {
   "namespace": "imboard-ai/development",
-  "content": "---\nname: setup-react\ntitle: Setup React Library\nversion: 1.0.0\n---\n\n# Instructions\n...",
+  "content": "---dossier\n{\n  \"name\": \"setup-react\",\n  \"title\": \"Setup React Library\",\n  \"version\": \"1.0.0\"\n}\n---\n\n# Instructions\n...",
   "changelog": "Initial publish"
 }
 ```
@@ -96,7 +96,7 @@ github: {
 
 ### Step 2: Create `lib/dossier.js` - Dossier parsing utilities
 Functions:
-- `parseFrontmatter(content)` - Extract YAML frontmatter from .ds.md
+- `parseFrontmatter(content)` - Extract JSON/YAML frontmatter from .ds.md
 - `validateDossier(parsed)` - Check required fields (name, title, version)
 - `buildFullName(namespace, name)` - Combine namespace + name
 
@@ -159,21 +159,25 @@ api/v1/
 ## Dossier Frontmatter Schema
 
 Required fields:
-```yaml
----
-name: setup-react        # Slug, lowercase, hyphens only
-title: Setup React Library
-version: 1.0.0           # Semver
+```json
+---dossier
+{
+  "name": "setup-react",
+  "title": "Setup React Library",
+  "version": "1.0.0"
+}
 ---
 ```
 
 Optional fields:
-```yaml
----
-description: Short description
-category: development
-tags: [react, library]
-author: yuvaldim
+```json
+---dossier
+{
+  "description": "Short description",
+  "category": "development",
+  "tags": ["react", "library"],
+  "author": "yuvaldim"
+}
 ---
 ```
 
@@ -182,7 +186,7 @@ author: yuvaldim
 ## Validation Rules
 
 1. **Content size:** Max 1MB
-2. **Frontmatter:** Must be valid YAML between `---` markers
+2. **Frontmatter:** Must be valid JSON/YAML between `---dossier` or `---` markers
 3. **Required fields:** name, title, version
 4. **Name format:** lowercase alphanumeric + hyphens, 1-64 chars
 5. **Version format:** Valid semver (x.y.z)
@@ -224,7 +228,7 @@ author: yuvaldim
 1. **Path traversal:** Reject names containing `..`, `/`, or non-alphanumeric chars
 2. **Namespace validation:** Always verify against JWT claims
 3. **Bot token scope:** Limited to content repo only
-4. **Content validation:** Parse YAML safely, reject malformed input
+4. **Content validation:** Parse JSON/YAML safely, reject malformed input
 
 ---
 

--- a/registry/docs/planning/registry-api-design.md
+++ b/registry/docs/planning/registry-api-design.md
@@ -561,7 +561,7 @@ Read-only methods (`GET`, `HEAD`) are allowed from any origin. Requests without 
 | `SCHEMA_VALIDATION_FAILED` | 400 | Frontmatter doesn't match schema |
 | `CHECKSUM_MISMATCH` | 400 | Declared checksum != computed |
 | `SIGNATURE_INVALID` | 400 | Signature verification failed |
-| `VERSION_EXISTS` | 409 | Version already published |
+| `VERSION_EXISTS` | 409 | Version already published *(planned — not yet implemented)* |
 | `VERSION_INVALID` | 400 | Not valid semver or not greater than existing |
 | `FORBIDDEN` | 403 | No permission to publish to namespace (see note below) |
 | `RATE_LIMITED` | 429 | Too many publish requests (include `Retry-After`) |


### PR DESCRIPTION
## Summary
- Mark `VERSION_EXISTS` error code as planned/not yet implemented in registry-api-design.md
- Align all frontmatter examples in mvp1-phase2-implementation.md to `---dossier` JSON format (matching auth-and-publish.md and registry-api-design.md)
- Fix DELETE `FORBIDDEN` error message in auth-and-publish.md to match actual code output (`Cannot publish to namespace` with `namespace` field)
- Update validation rules and `parseFrontmatter` description to reflect JSON/YAML support

Closes #286

## Test plan
- [x] All 142 existing tests pass (docs-only change, no code modified)
- [x] Verified FORBIDDEN message matches `registry/lib/auth.ts:159`
- [x] Verified `VERSION_EXISTS` is not implemented in any `.ts` handler
- [x] Verified parser supports both `---dossier` JSON and `---` YAML formats

Co-Authored-By: Claude <noreply@anthropic.com>