### PR TITLE
ci: add @ai-dossier/worktree-pool to npm publish pipeline

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -166,6 +166,25 @@ jobs:
           cd mcp-server
           npm publish --provenance --access public
 
+      - name: Check if @ai-dossier/worktree-pool needs publishing
+        id: check-pool
+        run: |
+          CURRENT=$(node -p "require('./packages/worktree-pool/package.json').version")
+          PUBLISHED=$(npm view @ai-dossier/worktree-pool version 2>/dev/null || echo "0.0.0")
+          if [ "$CURRENT" = "$PUBLISHED" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Worktree-pool $CURRENT already published, skipping"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "Publishing worktree-pool $CURRENT (current published: $PUBLISHED)"
+          fi
+
+      - name: Publish @ai-dossier/worktree-pool
+        if: steps.check-pool.outputs.skip != 'true'
+        run: |
+          cd packages/worktree-pool
+          npm publish --provenance --access public
+
   verify:
     needs: publish
     runs-on: ubuntu-latest
@@ -182,6 +201,7 @@ jobs:
           npm view @ai-dossier/core version
           npm view @ai-dossier/cli version
           npm view @ai-dossier/mcp-server version
+          npm view @ai-dossier/worktree-pool version
 
       - name: Smoke test CLI
         run: npx @ai-dossier/cli --help

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Dossier Build System
 # Handles build order dependencies across npm workspaces
 
-.PHONY: all build build-all clean test test-coverage install help lint format check
+.PHONY: all build build-all clean test test-coverage install help lint format check build-pool
 .DEFAULT_GOAL := help
 
 ## help: Show this help message
@@ -15,7 +15,8 @@ help:
 	@echo "  1. packages/core (TypeScript → dist/)"
 	@echo "  2. mcp-server (TypeScript → dist/, depends on core)"
 	@echo "  3. cli (TypeScript → dist/)"
-	@echo "  4. registry (TypeScript, deployed via Vercel, depends on core)"
+	@echo "  4. packages/worktree-pool (TypeScript → dist/)"
+	@echo "  5. registry (TypeScript, deployed via Vercel, depends on core)"
 
 ## install: Install all npm dependencies
 install:
@@ -27,7 +28,7 @@ install:
 build: lint build-all
 
 ## build-all: Build all packages in dependency order (no lint)
-build-all: build-core build-mcp build-cli
+build-all: build-core build-mcp build-cli build-pool
 	@echo "✓ All packages built successfully"
 
 ## build-core: Build @ai-dossier/core package
@@ -48,10 +49,17 @@ build-cli: build-core
 	cd cli && npm run build
 	@echo "✓ cli built"
 
+## build-pool: Build @ai-dossier/worktree-pool package
+build-pool:
+	@echo "Building packages/worktree-pool..."
+	cd packages/worktree-pool && npm run build
+	@echo "✓ packages/worktree-pool built"
+
 ## clean: Remove all build artifacts
 clean:
 	@echo "Cleaning build artifacts..."
 	rm -rf packages/core/dist
+	rm -rf packages/worktree-pool/dist
 	rm -rf mcp-server/dist
 	rm -rf cli/dist
 	@echo "✓ Build artifacts cleaned"


### PR DESCRIPTION
## Summary
- Add `@ai-dossier/worktree-pool` to the `publish-packages.yml` CI workflow (check version → publish → verify)
- Add `build-pool` target to Makefile and include it in `build-all`
- Add worktree-pool dist to `clean` target

The package was already configured with `publishConfig.access: "public"` and proper `bin`/`files` fields — it just wasn't wired into the CI pipeline.

## Test plan
- CI passes (lint, test, build-all now includes worktree-pool)
- After merge, the publish workflow will detect version `0.1.0` as unpublished and publish to npm
- Verify: `npm view @ai-dossier/worktree-pool` shows the package

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>