### PR TITLE
docs: complete onboarding tutorial suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 > Dossier turns plain-text instructions into executable workflows with built-in verification.
 > Like Dockerfiles for AI automation—structured, portable, verifiable.
 
-**New here?** → [5-min Quick Start](docs/getting-started/installation.md) | **Want to try now?** → [Get started in 30 seconds](#get-started)
+**New here?** → [5-min Quick Start](docs/getting-started/installation.md) | **Using Claude Code?** → [MCP in 60 Seconds](docs/tutorials/mcp-quickstart.md) | **Want to try now?** → [Get started in 30 seconds](#get-started)
 
 ---
 
@@ -212,7 +212,7 @@ See the [CLI documentation](./cli/README.md#config-command) for full registry ma
 
 | | |
 |---|---|
-| **Getting Started** | [Quick Start](docs/getting-started/installation.md) · [Your First Dossier](docs/tutorials/your-first-dossier.md) · [FAQ](docs/explanation/faq.md) |
+| **Getting Started** | [Quick Start](docs/getting-started/installation.md) · [MCP in 60 Seconds](docs/tutorials/mcp-quickstart.md) · [Your First Dossier](docs/tutorials/your-first-dossier.md) · [FAQ](docs/explanation/faq.md) |
 | **Reference** | [Protocol](docs/reference/protocol.md) · [Specification](docs/reference/specification.md) · [Schema](docs/reference/schema.md) · [JSON Schema](./dossier-schema.json) |
 | **Guides** | [Authoring Guidelines](docs/guides/authoring-guidelines.md) · [Dossier Guide](docs/guides/dossier-guide.md) · [Adopter Playbooks](docs/guides/adopter-playbooks.md) · [Examples](./examples/) |
 | **Packages** | [CLI](./cli/) · [MCP Server](./mcp-server/) · [Core Library](./packages/core/) · [Registry](./registry/) |

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -4,15 +4,16 @@ Step-by-step learning experiences designed to help you master Dossier.
 
 ## Available Tutorials
 
-- **[Your First Dossier](./your-first-dossier.md)** - Create, verify, and execute your first dossier
+1. **[MCP in 60 Seconds](./mcp-quickstart.md)** - Add dossier support to Claude Code with one command
+2. **[Your First Dossier](./your-first-dossier.md)** - Create, verify, and execute your first dossier
+3. **[Author and Publish](./author-and-publish.md)** - Write a dossier from scratch and publish it to the registry
+4. **[Record a Demo](./record-a-demo.md)** - Create terminal recordings of dossier executions
 
-## Tutorial Format
+## Where to Start
 
-Each tutorial:
-- Takes you step-by-step through a real-world scenario
-- Assumes no prior knowledge
-- Includes hands-on exercises
-- Shows you how to verify your progress
+- **Using Claude Code?** Start with [MCP in 60 Seconds](./mcp-quickstart.md) -- you will be running dossiers in under a minute.
+- **Want to understand the format?** Start with [Your First Dossier](./your-first-dossier.md) for a hands-on walkthrough of dossier structure.
+- **Ready to create your own?** Jump to [Author and Publish](./author-and-publish.md).
 
 ## Not Finding What You Need?
 

--- a/docs/tutorials/author-and-publish.md
+++ b/docs/tutorials/author-and-publish.md
@@ -1,0 +1,144 @@
+# Author and Publish
+
+Create a dossier, validate it, add a checksum, and publish it to the registry.
+
+## Prerequisites
+
+- Node.js 20+ installed
+- The CLI installed: `npm install -g @ai-dossier/cli`
+- A project directory to work in
+
+## Step 1: Scaffold a Dossier
+
+```bash
+ai-dossier create setup-dev-environment
+```
+
+This creates `setup-dev-environment.ds.md` with the standard template. Open it in your editor.
+
+## Step 2: Write the Dossier
+
+Replace the template content with your own. Here is a minimal example:
+
+```markdown
+---dossier
+{
+  "dossier_schema_version": "1.0.0",
+  "title": "Setup Dev Environment",
+  "version": "1.0.0",
+  "protocol_version": "1.0",
+  "status": "stable",
+  "objective": "Configure a local development environment with all dependencies and tooling",
+  "category": ["development"],
+  "tags": ["setup", "environment"],
+  "risk_level": "low",
+  "risk_factors": ["creates_files", "modifies_files"],
+  "destructive_operations": []
+}
+---
+
+# Setup Dev Environment
+
+## Objective
+
+Configure the local development environment so that the project builds, tests pass, and the dev server starts.
+
+## Constraints
+
+- Use the package manager already configured in the project (check for lock files)
+- Do not modify existing source code
+- Environment variables should go in `.env.local` (gitignored), not `.env`
+
+## Known Pitfalls
+
+- If the project uses a `.nvmrc` or `.node-version` file, switch to the specified Node version before installing dependencies. Mismatched versions cause native module build failures that are hard to debug.
+
+## Validation
+
+- [ ] `npm test` (or equivalent) passes with zero failures
+- [ ] Dev server starts without errors
+- [ ] No uncommitted changes to tracked files (only new gitignored files)
+```
+
+Key authoring principles:
+- State **what** to achieve, not **how** to do it step-by-step
+- Include **constraints** the agent cannot infer from the codebase
+- Document **known pitfalls** that would waste time
+- Write **validation** criteria that are concrete and verifiable
+
+See the [Authoring Guidelines](../guides/authoring-guidelines.md) for detailed guidance.
+
+## Step 3: Validate
+
+Check that the dossier format is correct:
+
+```bash
+ai-dossier validate setup-dev-environment.ds.md
+```
+
+Fix any errors the validator reports (missing required fields, invalid values, etc.).
+
+## Step 4: Add a Checksum
+
+Checksums let consumers verify the dossier content has not been tampered with:
+
+```bash
+ai-dossier checksum setup-dev-environment.ds.md --update
+```
+
+This writes a `checksum` field into the frontmatter. Verify it:
+
+```bash
+ai-dossier checksum setup-dev-environment.ds.md --verify
+```
+
+## Step 5: Test with an AI
+
+Before publishing, run the dossier with your AI assistant to verify it works.
+
+**With the MCP server (Claude Code):**
+
+```
+Execute the dossier at setup-dev-environment.ds.md
+```
+
+**Without MCP (any LLM):**
+
+Copy the file content and paste it with:
+
+```
+This is a dossier. Please execute it step-by-step and validate the success criteria.
+```
+
+Iterate on the dossier content until the AI produces the expected result.
+
+## Step 6: Publish
+
+Authenticate with the registry:
+
+```bash
+ai-dossier login
+```
+
+Publish:
+
+```bash
+ai-dossier publish setup-dev-environment.ds.md
+```
+
+Your dossier is now discoverable via `ai-dossier search` and the [Dossier Registry](https://registry.dossier.dev).
+
+## Lifecycle Summary
+
+```
+create  -->  write  -->  validate  -->  checksum  -->  test  -->  publish
+                ^                                        |
+                |                                        |
+                +----------  iterate  <------------------+
+```
+
+## Next Steps
+
+- Browse the [Dossier Registry](https://registry.dossier.dev) to see published dossiers
+- Read the [Dossier Guide](../guides/dossier-guide.md) for the full schema reference
+- Learn about [signatures and security](../explanation/security-model.md) for signing dossiers

--- a/docs/tutorials/mcp-quickstart.md
+++ b/docs/tutorials/mcp-quickstart.md
@@ -1,0 +1,88 @@
+# MCP in 60 Seconds
+
+Add dossier support to Claude Code and start using dossiers immediately.
+
+## Prerequisites
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and working
+- Node.js 20+ installed
+
+## Step 1: Add the MCP Server
+
+Run this single command:
+
+```bash
+claude mcp add dossier --scope user -- npx @ai-dossier/mcp-server
+```
+
+This registers the dossier MCP server globally so it is available in every project.
+
+Verify it was added:
+
+```bash
+claude mcp list
+```
+
+You should see `dossier` in the output.
+
+## Step 2: Use It
+
+Open Claude Code in any project and try these prompts:
+
+**List dossiers in the current project:**
+
+```
+List available dossiers
+```
+
+**Search the public registry:**
+
+```
+Search for dossiers about deployment
+```
+
+**Run a dossier from a URL:**
+
+```
+Run the dossier at https://raw.githubusercontent.com/imboard-ai/ai-dossier/main/examples/guides/context-engineering-best-practices.ds.md
+```
+
+**Run a local dossier:**
+
+```
+Execute the dossier at ./dossiers/setup-environment.ds.md
+```
+
+That's it. Claude Code now understands dossiers natively -- it can discover, verify, and execute them without copy-pasting URLs or reading documentation first.
+
+## What Just Happened?
+
+The MCP server gives Claude Code several capabilities:
+
+- **`list_dossiers`** -- find `.ds.md` files in your project
+- **`search_dossiers`** -- search the public registry by keyword
+- **`read_dossier`** -- parse and return dossier content
+- **`verify_dossier`** -- check integrity (checksums) and authenticity (signatures)
+- **`resolve_graph`** / **`start_journey`** -- orchestrate multi-dossier workflows
+
+See the [MCP Server README](../../mcp-server/README.md) for the full tool reference.
+
+## Alternative: Claude Desktop
+
+If you use Claude Desktop instead of Claude Code, add this to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "dossier": {
+      "command": "npx",
+      "args": ["-y", "@ai-dossier/mcp-server"]
+    }
+  }
+}
+```
+
+## Next Steps
+
+- [Author and Publish](./author-and-publish.md) -- create your own dossier and publish it to the registry
+- [Your First Dossier](./your-first-dossier.md) -- deeper walkthrough of dossier structure and the CLI

--- a/docs/tutorials/record-a-demo.md
+++ b/docs/tutorials/record-a-demo.md
@@ -1,0 +1,113 @@
+# Record a Demo
+
+Create a terminal recording that shows a dossier being executed. Useful for documentation, README demos, and sharing workflows with your team.
+
+## Prerequisites
+
+- A working dossier you want to demo (see [Author and Publish](./author-and-publish.md))
+- [asciinema](https://asciinema.org/) installed:
+
+  ```bash
+  # macOS
+  brew install asciinema
+
+  # Ubuntu/Debian
+  sudo apt install asciinema
+
+  # pip (any platform)
+  pip install asciinema
+  ```
+
+## Step 1: Plan the Recording
+
+Decide what to show. A good demo recording covers:
+
+1. **Verify** -- show the security check passing
+2. **Execute** -- run the dossier with an AI
+3. **Validate** -- show the success criteria being met
+
+Keep it short. Under 2 minutes is ideal; anything over 3 minutes loses the viewer.
+
+## Step 2: Prepare the Environment
+
+Set up a clean state so the recording is reproducible:
+
+```bash
+# Create a temporary project directory
+mkdir /tmp/demo-project && cd /tmp/demo-project
+git init
+```
+
+If your dossier expects specific project structure (e.g., a `package.json`), create the minimum required files.
+
+## Step 3: Record
+
+```bash
+asciinema rec demo.cast
+```
+
+Now run through your planned steps inside the recording session. For example:
+
+```bash
+# Show the dossier content
+cat my-dossier.ds.md
+
+# Verify integrity
+ai-dossier verify my-dossier.ds.md
+
+# Execute with Claude Code (or show the copy-paste flow for web LLMs)
+# ...
+
+# Show the result
+ai-dossier info my-dossier.ds.md
+```
+
+When finished, press `Ctrl+D` or type `exit` to stop recording.
+
+## Step 4: Review and Trim
+
+Play back the recording:
+
+```bash
+asciinema play demo.cast
+```
+
+If you need to re-record, just run `asciinema rec demo.cast` again -- it overwrites the file.
+
+## Step 5: Share
+
+**Upload to asciinema.org:**
+
+```bash
+asciinema upload demo.cast
+```
+
+This returns a URL you can embed in READMEs and documentation.
+
+**Convert to GIF (for GitHub READMEs):**
+
+```bash
+# Install agg (asciinema gif generator)
+cargo install --git https://github.com/asciinema/agg
+
+# Convert
+agg demo.cast demo.gif
+```
+
+**Embed in markdown:**
+
+```markdown
+[![Demo](https://asciinema.org/a/YOUR_ID.svg)](https://asciinema.org/a/YOUR_ID)
+```
+
+## Tips for Good Recordings
+
+- **Add pauses** between commands so viewers can read the output. Type deliberately, not fast.
+- **Use a clean terminal** -- no distracting prompt customizations. Consider `export PS1='$ '` before recording.
+- **Set terminal size** before recording: `stty rows 24 cols 80` gives a standard size that embeds well.
+- **Show the result**, not just the process. End the recording with proof that the dossier achieved its objective.
+
+## Next Steps
+
+- Embed the recording in your dossier's README or the project documentation
+- See the [examples/](../../examples/) directory for dossiers you can record demos of


### PR DESCRIPTION
## Summary

- Add **MCP in 60 Seconds** tutorial (`docs/tutorials/mcp-quickstart.md`) -- single-command MCP setup, completable in under 2 minutes
- Add **Author and Publish** tutorial (`docs/tutorials/author-and-publish.md`) -- full create/validate/checksum/publish lifecycle
- Add **Record a Demo** tutorial (`docs/tutorials/record-a-demo.md`) -- terminal recordings with asciinema for documentation
- Update tutorial index (`docs/tutorials/README.md`) with numbered list and "where to start" guidance
- Link MCP quickstart from main `README.md` (hero line + documentation table)

Closes #293

## Test plan

- [ ] Verify all internal links resolve (checked locally -- all targets exist)
- [ ] Follow MCP quickstart tutorial end-to-end with Claude Code
- [ ] Follow author-and-publish tutorial with the CLI
- [ ] Confirm tutorial index renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)