### PR TITLE
chore: bump all package versions, fix CI publish auth, add worktree-pool README

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -69,6 +69,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install npm with trusted publishing support
         run: npm install -g npm@latest

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -166,6 +166,25 @@ jobs:
           cd mcp-server
           npm publish --provenance --access public
 
+      - name: Check if @ai-dossier/worktree-pool needs publishing
+        id: check-pool
+        run: |
+          CURRENT=$(node -p "require('./packages/worktree-pool/package.json').version")
+          PUBLISHED=$(npm view @ai-dossier/worktree-pool version 2>/dev/null || echo "0.0.0")
+          if [ "$CURRENT" = "$PUBLISHED" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Worktree-pool $CURRENT already published, skipping"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "Publishing worktree-pool $CURRENT (current published: $PUBLISHED)"
+          fi
+
+      - name: Publish @ai-dossier/worktree-pool
+        if: steps.check-pool.outputs.skip != 'true'
+        run: |
+          cd packages/worktree-pool
+          npm publish --provenance --access public
+
   verify:
     needs: publish
     runs-on: ubuntu-latest
@@ -182,6 +201,7 @@ jobs:
           npm view @ai-dossier/core version
           npm view @ai-dossier/cli version
           npm view @ai-dossier/mcp-server version
+          npm view @ai-dossier/worktree-pool version
 
       - name: Smoke test CLI
         run: npx @ai-dossier/cli --help

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Dossier Build System
 # Handles build order dependencies across npm workspaces
 
-.PHONY: all build build-all clean test test-coverage install help lint format check
+.PHONY: all build build-all clean test test-coverage install help lint format check build-pool
 .DEFAULT_GOAL := help
 
 ## help: Show this help message
@@ -15,7 +15,8 @@ help:
 	@echo "  1. packages/core (TypeScript → dist/)"
 	@echo "  2. mcp-server (TypeScript → dist/, depends on core)"
 	@echo "  3. cli (TypeScript → dist/)"
-	@echo "  4. registry (TypeScript, deployed via Vercel, depends on core)"
+	@echo "  4. packages/worktree-pool (TypeScript → dist/)"
+	@echo "  5. registry (TypeScript, deployed via Vercel, depends on core)"
 
 ## install: Install all npm dependencies
 install:
@@ -27,7 +28,7 @@ install:
 build: lint build-all
 
 ## build-all: Build all packages in dependency order (no lint)
-build-all: build-core build-mcp build-cli
+build-all: build-core build-mcp build-cli build-pool
 	@echo "✓ All packages built successfully"
 
 ## build-core: Build @ai-dossier/core package
@@ -48,10 +49,17 @@ build-cli: build-core
 	cd cli && npm run build
 	@echo "✓ cli built"
 
+## build-pool: Build @ai-dossier/worktree-pool package
+build-pool:
+	@echo "Building packages/worktree-pool..."
+	cd packages/worktree-pool && npm run build
+	@echo "✓ packages/worktree-pool built"
+
 ## clean: Remove all build artifacts
 clean:
 	@echo "Cleaning build artifacts..."
 	rm -rf packages/core/dist
+	rm -rf packages/worktree-pool/dist
 	rm -rf mcp-server/dist
 	rm -rf cli/dist
 	@echo "✓ Build artifacts cleaned"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-dossier/cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Command-line tool for creating, verifying, and executing dossiers",
   "main": "dist/cli.js",
   "bin": {

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dossier/mcp-server",
-  "version": "1.0.0",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dossier/mcp-server",
-      "version": "1.0.0",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.927.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-dossier/mcp-server",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "MCP server for dossier automation standard - enables LLMs to discover, verify, and execute dossiers",
   "main": "dist/index.js",
   "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
     },
     "cli": {
       "name": "@ai-dossier/cli",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ai-dossier/core": "^1.0.1",
@@ -48,7 +48,7 @@
     },
     "mcp-server": {
       "name": "@ai-dossier/mcp-server",
-      "version": "1.0.2",
+      "version": "1.0.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ai-dossier/core": "^1.0.1",
@@ -6979,7 +6979,7 @@
     },
     "packages/core": {
       "name": "@ai-dossier/core",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.927.0",
@@ -6999,7 +6999,7 @@
     },
     "packages/worktree-pool": {
       "name": "@ai-dossier/worktree-pool",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "AGPL-3.0-only",
       "bin": {
         "worktree-pool": "dist/cli.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-dossier/core",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Core verification and parsing logic for dossier automation standard",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/worktree-pool/README.md
+++ b/packages/worktree-pool/README.md
@@ -1,0 +1,69 @@
+# @ai-dossier/worktree-pool
+
+Pre-warmed git worktree pool for instant issue setup. Eliminates the ~3-5 minute cold start (git worktree add + npm install + build) by maintaining a pool of ready-to-use worktrees.
+
+## Install
+
+```bash
+npm install -g @ai-dossier/worktree-pool
+```
+
+Or use directly with npx:
+
+```bash
+npx @ai-dossier/worktree-pool status
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `worktree-pool status` | Show pool inventory (warm/assigned/stale counts) |
+| `worktree-pool replenish [--count N]` | Pre-warm spares up to target count |
+| `worktree-pool claim --issue N --branch B` | Claim a warm worktree, print path |
+| `worktree-pool return --path P` | Return worktree to pool for reuse |
+| `worktree-pool refresh` | Fetch origin + rebuild in all warm worktrees |
+| `worktree-pool gc` | Remove stale/orphaned/excess worktrees |
+| `worktree-pool init` | Configure pool directory for this project |
+
+## Quick Start
+
+```bash
+# Initialize pool in your repo
+worktree-pool init
+
+# Pre-warm 3 worktrees
+worktree-pool replenish --count 3
+
+# Check pool status
+worktree-pool status
+
+# Claim a worktree for an issue (~2 seconds)
+WORKTREE_PATH=$(worktree-pool claim --issue 42 --branch feature/42-add-dashboard)
+cd "$WORKTREE_PATH"
+
+# Return worktree to pool when done
+worktree-pool return --path "$WORKTREE_PATH"
+
+# Clean up stale worktrees
+worktree-pool gc
+```
+
+## How It Works
+
+1. **Replenish** creates worktrees from `origin/main` on temp branches, runs `npm install` and builds
+2. **Claim** renames a warm worktree, switches to your feature branch — instant setup
+3. **Return** recycles the worktree back to pool on a fresh temp branch
+4. **GC** removes stale entries (>72h) and reconciles disk state vs pool state
+
+## Integration
+
+Works with [ai-dossier](https://github.com/imboard-ai/ai-dossier) workflows:
+
+- `setup-issue-workflow` v1.6.0+ auto-claims from pool when available
+- `full-cycle-issue` v2.5.0+ returns worktrees to pool after merge
+- `batch-issues.sh --pool` pre-warms before spawning agents
+
+## License
+
+AGPL-3.0-only

--- a/packages/worktree-pool/package.json
+++ b/packages/worktree-pool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-dossier/worktree-pool",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pre-warmed git worktree pool for instant issue setup",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- **Fix CI publish**: Add `registry-url` to `setup-node` in the publish job — without this, OIDC auth was never configured and all `npm publish --provenance` calls fail with ENEEDAUTH
- **Add README** for `@ai-dossier/worktree-pool` — shown on npmjs.com package page
- **Bump all versions** so CI detects unpublished versions and triggers publish:
  - `@ai-dossier/core` 1.0.2 → 1.0.3
  - `@ai-dossier/cli` 0.5.0 → 0.5.1
  - `@ai-dossier/mcp-server` 1.0.4 → 1.0.5
  - `@ai-dossier/worktree-pool` 0.1.0 → 0.1.1

## Test plan
- CI passes (lint, test, build)
- After merge, publish workflow should successfully publish all 4 packages via OIDC provenance
- Verify: `npm view @ai-dossier/worktree-pool@0.1.1`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>