### PR TITLE
ci(cli): add pre-publish smoke tests for the release pipeline

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -52,8 +52,91 @@ jobs:
       - name: Test
         run: make test
 
-  publish:
+  smoke:
     needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build all packages
+        run: make build-all
+
+      - name: Pack all packages
+        run: |
+          mkdir -p /tmp/tarballs
+          for pkg in packages/core cli mcp-server packages/worktree-pool; do
+            (cd "$pkg" && npm pack --pack-destination /tmp/tarballs)
+          done
+          ls -1 /tmp/tarballs
+
+      - name: Install tarballs into a fixture project
+        run: |
+          mkdir -p /tmp/smoke && cd /tmp/smoke
+          # `ls ... | head -1` guards against npm pack ever producing multiple
+          # matching tarballs (e.g. versioned + tag-suffixed builds).
+          CORE_TGZ=$(ls /tmp/tarballs/ai-dossier-core-*.tgz | head -1)
+          CLI_TGZ=$(ls /tmp/tarballs/ai-dossier-cli-*.tgz | head -1)
+          # cli depends on @ai-dossier/core; install both via file: so npm
+          # resolves the peer locally without needing the registry version.
+          cat > package.json <<EOF
+          {
+            "name": "smoke-fixture",
+            "version": "0.0.0",
+            "private": true,
+            "dependencies": {
+              "@ai-dossier/core": "file:$CORE_TGZ",
+              "@ai-dossier/cli":  "file:$CLI_TGZ"
+            }
+          }
+          EOF
+          npm install --no-audit --no-fund
+
+      - name: Tier 1 — non-interactive smoke (each wrapped in timeout)
+        run: |
+          BIN=/tmp/smoke/node_modules/.bin/ai-dossier
+          test -x "$BIN" || (echo "ai-dossier binary not executable at $BIN"; exit 1)
+
+          echo "::group::ai-dossier --version"
+          timeout 10s "$BIN" --version
+          echo "::endgroup::"
+
+          echo "::group::ai-dossier doctor"
+          # `doctor` may exit non-zero for environment warnings (no MCP config,
+          # missing claude binary on a clean runner). We only care that the
+          # process exits within the timeout, not the diagnostic outcome.
+          timeout 10s "$BIN" doctor || true
+          echo "::endgroup::"
+
+          echo "::group::ai-dossier whoami (with fixture token)"
+          PAYLOAD=$(node -e "process.stdout.write(Buffer.from(JSON.stringify({sub:'smoke',orgs:[],exp:Math.floor(Date.now()/1000)+86400})).toString('base64url'))")
+          # Inline env: token is scoped to this single command invocation only,
+          # never visible to follow-on commands or hooks in this step.
+          DOSSIER_REGISTRY_TOKEN="header.${PAYLOAD}.sig" \
+            HOME="$(mktemp -d)" \
+            timeout 10s "$BIN" whoami
+          echo "::endgroup::"
+
+      - name: Tier 2 — interactive login smoke (regression guard for #386)
+        run: |
+          BIN=/tmp/smoke/node_modules/.bin/ai-dossier
+          test -x "$BIN" || (echo "ai-dossier binary not executable at $BIN"; exit 1)
+          # smoke.mjs sets DOSSIER_LOGIN_ALLOW_NONINTERACTIVE=1 internally to
+          # bypass login's TTY guard while exercising the full success path.
+          node cli/test/smoke/login.smoke.mjs "$BIN"
+
+  publish:
+    needs: [test, smoke]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -196,13 +279,12 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Verify packages are available
+      - name: Verify packages are available on npm
         run: |
           echo "Verifying published packages..."
           npm view @ai-dossier/core version
           npm view @ai-dossier/cli version
           npm view @ai-dossier/mcp-server version
           npm view @ai-dossier/worktree-pool version
-
-      - name: Smoke test CLI
-        run: npx @ai-dossier/cli --help
+          # Behavioral smoke testing happens in the pre-publish `smoke` job
+          # against the same tarball; this job only confirms registry publish.

--- a/cli/package.json
+++ b/cli/package.json
@@ -15,7 +15,8 @@
     "build": "tsc",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:smoke": "node test/smoke/login.smoke.mjs ./bin/ai-dossier"
   },
   "keywords": [
     "dossier",

--- a/cli/src/__tests__/commands/login.test.ts
+++ b/cli/src/__tests__/commands/login.test.ts
@@ -39,7 +39,11 @@ describe('login command', () => {
 
     const program = createTestProgram();
     registerLoginCommand(program);
-    await program.parseAsync(['node', 'dossier', 'login']);
+    // login calls process.exit(0) on success — global setup throws on exit
+    // so the action surfaces as a rejection with a predictable message.
+    await expect(program.parseAsync(['node', 'dossier', 'login'])).rejects.toThrow(
+      'process.exit(0)'
+    );
 
     expect(credentials.saveCredentials).toHaveBeenCalledWith(
       {
@@ -63,7 +67,9 @@ describe('login command', () => {
 
     const program = createTestProgram();
     registerLoginCommand(program);
-    await program.parseAsync(['node', 'dossier', 'login']);
+    await expect(program.parseAsync(['node', 'dossier', 'login'])).rejects.toThrow(
+      'process.exit(0)'
+    );
 
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('org1, org2'));
   });
@@ -74,7 +80,9 @@ describe('login command', () => {
     const program = createTestProgram();
     registerLoginCommand(program);
 
-    await expect(program.parseAsync(['node', 'dossier', 'login'])).rejects.toThrow();
+    await expect(program.parseAsync(['node', 'dossier', 'login'])).rejects.toThrow(
+      'process.exit(1)'
+    );
 
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Login failed'));
   });

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -19,7 +19,12 @@ For non-interactive environments (CI/CD), use environment variables instead:
 `
     )
     .action(async (options: { registry?: string }) => {
-      if (!process.stdin.isTTY) {
+      // Non-interactive sessions can't complete the OAuth copy/paste flow.
+      // Surface the env-var alternative early — before opening a browser or
+      // printing the auth URL — to keep CI logs clean. Smoke tests bypass
+      // this with DOSSIER_LOGIN_ALLOW_NONINTERACTIVE=1 to exercise the full
+      // login path with piped stdin.
+      if (!process.stdin.isTTY && !process.env.DOSSIER_LOGIN_ALLOW_NONINTERACTIVE) {
         console.error('\n❌ Non-interactive session detected. Cannot run OAuth flow.');
         console.error('   Set the DOSSIER_REGISTRY_TOKEN environment variable instead:\n');
         console.error('   export DOSSIER_REGISTRY_TOKEN=<your-token>\n');
@@ -64,5 +69,14 @@ For non-interactive environments (CI/CD), use environment variables instead:
         console.error(`\n❌ Login failed: ${(err as Error).message}\n`);
         process.exit(1);
       }
+      // Force exit on the success path. stdin is already unref'd by prompt()
+      // (PR #386), but when stdio is fully piped (CI smoke tests, scripted
+      // callers) stdout/stderr remain referenced and keep the event loop
+      // alive. Unref'ing them is unreliable because Node may re-ref on
+      // pending kernel writes; an explicit exit is the most robust signal
+      // that this command has completed all its synchronous work.
+      // Placed outside the try block so the catch can't intercept it —
+      // anything async added on the success path MUST be awaited inside try.
+      process.exit(0);
     });
 }

--- a/cli/src/oauth.ts
+++ b/cli/src/oauth.ts
@@ -30,6 +30,13 @@ class OAuthError extends Error {
 }
 
 /**
+ * Exact prompt string the user sees when login is awaiting the OAuth code.
+ * Exported so smoke tests can wait for it on stderr without duplicating the
+ * literal — keeps the test from silently breaking if the copy is reworded.
+ */
+export const LOGIN_CODE_PROMPT = 'Enter the code from your browser: ';
+
+/**
  * Decode a base64url-encoded string, adding padding if needed.
  */
 function decodeBase64Url(data: string): string {
@@ -61,17 +68,23 @@ function openBrowser(url: string): void {
     args = [url];
   }
 
-  execFile(cmd, args, (_err) => {
+  const child = execFile(cmd, args, (_err) => {
     // Browser failed to open — URL is already printed for the user
   });
+  // Don't keep the parent alive while the browser process lingers.
+  child.unref();
 }
 
 /**
- * Prompt the user for input via stdin.
+ * Prompt the user for input via the given readable stream (default: process.stdin).
+ * Exported for tests; production callers omit `input` and get process.stdin.
  */
-function prompt(question: string): Promise<string> {
+export function prompt(
+  question: string,
+  input: NodeJS.ReadableStream = process.stdin
+): Promise<string> {
   const rl = readline.createInterface({
-    input: process.stdin,
+    input,
     output: process.stderr,
   });
   return new Promise((resolve) => {
@@ -79,7 +92,10 @@ function prompt(question: string): Promise<string> {
       rl.close();
       // Without this, readline's reference on stdin keeps the event loop alive
       // and the CLI hangs after a successful login instead of exiting.
-      process.stdin.unref();
+      // Only applies to process.stdin; other streams manage their own refs.
+      if (input === process.stdin) {
+        process.stdin.unref();
+      }
       resolve(answer);
     });
   });
@@ -98,9 +114,14 @@ async function runOAuthFlow(registryUrl: string): Promise<OAuthResult> {
 
   openBrowser(authUrl);
 
-  const code = (await prompt('Enter the code from your browser: ')).trim();
+  const code = (await prompt(LOGIN_CODE_PROMPT)).trim();
 
   if (!code) {
+    if (!process.stdin.isTTY) {
+      throw new OAuthError(
+        'No code provided. Non-interactive session detected — set DOSSIER_REGISTRY_TOKEN instead.'
+      );
+    }
     throw new OAuthError('No code provided');
   }
 

--- a/cli/test/smoke/login.smoke.mjs
+++ b/cli/test/smoke/login.smoke.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// Standalone smoke test: drives `ai-dossier login` end-to-end through a piped
+// stdin, asserting the process exits cleanly within a short timeout. This is
+// the regression guard for PR #386 (login hung after success because readline
+// kept stdin referenced) and any future process-exit regressions in the
+// success path.
+//
+// Usage: node login.smoke.mjs <path-to-ai-dossier-binary>
+//
+// Run from CI against an unpacked tarball, or locally against ./cli/bin/ai-dossier.
+
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const BIN = process.argv[2];
+if (!BIN) {
+  console.error('Usage: node login.smoke.mjs <path-to-ai-dossier-binary>');
+  process.exit(2);
+}
+
+// Import the prompt constant from the same package the binary belongs to so
+// the marker stays in sync with the production string. Resolved relative to
+// the binary path so this works for both workspace builds and unpacked
+// tarballs in CI.
+const requireFromBin = createRequire(path.resolve(BIN));
+const { LOGIN_CODE_PROMPT } = requireFromBin('../dist/oauth.js');
+if (typeof LOGIN_CODE_PROMPT !== 'string') {
+  console.error('FAIL: could not load LOGIN_CODE_PROMPT from CLI build');
+  process.exit(2);
+}
+
+const TIMEOUT_MS = 8000;
+
+// Hand-roll a fixture JWT. The CLI decodes but does NOT verify the signature,
+// so any string in the signature segment works. Outer base64url wrap matches
+// the wire format the registry hands to the user.
+function makeFixtureCode() {
+  const payload = {
+    sub: 'smoke-test-user',
+    orgs: ['smoke-org'],
+    exp: Math.floor(Date.now() / 1000) + 86400, // +1 day
+  };
+  const encoded = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const token = `header.${encoded}.sig`;
+  return Buffer.from(token).toString('base64url');
+}
+
+// Isolate $HOME so saveCredentials writes to a tempdir, not the runner's home.
+const fakeHome = mkdtempSync(path.join(tmpdir(), 'ai-dossier-smoke-'));
+
+let cleanedUp = false;
+function cleanup() {
+  if (cleanedUp) return;
+  cleanedUp = true;
+  try {
+    rmSync(fakeHome, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+// Make sure the tempdir is reaped on any exit path — including SIGINT/SIGTERM
+// (CI cancels) and uncaught exceptions. process.on('exit') runs synchronously.
+process.on('exit', cleanup);
+process.on('SIGINT', () => {
+  cleanup();
+  process.exit(130);
+});
+process.on('SIGTERM', () => {
+  cleanup();
+  process.exit(143);
+});
+process.on('uncaughtException', (err) => {
+  console.error('uncaughtException:', err);
+  cleanup();
+  process.exit(1);
+});
+
+const child = spawn(process.execPath, [BIN, 'login'], {
+  env: {
+    ...process.env,
+    HOME: fakeHome,
+    // Bypass the non-interactive guard so the CLI accepts the piped stdin.
+    DOSSIER_LOGIN_ALLOW_NONINTERACTIVE: '1',
+  },
+  stdio: ['pipe', 'pipe', 'pipe'],
+});
+
+let stderrBuf = '';
+let promptSeen = false;
+let timedOut = false;
+
+const timer = setTimeout(() => {
+  timedOut = true;
+  console.error(`FAIL: timeout after ${TIMEOUT_MS}ms`);
+  console.error(`  stderr so far: ${JSON.stringify(stderrBuf.slice(-200))}`);
+  child.kill('SIGKILL');
+  process.exit(1);
+}, TIMEOUT_MS);
+
+child.stderr.on('data', (chunk) => {
+  stderrBuf += chunk.toString();
+  if (!promptSeen && stderrBuf.includes(LOGIN_CODE_PROMPT)) {
+    promptSeen = true;
+    child.stdin.write(`${makeFixtureCode()}\n`);
+    child.stdin.end();
+  }
+});
+
+child.stdout.on('data', () => {
+  /* drain */
+});
+
+child.on('exit', (code, signal) => {
+  clearTimeout(timer);
+  if (timedOut) return; // already reported
+  if (signal) {
+    console.error(`FAIL: child killed by signal ${signal}`);
+    process.exit(1);
+  }
+  if (code !== 0) {
+    console.error(`FAIL: exit code ${code}`);
+    console.error(`  stderr: ${stderrBuf}`);
+    process.exit(1);
+  }
+  if (!promptSeen) {
+    console.error('FAIL: child exited 0 but the login prompt was never seen');
+    process.exit(1);
+  }
+  console.log('PASS: ai-dossier login exited cleanly within timeout');
+});


### PR DESCRIPTION
## Summary

Replace the shallow post-publish `npx @ai-dossier/cli --help` with a deeper **pre-publish** smoke gate that exercises real exit paths against the same tarball that `npm publish` will ship. Closes #387.

The motivation is concrete: PR #386 fixed `ai-dossier login` hanging after a successful auth. The previous `--help` smoke test could not — and would not — have caught it, because `--help` doesn't go through the prompt path. We discovered the bug manually because the local dev binary is a workspace symlink, not the published artifact.

## Pipeline change

```
test → smoke → publish → verify
              ^^^^^^^
              new pre-publish gate
```

The new `smoke` job builds, runs `npm pack` on all four workspace packages, installs them into a fixture project via `file:` refs (no Verdaccio needed), and runs:

- **Tier 1** (each wrapped in `timeout 10s`):
  - `ai-dossier --version`
  - `ai-dossier doctor`
  - `DOSSIER_REGISTRY_TOKEN=<fixture-jwt> ai-dossier whoami`
- **Tier 2**: `cli/test/smoke/login.smoke.mjs` — spawns the binary, waits for the OAuth prompt on stderr, pipes a hand-rolled JWT to stdin, asserts exit 0 within 8s. This is the regression guard for the #386 class of bug.

The post-publish `verify` job is kept but stripped to a registry-availability check.

## Code changes (to make Tier 2 work without a PTY dep)

- `cli/src/oauth.ts`:
  - `prompt()` accepts an optional stdin source (default `process.stdin`); only unrefs `process.stdin` when actually using it
  - `openBrowser()` calls `child.unref()` on the spawned `xdg-open`/`open`/`cmd` so the parent can exit even if the browser hangs
  - New exported constant `LOGIN_CODE_PROMPT` — the smoke test imports it from the built package, so a wording change in the prompt cannot silently break the test
- `cli/src/commands/login.ts`:
  - The non-interactive guard now respects `DOSSIER_LOGIN_ALLOW_NONINTERACTIVE=1` (smoke-only) so spawn-with-piped-stdin can drive the full login path
  - `process.exit(0)` placed **outside** the try block on the success path — when stdio is fully piped, stdout/stderr Sockets keep the event loop alive even after the stdin unref, and unref'ing stdout is unreliable due to pending kernel writes
- `cli/src/__tests__/commands/login.test.ts`: aligned with the existing global throw-based `process.exit` mock in `helpers/setup.ts` (matches the pattern used in `doctor.test.ts`, `validate.test.ts`, `publish.test.ts`)
- `cli/package.json`: new `test:smoke` script — `npm run test:smoke -w cli`

## Tradeoffs / known limitations

- **`process.exit(0)` masks `unref`-only regressions.** The architecture review flagged that with `process.exit(0)` in place, reverting just `process.stdin.unref()` (the literal #386 fix) no longer fails the smoke test. The unref-only fix doesn't work in fully-piped stdio, and unref'ing stdout/stderr is fragile because Node may re-ref on pending kernel writes. The smoke test now catches a broader class — "login command's exit path is broken" — rather than the exact mechanism. Worth revisiting if a more precise unref unit test feels valuable.
- **No `upload-artifact` reuse between `test` and `smoke` yet.** They both run `npm ci` + `make build-all`. The performance review estimated ~90s/release saving. Deferred to a follow-up: making `test` produce tarballs and `smoke` consume them via `download-artifact` is a larger restructure.
- **Pack-loop and JWT-fixture not extracted to scripts.** The CI runs them inline. Worth extracting if reused; for now duplication risk is low (literal short snippets).

## Test plan

- [x] All 451 cli tests pass locally (`npm test -w cli`)
- [x] `npm run test:smoke -w cli` passes against the local build
- [x] Reverting these changes (via `git stash`) makes the smoke test fail (regression detection works)
- [x] Manually verified the tarball-install path works with a packed workspace
- [ ] CI green on this branch
- [ ] Manual sanity check after merge: bump a patch version, watch the publish workflow, confirm `smoke` job runs and gates `publish`

## Reviews applied

This PR went through 4 review passes (security, architecture, performance, code quality) before submission. Notable fixes from the reviews:

- Token scoping: `DOSSIER_REGISTRY_TOKEN` is now inline-per-command, not exported into the step env
- `cleanup()` in `login.smoke.mjs` registered for `SIGINT`/`SIGTERM`/`uncaughtException`/`exit` so CI cancellation never leaves a fixture credentials file behind
- Test pattern aligned with existing global throw-based `process.exit` mock
- Restored the early CI hint that exits before opening a browser (with smoke-bypass env var)
- Tarball glob pinned with `head -1` to guard against multi-tarball edge cases
- `timeout-minutes: 5` safety net on the `smoke` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)