### PR TITLE
feat: pool-aware dossiers + remove batch prompt hint

### DIFF
--- a/scripts/batch-issues.sh
+++ b/scripts/batch-issues.sh
@@ -341,11 +341,7 @@ for issue in "${ISSUES[@]}"; do
 
   LOG_FILE="${LOG_DIR}/${issue}.log"
 
-  # Build agent prompt — add pool hint if --pool is active
   AGENT_PROMPT="full cycle issue #${issue}"
-  if [[ "$USE_POOL" == "true" ]]; then
-    AGENT_PROMPT="full cycle issue #${issue}. Use 'npx worktree-pool claim --issue ${issue} --branch <branch>' to claim a pre-warmed worktree instead of creating a new one."
-  fi
 
   if [[ "$DRY_RUN" == "true" ]]; then
     log "[dry-run] #${issue}: claude -p --model ${MODEL} --allowedTools Bash,Read,Edit,Write,Glob,Grep,Agent"


### PR DESCRIPTION
## Summary
- Published `setup-issue-workflow@1.6.0` to registry — auto-detects worktree pool when user picks option 1 (new worktree), claims pre-warmed worktree for ~2s instant setup, falls back to cold creation when pool unavailable
- Published `full-cycle-issue@2.5.0` to registry — returns worktree to pool in Phase 9 teardown instead of destroying, enabling reuse
- Removed pool prompt hint from `batch-issues.sh` since the dossiers now handle pool awareness natively (no more injecting claim instructions in the agent prompt)

Closes #357
Closes #358

## Test plan
- `ai-dossier info imboard-ai/development/git/setup-issue-workflow@1.6.0` confirms published
- `ai-dossier info imboard-ai/full-cycle-issue@2.5.0` confirms published
- `batch-issues.sh --pool --dry-run 100` still works (pre-warm step shown, no prompt hint)
- Full cycle with pool: `npx worktree-pool replenish --count 1` then run full-cycle-issue — should claim from pool

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>