### PR TITLE
refactor(registry): pure validation pattern for validatePublishInput

### DIFF
--- a/registry/api/v1/dossiers/index.ts
+++ b/registry/api/v1/dossiers/index.ts
@@ -9,7 +9,6 @@ import { fetchManifestDossiers, normalizeDossier } from '../../../lib/manifest';
 import {
   badRequest,
   getRequestId,
-  invalidNamespaceError,
   invalidPathError,
   jsonError,
   methodNotAllowed,
@@ -67,84 +66,89 @@ async function handleList(_req: VercelRequest, res: VercelResponse, requestId: s
 
 export type PublishInput = { namespace: string; content: string; changelog: string | undefined };
 
-/** Validates the publish request body and headers. Returns validated fields on success, or `null` after sending an error response. */
-export function validatePublishInput(
-  req: VercelRequest,
-  res: VercelResponse,
-  requestId: string
-): PublishInput | null {
+export type ValidationSuccess = { ok: true; data: PublishInput };
+export type ValidationFailure = { ok: false; status: number; code: string; message: string };
+export type ValidationResult = ValidationSuccess | ValidationFailure;
+
+/** Pure validation: returns a discriminated union instead of writing to `res`. */
+export function validatePublishInput(req: VercelRequest): ValidationResult {
   const contentType = req.headers['content-type'];
   if (!contentType || !contentType.includes('application/json')) {
-    jsonError(
-      res,
-      HTTP_STATUS.UNSUPPORTED_MEDIA_TYPE,
-      'UNSUPPORTED_MEDIA_TYPE',
-      `Content-Type must be application/json, received: ${contentType || '(none)'}`,
-      requestId
-    );
-    return null;
+    return {
+      ok: false,
+      status: HTTP_STATUS.UNSUPPORTED_MEDIA_TYPE,
+      code: 'UNSUPPORTED_MEDIA_TYPE',
+      message: `Content-Type must be application/json, received: ${contentType || '(none)'}`,
+    };
   }
 
   const { namespace, content, changelog } = req.body || {};
 
   if (!namespace || typeof namespace !== 'string') {
-    badRequest(
-      res,
-      'MISSING_FIELD',
-      'Missing required field: namespace (must be a string)',
-      requestId
-    );
-    return null;
+    return {
+      ok: false,
+      status: HTTP_STATUS.BAD_REQUEST,
+      code: 'MISSING_FIELD',
+      message: 'Missing required field: namespace (must be a string)',
+    };
   }
 
   if (!content || typeof content !== 'string') {
-    badRequest(
-      res,
-      'MISSING_FIELD',
-      'Missing required field: content (must be a string)',
-      requestId
-    );
-    return null;
+    return {
+      ok: false,
+      status: HTTP_STATUS.BAD_REQUEST,
+      code: 'MISSING_FIELD',
+      message: 'Missing required field: content (must be a string)',
+    };
   }
 
   if (changelog !== undefined && typeof changelog !== 'string') {
-    badRequest(res, 'INVALID_FIELD', 'Field changelog must be a string', requestId);
-    return null;
+    return {
+      ok: false,
+      status: HTTP_STATUS.BAD_REQUEST,
+      code: 'INVALID_FIELD',
+      message: 'Field changelog must be a string',
+    };
   }
 
   if (typeof changelog === 'string' && changelog.length > MAX_CHANGELOG_LENGTH) {
-    badRequest(
-      res,
-      'CHANGELOG_TOO_LONG',
-      `Changelog exceeds maximum length of ${MAX_CHANGELOG_LENGTH} characters`,
-      requestId
-    );
-    return null;
+    return {
+      ok: false,
+      status: HTTP_STATUS.BAD_REQUEST,
+      code: 'CHANGELOG_TOO_LONG',
+      message: `Changelog exceeds maximum length of ${MAX_CHANGELOG_LENGTH} characters`,
+    };
   }
 
   if (content.length > MAX_CONTENT_SIZE) {
-    jsonError(
-      res,
-      HTTP_STATUS.CONTENT_TOO_LARGE,
-      'CONTENT_TOO_LARGE',
-      `Content exceeds maximum size of ${MAX_CONTENT_SIZE / 1024}KB`,
-      requestId
-    );
-    return null;
+    return {
+      ok: false,
+      status: HTTP_STATUS.CONTENT_TOO_LARGE,
+      code: 'CONTENT_TOO_LARGE',
+      message: `Content exceeds maximum size of ${MAX_CONTENT_SIZE / 1024}KB`,
+    };
   }
 
   const namespaceValidation = dossier.validateNamespace(namespace);
   if (!namespaceValidation.valid) {
-    invalidNamespaceError(res, requestId, namespaceValidation.error);
-    return null;
+    return {
+      ok: false,
+      status: HTTP_STATUS.BAD_REQUEST,
+      code: 'INVALID_NAMESPACE',
+      message: namespaceValidation.error,
+    };
   }
 
-  return { namespace, content, changelog };
+  return { ok: true, data: { namespace, content, changelog } };
 }
 
 async function handlePublish(req: VercelRequest, res: VercelResponse, requestId: string) {
-  const input = validatePublishInput(req, res, requestId);
-  if (!input) return;
+  const result = validatePublishInput(req);
+  if (!result.ok) {
+    return jsonError(res, result.status, result.code, result.message, requestId);
+  }
+
+  const input = result.data;
 
   const { namespace, content, changelog } = input;
 

--- a/registry/tests/validate-publish-input.test.ts
+++ b/registry/tests/validate-publish-input.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import type { ValidationFailure } from '../api/v1/dossiers/index';
 import { validatePublishInput } from '../api/v1/dossiers/index';
 import { MAX_CHANGELOG_LENGTH, MAX_CONTENT_SIZE } from '../lib/constants';
-import type { VercelRequest, VercelResponse } from '../lib/types';
-import { createMockReq, createMockRes } from './helpers/mocks';
+import type { VercelRequest } from '../lib/types';
+import { createMockReq } from './helpers/mocks';
 
 const validBody = {
   namespace: 'test-org',
@@ -18,112 +19,93 @@ function makeReq(overrides: Parameters<typeof createMockReq>[0] = {}) {
   }) as unknown as VercelRequest;
 }
 
-function errorCode(body: unknown): string {
-  return (body as { error: { code: string } }).error.code;
+function expectFailure(result: { ok: boolean }, status: number, code: string) {
+  expect(result.ok).toBe(false);
+  const failure = result as ValidationFailure;
+  expect(failure.status).toBe(status);
+  expect(failure.code).toBe(code);
 }
 
 describe('validatePublishInput', () => {
   it('returns validated fields for a valid request', () => {
     const req = makeReq();
-    const { res } = createMockRes();
-    const result = validatePublishInput(req, res as unknown as VercelResponse, 'test-req-id');
+    const result = validatePublishInput(req);
     expect(result).toEqual({
-      namespace: 'test-org',
-      content: validBody.content,
-      changelog: undefined,
+      ok: true,
+      data: {
+        namespace: 'test-org',
+        content: validBody.content,
+        changelog: undefined,
+      },
     });
   });
 
   it('returns changelog when provided', () => {
     const body = { ...validBody, changelog: 'Updated docs' };
     const req = makeReq({ body });
-    const { res } = createMockRes();
-    const result = validatePublishInput(req, res as unknown as VercelResponse, 'test-req-id');
-    expect(result).not.toBeNull();
-    expect(result?.changelog).toBe('Updated docs');
+    const result = validatePublishInput(req);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.changelog).toBe('Updated docs');
+    }
   });
 
   it('rejects missing content-type', () => {
     const req = makeReq({ headers: {} });
-    const { res, getStatus, getBody } = createMockRes();
-    const result = validatePublishInput(req, res as unknown as VercelResponse, 'test-req-id');
-    expect(result).toBeNull();
-    expect(getStatus()).toBe(415);
-    expect(errorCode(getBody())).toBe('UNSUPPORTED_MEDIA_TYPE');
+    const result = validatePublishInput(req);
+    expectFailure(result, 415, 'UNSUPPORTED_MEDIA_TYPE');
   });
 
   it('rejects wrong content-type', () => {
     const req = makeReq({ headers: { 'content-type': 'text/plain' } });
-    const { res, getStatus } = createMockRes();
-    const result = validatePublishInput(req, res as unknown as VercelResponse, 'test-req-id');
-    expect(result).toBeNull();
-    expect(getStatus()).toBe(415);
+    const result = validatePublishInput(req);
+    expectFailure(result, 415, 'UNSUPPORTED_MEDIA_TYPE');
   });
 
   it('rejects missing namespace', () => {
     const req = makeReq({ body: { content: 'x' } });
-    const { res, getStatus, getBody } = createMockRes();
-    const result = validatePublishInput(req, res as unknown as VercelResponse, 'test-req-id');
-    expect(result).toBeNull();
-    expect(getStatus()).toBe(400);
-    expect(errorCode(getBody())).toBe('MISSING_FIELD');
+    const result = validatePublishInput(req);
+    expectFailure(result, 400, 'MISSING_FIELD');
   });
 
   it('rejects non-string namespace', () => {
     const req = makeReq({ body: { namespace: 123, content: 'x' } });
-    const { res, getStatus } = createMockRes();
-    const result = validatePublishInput(req, res as unknown as VercelResponse, 'test-req-id');
-    expect(result).toBeNull();
-    expect(getStatus()).toBe(400);
+    const result = validatePublishInput(req);
+    expectFailure(result, 400, 'MISSING_FIELD');
   });
 
   it('rejects missing content', () => {
     const req = makeReq({ body: { namespace: 'test-org' } });
-    const { res, getStatus, getBody } = createMockRes();
-    const result = validatePublishInput(req, res as unknown as VercelResponse, 'test-req-id');
-    expect(result).toBeNull();
-    expect(getStatus()).toBe(400);
-    expect(errorCode(getBody())).toBe('MISSING_FIELD');
+    const result = validatePublishInput(req);
+    expectFailure(result, 400, 'MISSING_FIELD');
   });
 
   it('rejects non-string changelog', () => {
     const req = makeReq({ body: { ...validBody, changelog: 42 } });
-    const { res, getStatus, getBody } = createMockRes();
-    const result = validatePublishInput(req, res as unknown as VercelResponse, 'test-req-id');
-    expect(result).toBeNull();
-    expect(getStatus()).toBe(400);
-    expect(errorCode(getBody())).toBe('INVALID_FIELD');
+    const result = validatePublishInput(req);
+    expectFailure(result, 400, 'INVALID_FIELD');
   });
 
   it('rejects changelog exceeding max length', () => {
     const req = makeReq({
       body: { ...validBody, changelog: 'a'.repeat(MAX_CHANGELOG_LENGTH + 1) },
     });
-    const { res, getStatus, getBody } = createMockRes();
-    const result = validatePublishInput(req, res as unknown as VercelResponse, 'test-req-id');
-    expect(result).toBeNull();
-    expect(getStatus()).toBe(400);
-    expect(errorCode(getBody())).toBe('CHANGELOG_TOO_LONG');
+    const result = validatePublishInput(req);
+    expectFailure(result, 400, 'CHANGELOG_TOO_LONG');
   });
 
   it('rejects content exceeding max size', () => {
     const req = makeReq({
       body: { namespace: 'test-org', content: 'x'.repeat(MAX_CONTENT_SIZE + 1) },
     });
-    const { res, getStatus, getBody } = createMockRes();
-    const result = validatePublishInput(req, res as unknown as VercelResponse, 'test-req-id');
-    expect(result).toBeNull();
-    expect(getStatus()).toBe(413);
-    expect(errorCode(getBody())).toBe('CONTENT_TOO_LARGE');
+    const result = validatePublishInput(req);
+    expectFailure(result, 413, 'CONTENT_TOO_LARGE');
   });
 
   it('rejects invalid namespace format', () => {
     const req = makeReq({ body: { namespace: '../../etc/passwd', content: 'x' } });
-    const { res, getStatus, getBody } = createMockRes();
-    const result = validatePublishInput(req, res as unknown as VercelResponse, 'test-req-id');
-    expect(result).toBeNull();
-    expect(getStatus()).toBe(400);
-    expect(errorCode(getBody())).toBe('INVALID_NAMESPACE');
+    const result = validatePublishInput(req);
+    expectFailure(result, 400, 'INVALID_NAMESPACE');
   });
 
   it('handles empty body gracefully', () => {
@@ -131,9 +113,7 @@ describe('validatePublishInput', () => {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
     }) as unknown as VercelRequest;
-    const { res, getStatus } = createMockRes();
-    const result = validatePublishInput(req, res as unknown as VercelResponse, 'test-req-id');
-    expect(result).toBeNull();
-    expect(getStatus()).toBe(400);
+    const result = validatePublishInput(req);
+    expectFailure(result, 400, 'MISSING_FIELD');
   });
 });


### PR DESCRIPTION
## Summary
- Refactored `validatePublishInput` to return a discriminated union (`ValidationSuccess | ValidationFailure`) instead of writing directly to `res`
- Removed `res` and `requestId` parameters from the function — the caller (`handlePublish`) now handles error responses via `jsonError`
- Updated all 12 tests to assert on the returned result object instead of mock response state

Closes #317

## Test plan
- [x] All 12 `validatePublishInput` tests pass with new pure return types
- [x] Full test suite (153 tests across 12 files) passes
- [x] Verified error codes and HTTP status codes are preserved identically

Co-Authored-By: Claude <noreply@anthropic.com>