### PR TITLE
Review findings batch: security, DRY, docs, and type safety fixes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,15 +51,14 @@ This allows partial failures to be surfaced without blocking successful results 
 
 ### Multi-Registry Failure Modes
 
-| Scenario | Behavior | User-Facing Output |
-|----------|----------|-------------------|
-| **All registries timeout** | All `Promise.allSettled()` results are rejected. `get`/`run` exit 1 with per-registry errors. `list`/`search` exit 0 with empty results and per-registry warnings. | `❌ Not found in any registry` or per-registry error details |
-| **Network partition** | Same as timeout — unreachable registries produce rejected promises. Reachable registries return normally. | Partial results with `⚠️  Showing partial results (N/M registries responded)` |
-| **Auth failure across registries** | Registry returns 401/403. Caught as `RegistryError` and included in the `errors` array. Other registries still queried. | `⚠️  Registry 'name': unauthorized` or similar per-registry error |
-| **Invalid response format** | JSON parse failure caught in `RegistryClient`. Falls back to HTTP status text. Treated as a registry error. | `⚠️  Registry 'name': <HTTP status text>` |
-| **No registries configured** | CLI falls back to hardcoded public registry. Commands proceed normally. | No error — transparent fallback |
+All failures are captured per-registry via `Promise.allSettled()` and included in the `errors` array alongside successful results. Key behaviors:
 
-See [cli/README.md](cli/README.md#exit-codes) for per-command exit codes.
+- **Partial failure**: Unreachable or erroring registries don't block results from healthy ones. The CLI succeeds if at least one registry responds.
+- **Total failure**: When all registries fail, `get`/`run`/`pull` exit 1; `list`/`search` exit 0 with empty results and per-registry warnings.
+- **Auth errors** (401/403): Treated as per-registry errors. Other registries are still queried.
+- **No registries configured**: CLI falls back to the hardcoded public registry transparently.
+
+For per-command exit codes and user-facing error output, see [cli/README.md — Exit Codes](cli/README.md#exit-codes).
 
 ## File Format
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Real-world dossiers demonstrating the protocol across different domains:
 | [ML Training Pipeline](./examples/data-science/train-ml-model.ds.md) | Train and validate ML models with reproducible experiment logs | ~10-15 min |
 | [DB Migration](./examples/database/migrate-schema.ds.md) | Execute schema changes with automatic backup and rollback capability | ~10 min |
 | [AWS Deploy](./examples/devops/deploy-to-aws.ds.md) | Deploy applications to AWS with infrastructure validation | ~15 min |
+| [External References](./examples/security/external-references-example.ds.md) | Declare and manage external URLs with trust levels | ~5 min |
 
 **Who should try these**: Project maintainers, DevOps/SRE teams, ML engineers, frontend developers
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -253,7 +253,7 @@ Multi-registry commands use the following exit codes:
 | `get` | Dossier found | Not found in any registry, or all registries failed | — |
 | `list --source registry` | Results returned, including when all registries fail (empty list + warnings) | Unexpected runtime error | — |
 | `search` | Results returned, including when all registries fail (no matches + warnings) | Unexpected runtime error | — |
-| `pull` | Always exits 0. Per-item errors are printed but do not affect the exit code. | — | — |
+| `pull` | At least one item pulled successfully (per-item errors are printed as warnings) | All requested items failed to pull | — |
 | `run` | Dossier executed successfully | Not found, fetch failed, or verification failed | No LLM detected, unknown LLM, or execution failed |
 
 **Partial failures**: When some registries fail but at least one succeeds, `list` returns exit `0` with a warning showing which registries failed:

--- a/cli/src/__tests__/commands/list.test.ts
+++ b/cli/src/__tests__/commands/list.test.ts
@@ -209,6 +209,27 @@ describe('list command', () => {
 
       expect(console.log).toHaveBeenCalledWith(expect.stringContaining('No dossiers found'));
     });
+
+    it('should warn when --risk is used in registry mode', async () => {
+      vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
+        dossiers: [
+          { name: 'test', version: '1.0.0', title: 'Test', category: 'dev', _registry: 'public' },
+        ] as any,
+        total: 1,
+        errors: [],
+      });
+
+      const program = createTestProgram();
+      registerListCommand(program);
+
+      await expect(
+        program.parseAsync(['node', 'dossier', 'list', '--source', 'registry', '--risk', 'high'])
+      ).rejects.toThrow();
+
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('--risk filter is not supported in registry mode')
+      );
+    });
   });
 
   describe('local source', () => {

--- a/cli/src/__tests__/commands/pull.test.ts
+++ b/cli/src/__tests__/commands/pull.test.ts
@@ -78,7 +78,7 @@ describe('pull command', () => {
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('updated'));
   });
 
-  it('should handle 404 error', async () => {
+  it('should exit 1 when all items fail', async () => {
     vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
       result: null,
       errors: [],
@@ -88,12 +88,14 @@ describe('pull command', () => {
     const program = createTestProgram();
     registerPullCommand(program);
 
-    await program.parseAsync(['node', 'dossier', 'pull', 'missing/dossier']);
+    await expect(
+      program.parseAsync(['node', 'dossier', 'pull', 'missing/dossier'])
+    ).rejects.toThrow();
 
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('not found'));
   });
 
-  it('should log error and continue on cache write failure', async () => {
+  it('should exit 1 on cache write failure when all items fail', async () => {
     vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
       result: { version: '1.0.0', _registry: 'public' },
       errors: [],
@@ -110,14 +112,35 @@ describe('pull command', () => {
     const program = createTestProgram();
     registerPullCommand(program);
 
-    await program.parseAsync(['node', 'dossier', 'pull', 'org/my-dossier']);
+    await expect(
+      program.parseAsync(['node', 'dossier', 'pull', 'org/my-dossier'])
+    ).rejects.toThrow();
 
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining('failed to write cache files')
     );
-    expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining('EACCES: permission denied')
-    );
+  });
+
+  it('should exit 0 when some items succeed and some fail', async () => {
+    vi.mocked(multiRegistry.multiRegistryGetDossier).mockImplementation(async (name: string) => {
+      if (name === 'org/good') {
+        return { result: { version: '1.0.0', _registry: 'public' } as any, errors: [] };
+      }
+      return { result: null, errors: [] };
+    });
+    vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
+      result: { content: '# Dossier', digest: null, _registry: 'public' },
+      errors: [],
+    });
+    mockedFs.existsSync.mockReturnValue(false);
+
+    const program = createTestProgram();
+    registerPullCommand(program);
+
+    await program.parseAsync(['node', 'dossier', 'pull', 'org/good', 'org/missing']);
+
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('downloaded'));
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('not found'));
   });
 
   it('should pull specific version', async () => {

--- a/cli/src/__tests__/commands/search.test.ts
+++ b/cli/src/__tests__/commands/search.test.ts
@@ -18,7 +18,7 @@ describe('search command', () => {
   });
 
   it('should display matching results', async () => {
-    vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
+    vi.mocked(multiRegistry.multiRegistrySearch).mockResolvedValue({
       dossiers: [
         {
           name: 'deploy-app',
@@ -28,16 +28,8 @@ describe('search command', () => {
           tags: ['deploy'],
           _registry: 'public',
         },
-        {
-          name: 'setup-db',
-          title: 'Setup Database',
-          description: 'Initialize database',
-          category: 'database',
-          tags: ['db'],
-          _registry: 'public',
-        },
       ] as any,
-      total: 2,
+      total: 1,
       errors: [],
     });
 
@@ -51,7 +43,7 @@ describe('search command', () => {
   });
 
   it('should show no results message', async () => {
-    vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
+    vi.mocked(multiRegistry.multiRegistrySearch).mockResolvedValue({
       dossiers: [],
       total: 0,
       errors: [],
@@ -68,7 +60,7 @@ describe('search command', () => {
   });
 
   it('should output JSON with --json', async () => {
-    vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
+    vi.mocked(multiRegistry.multiRegistrySearch).mockResolvedValue({
       dossiers: [
         {
           name: 'test',
@@ -96,7 +88,7 @@ describe('search command', () => {
   });
 
   it('should filter by content with --content flag', async () => {
-    vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
+    vi.mocked(multiRegistry.multiRegistrySearch).mockResolvedValue({
       dossiers: [
         {
           name: 'deploy-app',
@@ -141,7 +133,7 @@ describe('search command', () => {
   });
 
   it('should exit 1 on API error with registry context', async () => {
-    vi.mocked(multiRegistry.multiRegistryList).mockRejectedValue(new Error('Network error'));
+    vi.mocked(multiRegistry.multiRegistrySearch).mockRejectedValue(new Error('Network error'));
 
     const program = createTestProgram();
     registerSearchCommand(program);
@@ -154,7 +146,7 @@ describe('search command', () => {
   });
 
   it('should clamp page to minimum of 1', async () => {
-    vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
+    vi.mocked(multiRegistry.multiRegistrySearch).mockResolvedValue({
       dossiers: [
         {
           name: 'test',
@@ -178,7 +170,7 @@ describe('search command', () => {
   });
 
   it('should clamp perPage to maximum of 1000', async () => {
-    vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
+    vi.mocked(multiRegistry.multiRegistrySearch).mockResolvedValue({
       dossiers: [
         {
           name: 'test',
@@ -202,7 +194,7 @@ describe('search command', () => {
   });
 
   it('should clamp perPage to minimum of 1', async () => {
-    vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
+    vi.mocked(multiRegistry.multiRegistrySearch).mockResolvedValue({
       dossiers: [
         {
           name: 'test',
@@ -226,7 +218,7 @@ describe('search command', () => {
   });
 
   it('should log warning when content fetch fails for a dossier', async () => {
-    vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
+    vi.mocked(multiRegistry.multiRegistrySearch).mockResolvedValue({
       dossiers: [
         {
           name: 'fail-dossier',

--- a/cli/src/__tests__/credentials.test.ts
+++ b/cli/src/__tests__/credentials.test.ts
@@ -232,6 +232,7 @@ describe('credentials', () => {
       loadCredentials();
       expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('insecure permissions'));
       expect(mockedFs.chmodSync).toHaveBeenCalledWith(CREDENTIALS_FILE, 0o600);
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Permissions fixed to 0600'));
       errorSpy.mockRestore();
     });
   });

--- a/cli/src/__tests__/integration/registry-flow.test.ts
+++ b/cli/src/__tests__/integration/registry-flow.test.ts
@@ -96,7 +96,7 @@ describe('registry flow integration', () => {
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Published'));
 
     // Step 2: Search
-    vi.mocked(multiRegistry.multiRegistryList).mockResolvedValue({
+    vi.mocked(multiRegistry.multiRegistrySearch).mockResolvedValue({
       dossiers: [
         {
           name: 'org/my-workflow',

--- a/cli/src/commands/config-cmd.ts
+++ b/cli/src/commands/config-cmd.ts
@@ -258,7 +258,7 @@ Project-level config:
 
 Environment variables:
   DOSSIER_REGISTRY_URL    Override/add a registry URL (creates virtual "env" registry)
-  DOSSIER_REGISTRY_TOKEN  Auth token for the default registry
+  DOSSIER_REGISTRY_TOKEN  Auth token for the "env" registry (set via DOSSIER_REGISTRY_URL)
   DOSSIER_REGISTRY_USER   Username for registry authentication
   DOSSIER_REGISTRY_ORGS   Comma-separated org scopes for registry queries
 `

--- a/cli/src/commands/list.ts
+++ b/cli/src/commands/list.ts
@@ -66,6 +66,12 @@ Multi-registry note:
         }
 
         if (options.source === 'registry') {
+          if (options.risk) {
+            console.warn(
+              '⚠️  --risk filter is not supported in registry mode (risk_level is not included in registry listings)'
+            );
+          }
+
           const { page, perPage } = parsePaginationParams(options.page, options.perPage);
           const showRegistryLabel = resolveRegistries().length > 1;
 

--- a/cli/src/commands/pull.ts
+++ b/cli/src/commands/pull.ts
@@ -18,6 +18,7 @@ export function registerPullCommand(program: Command): void {
     .option('--force', 'Re-download even if already cached')
     .action(async (names: string[], options: { force?: boolean }) => {
       const cacheDir = path.join(os.homedir(), '.dossier', 'cache');
+      let failures = 0;
 
       for (const nameArg of names) {
         let [dossierName, version] = parseNameVersion(nameArg);
@@ -28,6 +29,7 @@ export function registerPullCommand(program: Command): void {
             if (!meta) {
               console.error(`❌ ${nameArg}: not found in any registry`);
               printRegistryErrors(metaErrors);
+              failures++;
               continue;
             }
             version = meta.version || 'latest';
@@ -50,6 +52,7 @@ export function registerPullCommand(program: Command): void {
           if (!result) {
             console.error(`❌ ${nameArg}: not found in any registry`);
             printRegistryErrors(contentErrors);
+            failures++;
             continue;
           }
           const content = result.content;
@@ -59,6 +62,7 @@ export function registerPullCommand(program: Command): void {
             const actual = sha256Hex(content);
             if (actual !== digest) {
               console.error(`❌ ${dossierName}@${version}: checksum mismatch after download`);
+              failures++;
               continue;
             }
           }
@@ -83,6 +87,7 @@ export function registerPullCommand(program: Command): void {
             console.error(
               `❌ ${dossierName}@${version}: failed to write cache files to '${dossierDir}': ${(writeErr as Error).message}`
             );
+            failures++;
             continue;
           }
 
@@ -96,7 +101,12 @@ export function registerPullCommand(program: Command): void {
           } else {
             console.error(`❌ ${nameArg}: ${e.message}`);
           }
+          failures++;
         }
+      }
+
+      if (failures === names.length) {
+        process.exit(1);
       }
     });
 }

--- a/cli/src/commands/search.ts
+++ b/cli/src/commands/search.ts
@@ -8,7 +8,7 @@ import {
   printRegistryErrors,
 } from '../helpers';
 import type { LabeledDossierListItem } from '../multi-registry';
-import { multiRegistryList } from '../multi-registry';
+import { multiRegistrySearch } from '../multi-registry';
 import { getClientForRegistry } from '../registry-client';
 
 /** Registers the `search` command — searches for dossiers across all configured registries. */
@@ -41,10 +41,9 @@ export function registerSearchCommand(program: Command): void {
         const { page, perPage } = parsePaginationParams(options.page, options.perPage);
         const limit = options.limit ? Math.max(1, parseInt(options.limit, 10) || 1) : undefined;
 
-        let allDossiers: LabeledDossierListItem[];
+        let matched: LabeledDossierListItem[];
         try {
-          const result = await multiRegistryList({
-            category: options.category,
+          const result = await multiRegistrySearch(query, {
             page: 1,
             perPage: 100,
           });
@@ -53,7 +52,15 @@ export function registerSearchCommand(program: Command): void {
             printRegistryErrors(result.errors, 'warning');
           }
 
-          allDossiers = result.dossiers;
+          matched = result.dossiers;
+
+          if (options.category) {
+            const cat = options.category.toLowerCase();
+            matched = matched.filter((d) => {
+              const cats = Array.isArray(d.category) ? d.category : [d.category || ''];
+              return cats.some((c) => String(c).toLowerCase().includes(cat));
+            });
+          }
         } catch (err: unknown) {
           const registryNames = resolveRegistries()
             .map((r) => r.name)
@@ -65,29 +72,13 @@ export function registerSearchCommand(program: Command): void {
           return;
         }
 
-        const queryLower = query.toLowerCase();
-        const terms = queryLower.split(/\s+/).filter(Boolean);
-
-        let matched = allDossiers.filter((d) => {
-          const fields = [
-            d.name || '',
-            d.title || '',
-            d.description || d.objective || '',
-            ...(Array.isArray(d.category) ? d.category : [d.category || '']),
-            ...(d.tags || []),
-          ]
-            .map((f) => String(f).toLowerCase())
-            .join(' ');
-
-          return terms.every((term) => fields.includes(term));
-        });
-
         // Content search: fetch body and filter by content match
         let contentMatches: Map<string, string> | null = null;
         if (options.content) {
           const registries = resolveRegistries();
           const CONCURRENCY = 5;
           contentMatches = new Map();
+          const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
 
           // Process in batches for concurrency limiting
           for (let i = 0; i < matched.length; i += CONCURRENCY) {

--- a/cli/src/credentials.ts
+++ b/cli/src/credentials.ts
@@ -44,6 +44,7 @@ function readCredentialsFile(): Record<string, unknown> | null {
           `Expected 0600. Credentials may have been compromised. Fixing permissions.`
       );
       fs.chmodSync(CREDENTIALS_FILE, 0o600);
+      console.error(`✅ Permissions fixed to 0600.`);
     }
     return JSON.parse(fs.readFileSync(CREDENTIALS_FILE, 'utf8'));
   } catch (error) {

--- a/cli/src/multi-registry.ts
+++ b/cli/src/multi-registry.ts
@@ -12,6 +12,7 @@ import type {
   DossierInfo,
   DossierListItem,
   ListDossiersOptions,
+  SearchOptions,
 } from './registry-client';
 import { getClientForRegistry } from './registry-client';
 
@@ -101,37 +102,46 @@ async function multiRegistryListFrom(
 }
 
 /**
- * Search dossiers across all registries.
- * Fetches all dossiers and filters client-side (same as single-registry search).
+ * Search dossiers across all registries using server-side search.
+ * Each registry filters results server-side; this function merges them.
  */
 async function multiRegistrySearch(
   query: string,
-  options: ListDossiersOptions = {}
+  options: SearchOptions = {}
 ): Promise<MultiRegistrySearchResult> {
-  const listResult = await multiRegistryList({ ...options, page: 1, perPage: 100 });
+  const registries = resolveRegistries();
 
-  const queryLower = query.toLowerCase();
-  const terms = queryLower.split(/\s+/).filter(Boolean);
+  const results = await Promise.allSettled(
+    registries.map(async (reg) => {
+      const token = getTokenForRegistry(reg.name);
+      const client = getClientForRegistry(reg.url, token);
+      const result = await client.searchDossiers(query, options);
+      const dossiers = (result.dossiers || []).map((d) => ({
+        ...d,
+        _registry: reg.name,
+      }));
+      return { dossiers, total: result.total || dossiers.length };
+    })
+  );
 
-  const matched = listResult.dossiers.filter((d) => {
-    const fields = [
-      d.name || '',
-      d.title || '',
-      d.description || d.objective || '',
-      ...(Array.isArray(d.category) ? d.category : [d.category || '']),
-      ...(d.tags || []),
-    ]
-      .map((f) => String(f).toLowerCase())
-      .join(' ');
+  const allDossiers: LabeledDossierListItem[] = [];
+  const errors: Array<{ registry: string; error: string }> = [];
+  let total = 0;
 
-    return terms.every((term) => fields.includes(term) || fields.indexOf(term) !== -1);
-  });
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result.status === 'fulfilled') {
+      allDossiers.push(...result.value.dossiers);
+      total += result.value.total;
+    } else {
+      errors.push({
+        registry: registries[i].name,
+        error: result.reason?.message || String(result.reason),
+      });
+    }
+  }
 
-  return {
-    dossiers: matched,
-    total: matched.length,
-    errors: listResult.errors,
-  };
+  return { dossiers: allDossiers, total, errors };
 }
 
 /**

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -251,11 +251,7 @@ Dossier Schema metadata is embedded at the **top of the Markdown file** using JS
 
 **Linter rule**: `external-references-declared` (default severity: `error`) scans the body for URLs and cross-references them against declared `external_references`. Placeholder URLs (`example.com`, `localhost`, `${VAR}`) are automatically excluded. URLs from `tools_required[].install_url`, `homepage`, `repository`, and `authors[].url` are auto-exempt.
 
-**Recommended agent behavior** (see [PROTOCOL.md](../../PROTOCOL.md) for full details):
-- URLs declared in `external_references` → Proceed (author has acknowledged the dependency)
-- URLs with `type: "script"` and `trust_level: "unknown"` → Require explicit user approval
-- URLs NOT declared in `external_references` → Warn user (URL is not in the trust chain)
-- `content_scope` is `"self-contained"` but body has URLs → Treat as configuration error
+**Agent behavior**: See [PROTOCOL.md — External Reference Handling](../../PROTOCOL.md#external-reference-handling) for the full agent behavior table and detection rules.
 
 ---
 

--- a/packages/core/src/linter/rules/tools-check-command.ts
+++ b/packages/core/src/linter/rules/tools-check-command.ts
@@ -1,16 +1,11 @@
 import type { LintRule } from '../types';
 
-interface ToolRequired {
-  name: string;
-  check_command?: string;
-}
-
 export const toolsCheckCommandRule: LintRule = {
   id: 'tools-check-command',
   description: 'tools_required entries should have a check_command',
   defaultSeverity: 'warning',
   run(context) {
-    const tools = context.frontmatter.tools_required as ToolRequired[] | undefined;
+    const tools = context.frontmatter.tools_required;
 
     if (!Array.isArray(tools) || tools.length === 0) {
       return [];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,6 +26,19 @@ export interface ExternalReference {
   required: boolean;
 }
 
+export interface ToolRequired {
+  name: string;
+  version?: string;
+  check_command?: string;
+  install_url?: string;
+}
+
+export interface DossierAuthor {
+  name?: string;
+  email?: string;
+  url?: string;
+}
+
 export interface DossierFrontmatter {
   dossier_schema_version?: string;
   name?: string;
@@ -42,6 +55,8 @@ export interface DossierFrontmatter {
   destructive_operations?: string[];
   content_scope?: ContentScope;
   external_references?: ExternalReference[];
+  tools_required?: ToolRequired[];
+  authors?: DossierAuthor[];
   requires_approval?: boolean;
   checksum?: {
     algorithm: string;

--- a/packages/core/src/utils/url-scanner.ts
+++ b/packages/core/src/utils/url-scanner.ts
@@ -40,9 +40,9 @@ export function collectDeclaredUrls(frontmatter: DossierFrontmatter): string[] {
     }
   }
 
-  if (Array.isArray(frontmatter.tools_required)) {
-    for (const tool of frontmatter.tools_required as Array<Record<string, unknown>>) {
-      if (typeof tool.install_url === 'string') {
+  if (frontmatter.tools_required) {
+    for (const tool of frontmatter.tools_required) {
+      if (tool.install_url) {
         urls.push(tool.install_url);
       }
     }
@@ -56,9 +56,9 @@ export function collectDeclaredUrls(frontmatter: DossierFrontmatter): string[] {
     urls.push(frontmatter.repository);
   }
 
-  if (Array.isArray(frontmatter.authors)) {
-    for (const author of frontmatter.authors as Array<Record<string, unknown>>) {
-      if (typeof author.url === 'string') {
+  if (frontmatter.authors) {
+    for (const author of frontmatter.authors) {
+      if (author.url) {
         urls.push(author.url);
       }
     }

--- a/registry/api/auth/callback.ts
+++ b/registry/api/auth/callback.ts
@@ -64,8 +64,12 @@ async function exchangeCodeAndRenderSuccess(res: VercelResponse, code: string): 
 
   log.info('Fetching user info and orgs');
   const [user, orgs] = await Promise.all([
-    auth.fetchGitHubUser(accessToken),
-    auth.fetchGitHubOrgs(accessToken),
+    auth.fetchGitHubUser(accessToken).catch((err) => {
+      throw new Error(`Failed to fetch GitHub user info: ${(err as Error).message}`);
+    }),
+    auth.fetchGitHubOrgs(accessToken).catch((err) => {
+      throw new Error(`Failed to fetch GitHub orgs: ${(err as Error).message}`);
+    }),
   ]);
   log.info('User authenticated', { user: user.login, orgs });
 

--- a/registry/api/auth/callback.ts
+++ b/registry/api/auth/callback.ts
@@ -91,7 +91,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     log.warn('OAuth provider error', { error, errorDescription });
     return res
       .status(HTTP_STATUS.BAD_REQUEST)
-      .send(renderErrorPage('Authentication Failed', errorDescription || error));
+      .send(
+        renderErrorPage(
+          'Authentication Failed',
+          'GitHub authentication failed. Please try again or contact support.'
+        )
+      );
   }
 
   if (!validateOAuthState(req, res, state)) {

--- a/registry/api/v1/docs.ts
+++ b/registry/api/v1/docs.ts
@@ -153,7 +153,8 @@ const errorResponseDoc = {
     error: {
       code: 'string - Error code (e.g., UPSTREAM_ERROR)',
       message: 'string - Human-readable error description',
-      request_id: 'string (UUID) - Correlation ID for server log lookup',
+      request_id:
+        'string - Correlation ID for server log lookup (echoed from X-Request-Id header, or server-generated UUID if absent)',
     },
   },
 };

--- a/registry/api/v1/dossiers/[...name].ts
+++ b/registry/api/v1/dossiers/[...name].ts
@@ -110,6 +110,7 @@ async function handleGet(
       code: 'UPSTREAM_ERROR',
       message: 'Failed to fetch dossier information',
       requestId,
+      context: { dossier: dossierName, isContentRequest },
     });
   }
 }
@@ -163,6 +164,7 @@ async function handleDelete(
       code: 'DELETE_ERROR',
       message: 'Failed to delete dossier. Please try again.',
       requestId,
+      context: { dossier: dossierName, version },
     });
   }
 }

--- a/registry/api/v1/dossiers/[...name].ts
+++ b/registry/api/v1/dossiers/[...name].ts
@@ -122,7 +122,7 @@ async function handleDelete(
   requestId: string
 ) {
   try {
-    const authorized = await authorizePublish(req, res, dossierName);
+    const authorized = await authorizePublish(req, res, dossierName, 'delete');
     if (!authorized) return;
 
     log.info('Deleting dossier', { requestId, dossier: dossierName, version });

--- a/registry/docs/planning/auth-and-publish.md
+++ b/registry/docs/planning/auth-and-publish.md
@@ -344,8 +344,15 @@ Returned when the dossier name fails validation:
 | `INVALID_PATH` | Path traversal detected |
 
 **Response (403 Forbidden):**
-
-Same `FORBIDDEN` response as `POST /api/v1/dossiers` above.
+```json
+{
+  "error": {
+    "code": "FORBIDDEN",
+    "message": "Cannot delete from namespace 'other-org/some-dossier'",
+    "namespace": "other-org/some-dossier"
+  }
+}
+```
 
 **Response (404 Not Found):**
 ```json

--- a/registry/docs/planning/auth-and-publish.md
+++ b/registry/docs/planning/auth-and-publish.md
@@ -344,15 +344,8 @@ Returned when the dossier name fails validation:
 | `INVALID_PATH` | Path traversal detected |
 
 **Response (403 Forbidden):**
-```json
-{
-  "error": {
-    "code": "FORBIDDEN",
-    "message": "Cannot publish to namespace 'other-org/some-dossier'",
-    "namespace": "other-org/some-dossier"
-  }
-}
-```
+
+Same `FORBIDDEN` response as `POST /api/v1/dossiers` above.
 
 **Response (404 Not Found):**
 ```json

--- a/registry/lib/auth.ts
+++ b/registry/lib/auth.ts
@@ -140,7 +140,8 @@ export async function fetchGitHubUser(
 export async function authorizePublish(
   req: VercelRequest,
   res: VercelResponse,
-  namespace: string
+  namespace: string,
+  action: 'publish' | 'delete' = 'publish'
 ): Promise<boolean> {
   const jwtPayload = await authenticateRequest(req, res);
   if (!jwtPayload) return false;
@@ -153,10 +154,11 @@ export async function authorizePublish(
       namespace,
       reason: permission.reason,
     });
+    const verb = action === 'delete' ? 'delete from' : 'publish to';
     res.status(HTTP_STATUS.FORBIDDEN).json({
       error: {
         code: 'FORBIDDEN',
-        message: `Cannot publish to namespace '${namespace}'`,
+        message: `Cannot ${verb} namespace '${namespace}'`,
         namespace,
       },
     });

--- a/registry/tests/permissions.test.ts
+++ b/registry/tests/permissions.test.ts
@@ -55,4 +55,24 @@ describe('authorizePublish - 403 response', () => {
 
     vi.restoreAllMocks();
   });
+
+  it('uses delete wording when action is delete', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const token = signJwt({
+      sub: 'alice',
+      email: 'alice@example.com',
+      orgs: ['acme-corp'],
+    });
+    const req = { headers: { authorization: `Bearer ${token}` } } as never;
+    const res = createViMockRes();
+
+    const result = await authorizePublish(req, res, 'evil-corp/bad-stuff', 'delete');
+    expect(result).toBe(false);
+
+    const jsonArg = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(jsonArg.error.message).toBe("Cannot delete from namespace 'evil-corp/bad-stuff'");
+
+    vi.restoreAllMocks();
+  });
 });


### PR DESCRIPTION
## Summary

Batch of fixes from automated review findings across CLI, registry, and core packages. Each commit addresses a specific issue:

- **#321** — Add typed `ToolRequired` and `DossierAuthor` to `DossierFrontmatter`, removing unsafe casts
- **#323** — Add external-references-example to README Examples Gallery
- **#324** — Replace duplicated agent behavior rules in schema.md with cross-reference to PROTOCOL.md
- **#314** — Correct `request_id` type description in docs.ts (accepts non-UUID values)
- **#303** — Add granular error context in OAuth callback and serverError calls
- **#302** — Prevent OAuth provider error message leakage to end users
- **#307** — Log confirmation after credentials permission repair
- **#306** — Correct DOSSIER_REGISTRY_TOKEN help text (refers to "env" registry)
- **#341** — Consolidate multi-registry failure modes table in ARCHITECTURE.md
- **#340** — Exit non-zero when all `pull` items fail
- **#334** — Warn when `--risk` filter is used in registry mode
- **#332** — Use server-side search instead of client-side filtering
- **#343** — Use operation-aware message ("delete from" vs "publish to") in FORBIDDEN response
- **#344** — Consolidate duplicated FORBIDDEN block in auth-and-publish.md

## Test plan

- [x] `npm run test -w packages/core` — 166 tests pass
- [x] `npm run test -w cli` — all tests pass (updated for search, pull, list, credentials changes)
- [x] `npm run test -w registry` — permissions test updated for delete action wording
- [x] Biome check: no lint/format issues in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)