### PR TITLE
ci: automated example dossier testing

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -1,0 +1,103 @@
+name: Test Examples
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'examples/**'
+      - 'dossier-schema.json'
+      - 'packages/core/**'
+      - 'cli/**'
+      - 'scripts/test-examples.sh'
+      - '.github/workflows/test-examples.yml'
+
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'examples/**'
+      - 'dossier-schema.json'
+      - 'packages/core/**'
+      - 'cli/**'
+      - 'scripts/test-examples.sh'
+      - '.github/workflows/test-examples.yml'
+
+  schedule:
+    # Weekly on Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+
+  workflow_dispatch: {}
+
+concurrency:
+  group: test-examples-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-examples:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: make build-all
+
+      - name: Validate all example dossiers
+        run: bash scripts/test-examples.sh
+
+  create-issue-on-failure:
+    needs: test-examples
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create issue for failing examples
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `Example dossiers failing (weekly check ${new Date().toISOString().slice(0, 10)})`;
+
+            // Avoid duplicates: check for open issue with same title prefix
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'bug,examples',
+              per_page: 10,
+            });
+            const prefix = 'Example dossiers failing (weekly check';
+            if (existing.data.some(i => i.title.startsWith(prefix))) {
+              console.log('Open issue already exists, skipping creation');
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: [
+                '## Example Dossiers Failing',
+                '',
+                `The weekly scheduled run of the [Test Examples workflow](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/workflows/test-examples.yml) failed.`,
+                '',
+                `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                '',
+                'Please investigate and fix the failing example dossiers.',
+              ].join('\n'),
+              labels: ['bug', 'examples'],
+            });

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ✅ Works with Claude, ChatGPT, Cursor—any LLM
 
 [![CI](https://github.com/imboard-ai/ai-dossier/actions/workflows/ci.yml/badge.svg)](https://github.com/imboard-ai/ai-dossier/actions/workflows/ci.yml)
+[![Examples](https://github.com/imboard-ai/ai-dossier/actions/workflows/test-examples.yml/badge.svg)](https://github.com/imboard-ai/ai-dossier/actions/workflows/test-examples.yml)
 [![npm version](https://img.shields.io/npm/v/@ai-dossier/cli)](https://www.npmjs.com/package/@ai-dossier/cli)
 [![npm downloads](https://img.shields.io/npm/dm/@ai-dossier/cli)](https://www.npmjs.com/package/@ai-dossier/cli)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
@@ -214,7 +215,7 @@ See the [CLI documentation](./cli/README.md#config-command) for full registry ma
 |---|---|
 | **Getting Started** | [Quick Start](docs/getting-started/installation.md) · [Your First Dossier](docs/tutorials/your-first-dossier.md) · [FAQ](docs/explanation/faq.md) |
 | **Reference** | [Protocol](docs/reference/protocol.md) · [Specification](docs/reference/specification.md) · [Schema](docs/reference/schema.md) · [JSON Schema](./dossier-schema.json) |
-| **Guides** | [Authoring Guidelines](docs/guides/authoring-guidelines.md) · [Dossier Guide](docs/guides/dossier-guide.md) · [Adopter Playbooks](docs/guides/adopter-playbooks.md) · [Examples](./examples/) |
+| **Guides** | [Authoring Guidelines](docs/guides/authoring-guidelines.md) · [Dossier Guide](docs/guides/dossier-guide.md) · [CI/CD Integration](docs/guides/ci-cd-integration.md) · [Adopter Playbooks](docs/guides/adopter-playbooks.md) · [Examples](./examples/) |
 | **Packages** | [CLI](./cli/) · [MCP Server](./mcp-server/) · [Core Library](./packages/core/) · [Registry](./registry/) |
 | **Project** | [Architecture](ARCHITECTURE.md) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Changelog](CHANGELOG.md) |
 

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# ------------------------------------------------------------------
+# test-examples.sh
+#
+# Finds every .ds.md file under examples/ and runs:
+#   1. `dossier validate`        -- frontmatter structure validation
+#   2. `dossier checksum --verify` -- SHA256 integrity check
+#
+# Uses `checksum --verify` instead of the full `verify` pipeline
+# because CI has no trusted-keys setup, so signature trust checks
+# would always BLOCK signed dossiers.
+#
+# Exit code 0 only when every dossier passes both checks.
+# ------------------------------------------------------------------
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLI="node ${REPO_ROOT}/cli/dist/cli.js"
+EXAMPLES_DIR="${REPO_ROOT}/examples"
+
+passed=0
+failed=0
+failures=()
+
+# Collect all .ds.md files
+mapfile -t dossier_files < <(find "$EXAMPLES_DIR" -name '*.ds.md' -type f | sort)
+
+if [ ${#dossier_files[@]} -eq 0 ]; then
+  echo "ERROR: No .ds.md files found in ${EXAMPLES_DIR}"
+  exit 1
+fi
+
+echo "============================================"
+echo "  Dossier Example Tests"
+echo "============================================"
+echo ""
+echo "Found ${#dossier_files[@]} dossier(s) in examples/"
+echo ""
+
+for file in "${dossier_files[@]}"; do
+  relative="${file#"${REPO_ROOT}/"}"
+  echo "--- ${relative} ---"
+
+  file_ok=true
+
+  # 1. Validate (frontmatter structure)
+  if $CLI validate "$file" --quiet 2>&1; then
+    echo "  validate:  PASS"
+  else
+    echo "  validate:  FAIL"
+    file_ok=false
+  fi
+
+  # 2. Checksum (SHA256 integrity)
+  if $CLI checksum --verify "$file" 2>&1; then
+    echo "  checksum:  PASS"
+  else
+    echo "  checksum:  FAIL"
+    file_ok=false
+  fi
+
+  if $file_ok; then
+    ((passed++))
+  else
+    ((failed++))
+    failures+=("$relative")
+  fi
+
+  echo ""
+done
+
+# Summary
+echo "============================================"
+echo "  Summary"
+echo "============================================"
+echo "  Total:  ${#dossier_files[@]}"
+echo "  Passed: ${passed}"
+echo "  Failed: ${failed}"
+
+if [ ${#failures[@]} -gt 0 ]; then
+  echo ""
+  echo "  Failures:"
+  for f in "${failures[@]}"; do
+    echo "    - ${f}"
+  done
+fi
+echo "============================================"
+
+if [ "$failed" -gt 0 ]; then
+  exit 1
+fi
+
+echo ""
+echo "All example dossiers passed."
+exit 0


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow (`.github/workflows/test-examples.yml`) that validates all example dossiers
- Add test script (`scripts/test-examples.sh`) that discovers and tests every `.ds.md` file in `examples/`
- Add Examples badge to `README.md`

Closes #16

## Details

**Workflow triggers:**
- Push to `main` or PR targeting `main` when examples, schema, core, CLI, or workflow files change
- Weekly schedule (Monday 06:00 UTC)
- Manual dispatch

**What it tests (per dossier):**
- `dossier validate --quiet` -- frontmatter structure (required fields, valid statuses, semver, etc.)
- `dossier checksum --verify` -- SHA256 integrity (body content has not been tampered with)

Uses `checksum --verify` instead of the full `verify` pipeline because CI has no trusted-keys setup, so signature trust checks would BLOCK signed dossiers (like `hello-world.ds.md`).

**On weekly failure:** auto-creates a GitHub issue labeled `bug` + `examples` (with dedup check).

**Node matrix:** 20 and 22 (matches existing CI workflow).

## Test plan

- [x] Ran `scripts/test-examples.sh` locally -- all 3 example dossiers pass (validate + checksum)
- [ ] CI workflow triggers on this PR (path filter matches `.github/workflows/test-examples.yml`)
- [ ] Verify badge renders on README after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)