### PR TITLE
feat(core): add output coherence validation for dossier execution results

### DIFF
--- a/packages/core/src/__tests__/coherence.test.ts
+++ b/packages/core/src/__tests__/coherence.test.ts
@@ -1,0 +1,407 @@
+import { describe, expect, it } from 'vitest';
+import type { CoherenceContext, DeclaredOutputSchema, StepOutput } from '../coherence';
+import { validateCoherence, validateStepCoherence } from '../coherence';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStep(name: string, index: number, outputs: Record<string, unknown>): StepOutput {
+  return { stepName: name, stepIndex: index, outputs };
+}
+
+function makeContext(
+  steps: StepOutput[],
+  schemas?: Map<string, DeclaredOutputSchema>
+): CoherenceContext {
+  return { steps, declaredSchemas: schemas };
+}
+
+// ---------------------------------------------------------------------------
+// validateCoherence — full journey validation
+// ---------------------------------------------------------------------------
+
+describe('validateCoherence', () => {
+  it('should return coherent for a clean journey with no issues', () => {
+    const result = validateCoherence(
+      makeContext([
+        makeStep('setup', 0, { project_path: '/tmp/app' }),
+        makeStep('build', 1, { artifact_path: '/tmp/app/dist' }),
+      ])
+    );
+
+    expect(result.coherent).toBe(true);
+    expect(result.errorCount).toBe(0);
+    expect(result.warningCount).toBe(0);
+  });
+
+  it('should return coherent:true for info-only diagnostics', () => {
+    const result = validateCoherence(makeContext([makeStep('setup', 0, { flag: 'true' })]));
+
+    // boolean-string info diagnostic
+    expect(result.infoCount).toBeGreaterThan(0);
+    expect(result.coherent).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema compliance checks
+// ---------------------------------------------------------------------------
+
+describe('schema compliance', () => {
+  const schemas = new Map<string, DeclaredOutputSchema>([
+    [
+      'setup',
+      {
+        configuration: [
+          { key: 'project_path', description: 'Root project path' },
+          { key: 'db_url', description: 'Database connection URL' },
+        ],
+      },
+    ],
+  ]);
+
+  it('should warn when a declared output key is missing from step outputs', () => {
+    const result = validateCoherence(
+      makeContext([makeStep('setup', 0, { project_path: '/tmp/app' })], schemas)
+    );
+
+    const missing = result.diagnostics.filter(
+      (d) => d.checkId === 'schema-compliance' && d.field === 'db_url'
+    );
+    expect(missing).toHaveLength(1);
+    expect(missing[0].severity).toBe('warning');
+    expect(missing[0].message).toContain('not reported');
+  });
+
+  it('should info when an undeclared output key is present', () => {
+    const result = validateCoherence(
+      makeContext(
+        [makeStep('setup', 0, { project_path: '/tmp/app', db_url: 'pg://...', extra_key: 'val' })],
+        schemas
+      )
+    );
+
+    const undeclared = result.diagnostics.filter(
+      (d) => d.checkId === 'schema-compliance' && d.field === 'extra_key'
+    );
+    expect(undeclared).toHaveLength(1);
+    expect(undeclared[0].severity).toBe('info');
+  });
+
+  it('should pass cleanly when all declared keys are present and no extras', () => {
+    const result = validateCoherence(
+      makeContext(
+        [makeStep('setup', 0, { project_path: '/tmp/app', db_url: 'pg://localhost/db' })],
+        schemas
+      )
+    );
+
+    const schemaIssues = result.diagnostics.filter((d) => d.checkId === 'schema-compliance');
+    expect(schemaIssues).toHaveLength(0);
+  });
+
+  it('should skip schema checks when no declaredSchemas provided', () => {
+    const result = validateCoherence(makeContext([makeStep('setup', 0, { anything: 'goes' })]));
+
+    const schemaIssues = result.diagnostics.filter((d) => d.checkId === 'schema-compliance');
+    expect(schemaIssues).toHaveLength(0);
+  });
+
+  it('should skip schema checks for steps not in the schema map', () => {
+    const result = validateCoherence(
+      makeContext([makeStep('unknown-step', 0, { key: 'val' })], schemas)
+    );
+
+    const schemaIssues = result.diagnostics.filter((d) => d.checkId === 'schema-compliance');
+    expect(schemaIssues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Anomaly detection
+// ---------------------------------------------------------------------------
+
+describe('anomaly detection', () => {
+  it('should warn on empty outputs', () => {
+    const result = validateCoherence(makeContext([makeStep('setup', 0, {})]));
+
+    const empty = result.diagnostics.filter((d) => d.checkId === 'anomaly-empty-output');
+    expect(empty).toHaveLength(1);
+    expect(empty[0].severity).toBe('warning');
+    expect(empty[0].message).toContain('no outputs');
+  });
+
+  it('should warn on null values', () => {
+    const result = validateCoherence(makeContext([makeStep('setup', 0, { path: null })]));
+
+    const nullDiags = result.diagnostics.filter((d) => d.checkId === 'anomaly-null-value');
+    expect(nullDiags).toHaveLength(1);
+    expect(nullDiags[0].field).toBe('path');
+  });
+
+  it('should warn on undefined values', () => {
+    const result = validateCoherence(makeContext([makeStep('setup', 0, { path: undefined })]));
+
+    const undefDiags = result.diagnostics.filter((d) => d.checkId === 'anomaly-null-value');
+    expect(undefDiags).toHaveLength(1);
+  });
+
+  it('should info on empty string values', () => {
+    const result = validateCoherence(makeContext([makeStep('setup', 0, { path: '' })]));
+
+    const emptyStr = result.diagnostics.filter((d) => d.checkId === 'anomaly-empty-value');
+    expect(emptyStr).toHaveLength(1);
+    expect(emptyStr[0].severity).toBe('info');
+  });
+
+  it('should detect size outliers when one step has drastically more outputs', () => {
+    const result = validateCoherence(
+      makeContext([
+        makeStep('step-a', 0, { a: '1' }),
+        makeStep('step-b', 1, { b: '2' }),
+        makeStep('step-c', 2, {
+          c1: '1',
+          c2: '2',
+          c3: '3',
+          c4: '4',
+          c5: '5',
+          c6: '6',
+          c7: '7',
+          c8: '8',
+          c9: '9',
+          c10: '10',
+          c11: '11',
+          c12: '12',
+          c13: '13',
+          c14: '14',
+          c15: '15',
+        }),
+      ])
+    );
+
+    const outliers = result.diagnostics.filter((d) => d.checkId === 'anomaly-size-outlier');
+    expect(outliers).toHaveLength(1);
+    expect(outliers[0].stepName).toBe('step-c');
+  });
+
+  it('should not flag size outliers when all steps have similar sizes', () => {
+    const result = validateCoherence(
+      makeContext([
+        makeStep('a', 0, { x: '1', y: '2' }),
+        makeStep('b', 1, { x: '1', y: '2', z: '3' }),
+        makeStep('c', 2, { x: '1', y: '2' }),
+      ])
+    );
+
+    const outliers = result.diagnostics.filter((d) => d.checkId === 'anomaly-size-outlier');
+    expect(outliers).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-step coherence
+// ---------------------------------------------------------------------------
+
+describe('cross-step coherence', () => {
+  it('should warn when the same key has different values across steps', () => {
+    const result = validateCoherence(
+      makeContext([
+        makeStep('setup', 0, { db_host: 'localhost' }),
+        makeStep('deploy', 1, { db_host: 'production.rds.amazonaws.com' }),
+      ])
+    );
+
+    const drift = result.diagnostics.filter((d) => d.checkId === 'cross-step-value-drift');
+    expect(drift).toHaveLength(1);
+    expect(drift[0].severity).toBe('warning');
+    expect(drift[0].message).toContain('localhost');
+    expect(drift[0].message).toContain('production.rds.amazonaws.com');
+  });
+
+  it('should not warn when the same key has the same value across steps', () => {
+    const result = validateCoherence(
+      makeContext([
+        makeStep('setup', 0, { db_host: 'localhost' }),
+        makeStep('deploy', 1, { db_host: 'localhost' }),
+      ])
+    );
+
+    const drift = result.diagnostics.filter((d) => d.checkId === 'cross-step-value-drift');
+    expect(drift).toHaveLength(0);
+  });
+
+  it('should not produce cross-step diagnostics for a single step', () => {
+    const result = validateCoherence(makeContext([makeStep('setup', 0, { path: '/tmp/app' })]));
+
+    const crossStep = result.diagnostics.filter((d) => d.checkId === 'cross-step-value-drift');
+    expect(crossStep).toHaveLength(0);
+  });
+
+  it('should track value drift across multiple steps', () => {
+    const result = validateCoherence(
+      makeContext([
+        makeStep('step-a', 0, { port: '5432' }),
+        makeStep('step-b', 1, { port: '5432' }), // same — no warning
+        makeStep('step-c', 2, { port: '3306' }), // changed — warning
+      ])
+    );
+
+    const drift = result.diagnostics.filter((d) => d.checkId === 'cross-step-value-drift');
+    expect(drift).toHaveLength(1);
+    expect(drift[0].stepName).toBe('step-c');
+  });
+
+  it('should ignore non-string values for cross-step checks', () => {
+    const result = validateCoherence(
+      makeContext([makeStep('a', 0, { count: 5 }), makeStep('b', 1, { count: 10 })])
+    );
+
+    const drift = result.diagnostics.filter((d) => d.checkId === 'cross-step-value-drift');
+    expect(drift).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Internal consistency
+// ---------------------------------------------------------------------------
+
+describe('internal consistency', () => {
+  it('should info when multiple keys have the same non-trivial value', () => {
+    const result = validateCoherence(
+      makeContext([
+        makeStep('setup', 0, {
+          source_path: '/tmp/project/src',
+          output_path: '/tmp/project/src',
+        }),
+      ])
+    );
+
+    const dupes = result.diagnostics.filter((d) => d.checkId === 'internal-duplicate-values');
+    expect(dupes).toHaveLength(1);
+    expect(dupes[0].message).toContain('source_path');
+    expect(dupes[0].message).toContain('output_path');
+  });
+
+  it('should not flag trivial duplicate values like "true" or "false"', () => {
+    const result = validateCoherence(
+      makeContext([
+        makeStep('setup', 0, {
+          feature_a: 'true',
+          feature_b: 'true',
+        }),
+      ])
+    );
+
+    const dupes = result.diagnostics.filter((d) => d.checkId === 'internal-duplicate-values');
+    expect(dupes).toHaveLength(0);
+  });
+
+  it('should info on boolean-like strings', () => {
+    const result = validateCoherence(makeContext([makeStep('setup', 0, { is_ready: 'true' })]));
+
+    const boolStr = result.diagnostics.filter((d) => d.checkId === 'internal-boolean-string');
+    expect(boolStr).toHaveLength(1);
+    expect(boolStr[0].severity).toBe('info');
+    expect(boolStr[0].message).toContain('boolean');
+  });
+
+  it('should not flag actual booleans', () => {
+    const result = validateCoherence(makeContext([makeStep('setup', 0, { is_ready: true })]));
+
+    const boolStr = result.diagnostics.filter((d) => d.checkId === 'internal-boolean-string');
+    expect(boolStr).toHaveLength(0);
+  });
+
+  it('should skip internal consistency checks for single-key outputs', () => {
+    const result = validateCoherence(
+      makeContext([makeStep('setup', 0, { only_key: '/same/path' })])
+    );
+
+    const dupes = result.diagnostics.filter((d) => d.checkId === 'internal-duplicate-values');
+    expect(dupes).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateStepCoherence — incremental single-step validation
+// ---------------------------------------------------------------------------
+
+describe('validateStepCoherence', () => {
+  it('should validate only the current step against prior context', () => {
+    const priorSteps = [makeStep('setup', 0, { db_host: 'localhost' })];
+    const currentStep = makeStep('deploy', 1, { db_host: 'production.rds.amazonaws.com' });
+
+    const result = validateStepCoherence(currentStep, priorSteps);
+
+    expect(result.coherent).toBe(false);
+    const drift = result.diagnostics.filter((d) => d.checkId === 'cross-step-value-drift');
+    expect(drift).toHaveLength(1);
+  });
+
+  it('should check schema compliance for the current step only', () => {
+    const schemas = new Map<string, DeclaredOutputSchema>([
+      ['deploy', { configuration: [{ key: 'endpoint', description: 'API endpoint' }] }],
+    ]);
+
+    const result = validateStepCoherence(makeStep('deploy', 1, {}), [], schemas);
+
+    // Empty output warning + missing schema key
+    const schemaIssues = result.diagnostics.filter((d) => d.checkId === 'schema-compliance');
+    expect(schemaIssues.some((d) => d.field === 'endpoint')).toBe(true);
+  });
+
+  it('should return coherent when no issues found', () => {
+    const priorSteps = [makeStep('setup', 0, { project_path: '/tmp/app' })];
+    const currentStep = makeStep('build', 1, { artifact_path: '/tmp/app/dist' });
+
+    const result = validateStepCoherence(currentStep, priorSteps);
+
+    expect(result.coherent).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe('edge cases', () => {
+  it('should handle empty steps array', () => {
+    const result = validateCoherence(makeContext([]));
+
+    expect(result.coherent).toBe(true);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it('should handle steps with complex non-string values gracefully', () => {
+    const result = validateCoherence(
+      makeContext([
+        makeStep('setup', 0, {
+          config: { nested: 'object' },
+          items: [1, 2, 3],
+          count: 42,
+        }),
+      ])
+    );
+
+    // Should not throw, and non-string values should be ignored by entity checks
+    expect(result).toBeDefined();
+    expect(result.diagnostics).toBeDefined();
+  });
+
+  it('should truncate long values in diagnostic messages', () => {
+    const longValue = 'a'.repeat(200);
+    const result = validateCoherence(
+      makeContext([
+        makeStep('a', 0, { key: longValue }),
+        makeStep('b', 1, { key: `${longValue}b` }),
+      ])
+    );
+
+    const drift = result.diagnostics.filter((d) => d.checkId === 'cross-step-value-drift');
+    expect(drift).toHaveLength(1);
+    expect(drift[0].message).toContain('...');
+    // Message should not contain the full 200-char value
+    expect(drift[0].message.length).toBeLessThan(400);
+  });
+});

--- a/packages/core/src/coherence/checks.ts
+++ b/packages/core/src/coherence/checks.ts
@@ -1,0 +1,267 @@
+/**
+ * Individual coherence checks for dossier execution outputs.
+ *
+ * Each check is a pure function: (context) => diagnostics[].
+ * Checks are lightweight and fast -- they catch messy failures,
+ * not enforce strict contracts.
+ */
+
+import type { CoherenceContext, CoherenceDiagnostic } from './types';
+
+// ---------------------------------------------------------------------------
+// 1. Schema compliance — do outputs match declared output schemas?
+// ---------------------------------------------------------------------------
+
+export function checkSchemaCompliance(context: CoherenceContext): CoherenceDiagnostic[] {
+  const diagnostics: CoherenceDiagnostic[] = [];
+  if (!context.declaredSchemas) return diagnostics;
+
+  for (const step of context.steps) {
+    const schema = context.declaredSchemas.get(step.stepName);
+    if (!schema) continue;
+
+    // Check that declared configuration keys are present in outputs
+    if (schema.configuration) {
+      for (const declared of schema.configuration) {
+        if (!(declared.key in step.outputs)) {
+          diagnostics.push({
+            checkId: 'schema-compliance',
+            severity: 'warning',
+            message: `Step "${step.stepName}" declares output "${declared.key}" but it was not reported`,
+            stepName: step.stepName,
+            field: declared.key,
+          });
+        }
+      }
+    }
+
+    // Check for undeclared outputs (outputs not in any declared category)
+    const declaredKeys = new Set<string>();
+    if (schema.configuration) {
+      for (const c of schema.configuration) {
+        declaredKeys.add(c.key);
+      }
+    }
+
+    if (declaredKeys.size > 0) {
+      for (const key of Object.keys(step.outputs)) {
+        if (!declaredKeys.has(key)) {
+          diagnostics.push({
+            checkId: 'schema-compliance',
+            severity: 'info',
+            message: `Step "${step.stepName}" reported undeclared output "${key}" — not in outputs.configuration`,
+            stepName: step.stepName,
+            field: key,
+          });
+        }
+      }
+    }
+  }
+
+  return diagnostics;
+}
+
+// ---------------------------------------------------------------------------
+// 2. Anomaly detection — unexpected empty outputs, size outliers
+// ---------------------------------------------------------------------------
+
+/** Ratio threshold: a step's output count differs from the mean by more than this factor */
+const SIZE_OUTLIER_FACTOR = 3;
+
+export function checkAnomalies(context: CoherenceContext): CoherenceDiagnostic[] {
+  const diagnostics: CoherenceDiagnostic[] = [];
+
+  for (const step of context.steps) {
+    // Empty output check
+    if (Object.keys(step.outputs).length === 0) {
+      diagnostics.push({
+        checkId: 'anomaly-empty-output',
+        severity: 'warning',
+        message: `Step "${step.stepName}" completed with no outputs — expected at least one key`,
+        stepName: step.stepName,
+      });
+      continue;
+    }
+
+    // Null / undefined value check
+    for (const [key, value] of Object.entries(step.outputs)) {
+      if (value === null || value === undefined) {
+        diagnostics.push({
+          checkId: 'anomaly-null-value',
+          severity: 'warning',
+          message: `Step "${step.stepName}" output "${key}" is ${value === null ? 'null' : 'undefined'}`,
+          stepName: step.stepName,
+          field: key,
+        });
+      }
+      if (value === '') {
+        diagnostics.push({
+          checkId: 'anomaly-empty-value',
+          severity: 'info',
+          message: `Step "${step.stepName}" output "${key}" is an empty string`,
+          stepName: step.stepName,
+          field: key,
+        });
+      }
+    }
+  }
+
+  // Size outlier detection: flag steps whose key count is drastically larger than
+  // the median of all other steps. Using median (not mean) prevents a single outlier
+  // from skewing the baseline.
+  const completedSteps = context.steps.filter((s) => Object.keys(s.outputs).length > 0);
+  if (completedSteps.length >= 3) {
+    for (const step of completedSteps) {
+      const size = Object.keys(step.outputs).length;
+      const otherSizes = completedSteps
+        .filter((s) => s !== step)
+        .map((s) => Object.keys(s.outputs).length)
+        .sort((a, b) => a - b);
+
+      const median =
+        otherSizes.length % 2 === 0
+          ? (otherSizes[otherSizes.length / 2 - 1] + otherSizes[otherSizes.length / 2]) / 2
+          : otherSizes[Math.floor(otherSizes.length / 2)];
+
+      if (median > 0 && size / median > SIZE_OUTLIER_FACTOR) {
+        diagnostics.push({
+          checkId: 'anomaly-size-outlier',
+          severity: 'info',
+          message: `Step "${step.stepName}" has ${size} output keys — ${(size / median).toFixed(1)}x the median of ${median}`,
+          stepName: step.stepName,
+        });
+      }
+    }
+  }
+
+  return diagnostics;
+}
+
+// ---------------------------------------------------------------------------
+// 3. Cross-step coherence — does step N's output make sense given step N-1?
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts "entity-like" string values from an output record.
+ * Looks for values that resemble paths, URLs, identifiers, etc.
+ */
+function extractEntityValues(outputs: Record<string, unknown>): Map<string, string> {
+  const entities = new Map<string, string>();
+  for (const [key, value] of Object.entries(outputs)) {
+    if (typeof value === 'string' && value.length > 0) {
+      entities.set(key, value);
+    }
+  }
+  return entities;
+}
+
+export function checkCrossStepCoherence(context: CoherenceContext): CoherenceDiagnostic[] {
+  const diagnostics: CoherenceDiagnostic[] = [];
+  if (context.steps.length < 2) return diagnostics;
+
+  // Build a map of all outputs from prior steps
+  const priorOutputs = new Map<string, { value: string; fromStep: string }>();
+
+  for (let i = 0; i < context.steps.length; i++) {
+    const step = context.steps[i];
+
+    if (i > 0) {
+      // Check if this step references keys from prior steps with different values
+      const currentEntities = extractEntityValues(step.outputs);
+
+      for (const [key, currentValue] of currentEntities) {
+        const prior = priorOutputs.get(key);
+        if (prior && prior.value !== currentValue) {
+          diagnostics.push({
+            checkId: 'cross-step-value-drift',
+            severity: 'warning',
+            message:
+              `Output key "${key}" changed from "${truncate(prior.value)}" (step "${prior.fromStep}") ` +
+              `to "${truncate(currentValue)}" (step "${step.stepName}") — verify this is intentional`,
+            stepName: step.stepName,
+            field: key,
+          });
+        }
+      }
+    }
+
+    // Add this step's outputs to the prior map
+    const entities = extractEntityValues(step.outputs);
+    for (const [key, value] of entities) {
+      priorOutputs.set(key, { value, fromStep: step.stepName });
+    }
+  }
+
+  return diagnostics;
+}
+
+// ---------------------------------------------------------------------------
+// 4. Internal consistency — within a single step's outputs
+// ---------------------------------------------------------------------------
+
+export function checkInternalConsistency(context: CoherenceContext): CoherenceDiagnostic[] {
+  const diagnostics: CoherenceDiagnostic[] = [];
+
+  for (const step of context.steps) {
+    const entries = Object.entries(step.outputs);
+    if (entries.length === 0) continue;
+
+    // Check for duplicate values under different keys (potential copy-paste / hallucination)
+    // Only meaningful when there are at least 2 entries
+    if (entries.length >= 2) {
+      const valueMap = new Map<string, string[]>();
+      for (const [key, value] of entries) {
+        if (typeof value === 'string' && value.length > 0) {
+          const existing = valueMap.get(value) || [];
+          existing.push(key);
+          valueMap.set(value, existing);
+        }
+      }
+
+      const trivialValues = new Set(['true', 'false', 'yes', 'no', 'ok', 'none', 'null']);
+      for (const [value, keys] of valueMap) {
+        if (keys.length > 1 && value.length > 3) {
+          if (!trivialValues.has(value.toLowerCase())) {
+            diagnostics.push({
+              checkId: 'internal-duplicate-values',
+              severity: 'info',
+              message:
+                `Step "${step.stepName}" has identical value "${truncate(value)}" ` +
+                `for keys: ${keys.join(', ')} — possible copy-paste error`,
+              stepName: step.stepName,
+            });
+          }
+        }
+      }
+    }
+
+    // Check for boolean-like string inconsistencies (e.g., "true" vs true)
+    for (const [key, value] of entries) {
+      if (typeof value === 'string') {
+        const lower = value.toLowerCase();
+        if (lower === 'true' || lower === 'false') {
+          diagnostics.push({
+            checkId: 'internal-boolean-string',
+            severity: 'info',
+            message:
+              `Step "${step.stepName}" output "${key}" is "${value}" (string) ` +
+              `instead of ${lower === 'true'} (boolean) — may cause type mismatches downstream`,
+            stepName: step.stepName,
+            field: key,
+          });
+        }
+      }
+    }
+  }
+
+  return diagnostics;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function truncate(value: string, maxLen = 60): string {
+  if (value.length <= maxLen) return value;
+  return `${value.slice(0, maxLen - 3)}...`;
+}

--- a/packages/core/src/coherence/index.ts
+++ b/packages/core/src/coherence/index.ts
@@ -1,0 +1,111 @@
+/**
+ * Output coherence validation for dossier execution results.
+ *
+ * Inspired by Anthropic's ICLR 2026 finding that AI fails incoherently
+ * on complex tasks (not systematically). This module provides lightweight
+ * sanity checks that catch the messy failures:
+ *
+ * - Schema compliance: do outputs match declared output schemas?
+ * - Anomaly detection: unexpected empty outputs, null values, size outliers
+ * - Cross-step coherence: does step N's output make sense given step N-1?
+ * - Internal consistency: duplicate values, type mismatches within a step
+ *
+ * Usage:
+ *   import { validateCoherence } from '@ai-dossier/core';
+ *
+ *   const result = validateCoherence({
+ *     steps: [
+ *       { stepName: 'setup', stepIndex: 0, outputs: { path: '/tmp/app' } },
+ *       { stepName: 'build', stepIndex: 1, outputs: { artifact: '/tmp/app/dist' } },
+ *     ],
+ *   });
+ *
+ *   if (!result.coherent) {
+ *     console.warn('Coherence issues found:', result.diagnostics);
+ *   }
+ */
+
+import {
+  checkAnomalies,
+  checkCrossStepCoherence,
+  checkInternalConsistency,
+  checkSchemaCompliance,
+} from './checks';
+import type { CoherenceContext, CoherenceDiagnostic, CoherenceResult } from './types';
+
+export type {
+  CoherenceContext,
+  CoherenceDiagnostic,
+  CoherenceResult,
+  CoherenceSeverity,
+  DeclaredOutputSchema,
+  StepOutput,
+} from './types';
+
+/**
+ * Run all coherence checks against a set of step outputs.
+ * Returns a result with diagnostics and summary counts.
+ */
+export function validateCoherence(context: CoherenceContext): CoherenceResult {
+  const diagnostics: CoherenceDiagnostic[] = [
+    ...checkSchemaCompliance(context),
+    ...checkAnomalies(context),
+    ...checkCrossStepCoherence(context),
+    ...checkInternalConsistency(context),
+  ];
+
+  const errorCount = diagnostics.filter((d) => d.severity === 'error').length;
+  const warningCount = diagnostics.filter((d) => d.severity === 'warning').length;
+  const infoCount = diagnostics.filter((d) => d.severity === 'info').length;
+
+  return {
+    diagnostics,
+    errorCount,
+    warningCount,
+    infoCount,
+    coherent: errorCount === 0 && warningCount === 0,
+  };
+}
+
+/**
+ * Validate coherence for a single step's outputs (e.g., called after each step_complete).
+ * This is a lighter-weight version that only checks the latest step against prior context.
+ */
+export function validateStepCoherence(
+  currentStep: { stepName: string; stepIndex: number; outputs: Record<string, unknown> },
+  priorSteps: Array<{ stepName: string; stepIndex: number; outputs: Record<string, unknown> }>,
+  declaredSchema?: Map<string, import('./types').DeclaredOutputSchema>
+): CoherenceResult {
+  const context: CoherenceContext = {
+    steps: [...priorSteps, currentStep],
+    declaredSchemas: declaredSchema,
+  };
+
+  // Run all checks but filter to only diagnostics about the current step
+  const allDiagnostics: CoherenceDiagnostic[] = [
+    ...checkSchemaCompliance({
+      steps: [currentStep],
+      declaredSchemas: declaredSchema,
+    }),
+    ...checkAnomalies({
+      steps: [currentStep],
+      declaredSchemas: declaredSchema,
+    }),
+    ...checkCrossStepCoherence(context),
+    ...checkInternalConsistency({
+      steps: [currentStep],
+    }),
+  ];
+
+  const errorCount = allDiagnostics.filter((d) => d.severity === 'error').length;
+  const warningCount = allDiagnostics.filter((d) => d.severity === 'warning').length;
+  const infoCount = allDiagnostics.filter((d) => d.severity === 'info').length;
+
+  return {
+    diagnostics: allDiagnostics,
+    errorCount,
+    warningCount,
+    infoCount,
+    coherent: errorCount === 0 && warningCount === 0,
+  };
+}

--- a/packages/core/src/coherence/types.ts
+++ b/packages/core/src/coherence/types.ts
@@ -1,0 +1,58 @@
+/**
+ * Types for output coherence validation.
+ *
+ * Coherence validation catches the "incoherent failures" described in
+ * Anthropic's ICLR 2026 research: AI doesn't fail systematically on
+ * complex tasks -- it fails *messily*. These types support lightweight
+ * sanity checks on dossier execution outputs.
+ */
+
+export type CoherenceSeverity = 'error' | 'warning' | 'info';
+
+export interface CoherenceDiagnostic {
+  checkId: string;
+  severity: CoherenceSeverity;
+  message: string;
+  stepName?: string;
+  field?: string;
+}
+
+/**
+ * A single step's output record, as reported by the LLM via step_complete.
+ * Maps output key -> value.
+ */
+export interface StepOutput {
+  stepName: string;
+  stepIndex: number;
+  outputs: Record<string, unknown>;
+}
+
+/**
+ * Declared output schema from a dossier's frontmatter `outputs` field.
+ * Maps step name -> declared output keys and their metadata.
+ */
+export interface DeclaredOutputSchema {
+  files?: Array<{ path: string; description: string; required?: boolean; format?: string }>;
+  configuration?: Array<{ key: string; description: string; export_as?: string }>;
+  state_changes?: Array<{ description: string; affects?: string; reversible?: boolean }>;
+  artifacts?: Array<{ path: string; purpose: string; type?: string }>;
+}
+
+/**
+ * Full context for coherence validation across a journey.
+ */
+export interface CoherenceContext {
+  /** All step outputs collected so far, in execution order. */
+  steps: StepOutput[];
+  /** Declared output schemas per step name (from frontmatter). */
+  declaredSchemas?: Map<string, DeclaredOutputSchema>;
+}
+
+export interface CoherenceResult {
+  diagnostics: CoherenceDiagnostic[];
+  errorCount: number;
+  warningCount: number;
+  infoCount: number;
+  /** true when no errors or warnings were found */
+  coherent: boolean;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,11 +5,22 @@
  * - Dossier parsing (frontmatter + body extraction)
  * - Checksum verification (SHA256 integrity checks)
  * - Signature verification (Minisign and AWS KMS)
+ * - Output coherence validation
  * - TypeScript type definitions
  */
 
 // Checksum exports
 export { calculateChecksum, verifyIntegrity } from './checksum';
+// Coherence validation exports
+export type {
+  CoherenceContext,
+  CoherenceDiagnostic,
+  CoherenceResult,
+  CoherenceSeverity,
+  DeclaredOutputSchema,
+  StepOutput,
+} from './coherence';
+export { validateCoherence, validateStepCoherence } from './coherence';
 export type { FormatOptions, FormatResult } from './formatter';
 // Formatter exports
 export { formatDossierContent, formatDossierFile } from './formatter';


### PR DESCRIPTION
## Summary

Closes #369

Adds a lightweight output coherence validation layer to `@ai-dossier/core` that catches incoherent AI failures in dossier execution results. Inspired by Anthropic's ICLR 2026 finding that AI fails *messily* on complex tasks (not systematically), this module provides sanity checks across four categories:

- **Schema compliance** -- validates that step outputs match declared `outputs.configuration` keys from frontmatter, and flags undeclared extras
- **Anomaly detection** -- catches empty outputs, null/undefined values, empty strings, and size outliers (steps with drastically more keys than peers, using median-based detection)
- **Cross-step coherence** -- detects value drift when the same output key appears in multiple steps with different values (e.g., `db_host` changing from `localhost` to `production.rds.amazonaws.com`)
- **Internal consistency** -- flags duplicate non-trivial values across keys (possible copy-paste hallucination) and boolean-like strings (`"true"` instead of `true`)

Two public APIs:
- `validateCoherence(context)` -- full-journey validation across all steps
- `validateStepCoherence(currentStep, priorSteps, schema?)` -- incremental per-step validation (for use in `step_complete`)

### Files changed

| File | Purpose |
|------|---------|
| `packages/core/src/coherence/types.ts` | Type definitions (`CoherenceContext`, `CoherenceResult`, `StepOutput`, etc.) |
| `packages/core/src/coherence/checks.ts` | Four check functions (pure, no side effects) |
| `packages/core/src/coherence/index.ts` | Public API (`validateCoherence`, `validateStepCoherence`) |
| `packages/core/src/index.ts` | Re-exports coherence types and functions |
| `packages/core/src/__tests__/coherence.test.ts` | 29 tests covering all check categories + edge cases |

## Test plan

- [x] All 29 new coherence tests pass
- [x] Full core test suite passes (194 tests, 0 failures)
- [x] TypeScript compiles with zero errors (`tsc --noEmit`)
- [x] Biome lint + format passes with zero issues
- [ ] Verify CI passes on this branch

Generated with [Claude Code](https://claude.com/claude-code)