### PR TITLE
chore: bump all packages minor version

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-dossier/cli",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Command-line tool for creating, verifying, and executing dossiers",
   "main": "dist/cli.js",
   "bin": {

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dossier/mcp-server",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dossier/mcp-server",
-      "version": "1.0.5",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.927.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-dossier/mcp-server",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "MCP server for dossier automation standard - enables LLMs to discover, verify, and execute dossiers",
   "main": "dist/index.js",
   "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
     },
     "cli": {
       "name": "@ai-dossier/cli",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ai-dossier/core": "^1.0.1",
@@ -48,7 +48,7 @@
     },
     "mcp-server": {
       "name": "@ai-dossier/mcp-server",
-      "version": "1.0.5",
+      "version": "1.1.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ai-dossier/core": "^1.0.1",
@@ -6979,7 +6979,7 @@
     },
     "packages/core": {
       "name": "@ai-dossier/core",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.927.0",
@@ -6999,7 +6999,7 @@
     },
     "packages/worktree-pool": {
       "name": "@ai-dossier/worktree-pool",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "AGPL-3.0-only",
       "bin": {
         "worktree-pool": "dist/cli.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-dossier/core",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Core verification and parsing logic for dossier automation standard",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/worktree-pool/package.json
+++ b/packages/worktree-pool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-dossier/worktree-pool",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pre-warmed git worktree pool for instant issue setup",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Minor version bump for all 4 packages to publish updated READMEs to npm.

| Package | Old | New |
|---------|-----|-----|
| `@ai-dossier/core` | 1.0.3 | 1.1.0 |
| `@ai-dossier/cli` | 0.5.1 | 0.6.0 |
| `@ai-dossier/mcp-server` | 1.0.5 | 1.1.0 |
| `@ai-dossier/worktree-pool` | 0.1.1 | 0.2.0 |

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>