### PR TITLE
docs: improve package READMEs for npm

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,4 +1,8 @@
-# Dossier CLI - Security Verification Tool
+# @ai-dossier/cli
+
+[![npm version](https://img.shields.io/npm/v/@ai-dossier/cli)](https://www.npmjs.com/package/@ai-dossier/cli)
+[![npm downloads](https://img.shields.io/npm/dm/@ai-dossier/cli)](https://www.npmjs.com/package/@ai-dossier/cli)
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://github.com/imboard-ai/ai-dossier/blob/main/LICENSE)
 
 **Enforce cryptographic verification before executing dossiers.**
 
@@ -687,11 +691,18 @@ Exit 0 (safe) or 1 (unsafe)
 - ✅ CLI parity with dossier-tools
 - ✅ `@ai-dossier` npm scope and CI/CD publishing
 
-### v0.4.0 (Current)
+### v0.4.0
 - ✅ Unified dossier parser across core/cli/mcp
 - ✅ JSON output mode (`--json` flag on commands)
 - ✅ Registry integration (publish, remove, install-skill)
 - ✅ Non-TTY stdin detection
+
+### v0.5.0 (Current)
+- ✅ Multi-registry support with parallel resolution
+- ✅ `dossier create` command with meta-dossier templates
+- ✅ `dossier export` and `dossier pull` commands
+- ✅ Agent discovery (`--agent` flag)
+- ✅ Enhanced auth: browser OAuth and env-based tokens
 
 ### v1.0.0 (Stable)
 - ⏳ Complete signature verification

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,4 +1,8 @@
-# Dossier MCP Server
+# @ai-dossier/mcp-server
+
+[![npm version](https://img.shields.io/npm/v/@ai-dossier/mcp-server)](https://www.npmjs.com/package/@ai-dossier/mcp-server)
+[![npm downloads](https://img.shields.io/npm/dm/@ai-dossier/mcp-server)](https://www.npmjs.com/package/@ai-dossier/mcp-server)
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://github.com/imboard-ai/ai-dossier/blob/main/LICENSE)
 
 MCP server for the dossier automation standard. Enables LLMs to discover, verify, and execute dossiers through the [Model Context Protocol](https://modelcontextprotocol.io/).
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,9 @@
 # @ai-dossier/core
 
+[![npm version](https://img.shields.io/npm/v/@ai-dossier/core)](https://www.npmjs.com/package/@ai-dossier/core)
+[![npm downloads](https://img.shields.io/npm/dm/@ai-dossier/core)](https://www.npmjs.com/package/@ai-dossier/core)
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://github.com/imboard-ai/ai-dossier/blob/main/LICENSE)
+
 Core parsing, verification, and linting logic for the [Dossier](https://github.com/imboard-ai/ai-dossier) automation standard.
 
 ## Installation
@@ -8,7 +12,7 @@ Core parsing, verification, and linting logic for the [Dossier](https://github.c
 npm install @ai-dossier/core
 ```
 
-Requires Node.js >= 18.0.0.
+Requires Node.js >= 20.0.0.
 
 ## Quick Start
 
@@ -225,6 +229,16 @@ import type {
   FormatOptions,        // { indent, sortKeys, updateChecksum }
   FormatResult,         // { formatted, changed }
 } from '@ai-dossier/core';
+```
+
+## Development
+
+Part of the [ai-dossier](https://github.com/imboard-ai/ai-dossier) monorepo.
+
+```bash
+npm run build -w packages/core    # build
+npm run test -w packages/core     # test
+make build-core                   # build via Makefile
 ```
 
 ## License

--- a/packages/worktree-pool/README.md
+++ b/packages/worktree-pool/README.md
@@ -1,5 +1,9 @@
 # @ai-dossier/worktree-pool
 
+[![npm version](https://img.shields.io/npm/v/@ai-dossier/worktree-pool)](https://www.npmjs.com/package/@ai-dossier/worktree-pool)
+[![npm downloads](https://img.shields.io/npm/dm/@ai-dossier/worktree-pool)](https://www.npmjs.com/package/@ai-dossier/worktree-pool)
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://github.com/imboard-ai/ai-dossier/blob/main/LICENSE)
+
 Pre-warmed git worktree pool for instant issue setup. Eliminates the ~3-5 minute cold start (git worktree add + npm install + build) by maintaining a pool of ready-to-use worktrees.
 
 ## Install
@@ -13,6 +17,8 @@ Or use directly with npx:
 ```bash
 npx @ai-dossier/worktree-pool status
 ```
+
+Requires Node.js >= 20.0.0.
 
 ## Commands
 
@@ -51,10 +57,40 @@ worktree-pool gc
 
 ## How It Works
 
+```
+replenish          claim               return
+    |                 |                   |
+    v                 v                   v
+origin/main ──> [warm worktree] ──> [assigned] ──> [recycled/warm]
+                 npm install         rename to       reset to
+                 + build             feature branch  temp branch
+```
+
 1. **Replenish** creates worktrees from `origin/main` on temp branches, runs `npm install` and builds
-2. **Claim** renames a warm worktree, switches to your feature branch — instant setup
+2. **Claim** renames a warm worktree, switches to your feature branch — instant setup (~2s)
 3. **Return** recycles the worktree back to pool on a fresh temp branch
 4. **GC** removes stale entries (>72h) and reconciles disk state vs pool state
+
+### Pool State
+
+Pool state is stored in `worktrees/.pool-state.json` (automatically gitignored). Each worktree transitions through:
+
+```
+creating -> warming -> warm -> assigned -> recycling -> warm
+                                       -> destroying
+```
+
+Concurrent access is protected by atomic `mkdir`-based file locking.
+
+## Configuration
+
+Default pool settings (configurable via `.pool-state.json`):
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `target_spares` | 5 | Number of warm spares to maintain |
+| `max_pool_size` | 10 | Maximum total worktrees in pool |
+| `stale_after_hours` | 72 | Hours before a warm worktree is considered stale |
 
 ## Integration
 
@@ -64,6 +100,23 @@ Works with [ai-dossier](https://github.com/imboard-ai/ai-dossier) workflows:
 - `full-cycle-issue` v2.5.0+ returns worktrees to pool after merge
 - `batch-issues.sh --pool` pre-warms before spawning agents
 
+### Batch Example
+
+```bash
+# Pre-warm pool, then spawn agents for issues 100-105
+./scripts/batch-issues.sh --pool 100..105
+```
+
+## Development
+
+Part of the [ai-dossier](https://github.com/imboard-ai/ai-dossier) monorepo.
+
+```bash
+npm run build -w packages/worktree-pool    # build
+npm run test -w packages/worktree-pool     # test
+make build-pool                            # build via Makefile
+```
+
 ## License
 
-AGPL-3.0-only
+[AGPL-3.0](https://github.com/imboard-ai/ai-dossier/blob/main/LICENSE)


### PR DESCRIPTION
## Summary
- Add npm version/downloads/license badges to all 4 package READMEs
- Fix Node.js version in core (18 -> 20)
- Update CLI roadmap (v0.5.0 section, mark as Current)
- Expand worktree-pool README with state diagram, config table, batch example
- Add development sections where missing

After merge + version bump, the updated READMEs will appear on each package's npmjs.com page.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>