### PR TITLE
fix(cli): release stdin after login prompt so CLI exits

### DIFF
--- a/cli/src/oauth.ts
+++ b/cli/src/oauth.ts
@@ -77,6 +77,9 @@ function prompt(question: string): Promise<string> {
   return new Promise((resolve) => {
     rl.question(question, (answer) => {
       rl.close();
+      // Without this, readline's reference on stdin keeps the event loop alive
+      // and the CLI hangs after a successful login instead of exiting.
+      process.stdin.unref();
       resolve(answer);
     });
   });


### PR DESCRIPTION
## Summary
- `ai-dossier login` printed the success message but the process never exited — terminal appeared to hang.
- Cause: `readline.createInterface({ input: process.stdin, ... })` in `cli/src/oauth.ts` references stdin, which keeps Node's event loop alive even after `rl.close()`.
- Fix: call `process.stdin.unref()` after the readline prompt resolves, so stdin no longer blocks process exit.

The login itself was always succeeding (credentials saved, JWT decoded) — only the exit path was broken. No behavior change for non-interactive flows (those bypass the prompt entirely).

## Test plan
- [ ] `ai-dossier login` exits cleanly after pasting the code
- [ ] `ai-dossier whoami` shows the saved credentials
- [ ] Login failure paths (empty code, malformed token) still surface their errors and exit non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)