### PR TITLE
refactor(registry): extract CORS allowed methods to shared constants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "vitest": "^3.1.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "mcp-server/node_modules/@vitest/expect": {

--- a/registry/lib/cors.ts
+++ b/registry/lib/cors.ts
@@ -6,6 +6,26 @@ const log = createLogger('cors');
 
 const DEFAULT_ALLOWED_ORIGINS = ['https://dossier.imboard.ai', 'https://registry.dossier.dev'];
 
+/** Single source of truth for HTTP methods allowed through CORS. */
+export const ALLOWED_METHODS = [
+  'GET',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'OPTIONS',
+  'HEAD',
+] as const;
+
+const SAFE_METHODS: ReadonlySet<string> = new Set(['GET', 'OPTIONS', 'HEAD']);
+
+/** Subset of ALLOWED_METHODS that mutate state and require CSRF origin checks. */
+export const MUTATING_METHODS = new Set<string>(
+  ALLOWED_METHODS.filter((m) => !SAFE_METHODS.has(m))
+);
+
+const ALLOWED_HEADERS = ['Authorization', 'Content-Type', 'Accept'] as const;
+
 /**
  * Normalizes an origin string for case-insensitive, port-aware comparison.
  * Uses the URL API which lowercases protocol/hostname, strips default ports
@@ -54,15 +74,13 @@ export function setCorsHeaders(
 
   if (normalizedOrigin && allowed.includes(normalizedOrigin)) {
     res.setHeader('Access-Control-Allow-Origin', normalizedOrigin);
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD');
-    res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type, Accept');
+    res.setHeader('Access-Control-Allow-Methods', ALLOWED_METHODS.join(', '));
+    res.setHeader('Access-Control-Allow-Headers', ALLOWED_HEADERS.join(', '));
     res.setHeader('Vary', 'Origin');
   } else if (origin) {
     log.warn('Rejected origin', { origin, normalizedOrigin, path: req.url });
   }
 }
-
-const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
 /**
  * Handles CORS preflight and enforces origin-based CSRF protection.

--- a/registry/tests/security.test.ts
+++ b/registry/tests/security.test.ts
@@ -101,6 +101,30 @@ describe('CORS restriction', () => {
     expect(methods).toContain('PATCH');
   });
 
+  it('derives MUTATING_METHODS from ALLOWED_METHODS (single source of truth)', async () => {
+    const { ALLOWED_METHODS, MUTATING_METHODS } = await import('../lib/cors');
+
+    for (const method of MUTATING_METHODS) {
+      expect(ALLOWED_METHODS).toContain(method);
+    }
+    // Read-only methods should not be in MUTATING_METHODS
+    expect(MUTATING_METHODS.has('GET')).toBe(false);
+    expect(MUTATING_METHODS.has('HEAD')).toBe(false);
+    expect(MUTATING_METHODS.has('OPTIONS')).toBe(false);
+  });
+
+  it('Access-Control-Allow-Methods header matches ALLOWED_METHODS constant', async () => {
+    const { setCorsHeaders, ALLOWED_METHODS } = await import('../lib/cors');
+    const { headers, req, res } = createCorsReqRes('https://dossier.imboard.ai');
+
+    setCorsHeaders(req, res);
+
+    const headerMethods = (headers['Access-Control-Allow-Methods'] as string)
+      .split(',')
+      .map((m) => m.trim());
+    expect(headerMethods).toEqual([...ALLOWED_METHODS]);
+  });
+
   it('respects CORS_ALLOWED_ORIGINS env var', async () => {
     const originalEnv = process.env.CORS_ALLOWED_ORIGINS;
     process.env.CORS_ALLOWED_ORIGINS = 'https://custom.example.com,https://another.example.com';


### PR DESCRIPTION
## Summary
- Extract inline HTTP method strings into named constants (`ALLOWED_METHODS`, `SAFE_METHODS`, `ALLOWED_HEADERS`) so `MUTATING_METHODS` is derived from a single source of truth
- Add 2 tests verifying the invariant: mutating methods are a subset of allowed methods, and the `Access-Control-Allow-Methods` header matches the constant

Closes #328

## Test plan
- [x] All 155 existing tests pass
- [x] 2 new invariant tests verify single-source-of-truth relationship
- [x] `MUTATING_METHODS ⊂ ALLOWED_METHODS` enforced by construction and tested

Co-Authored-By: Claude <noreply@anthropic.com>