### PR TITLE
feat(registry): execution trace API (CRUD + step append)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,4 @@ REFACTORING_PLAN.md
 # Worktrees
 worktrees/
 .worktree-pool.json
+.env*.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -1482,6 +1482,15 @@
         }
       }
     },
+    "node_modules/@neondatabase/serverless": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.1.0.tgz",
+      "integrity": "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=19.0.0"
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -6642,6 +6651,7 @@
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ai-dossier/core": "*",
+        "@neondatabase/serverless": "^1.1.0",
         "jsonwebtoken": "^9.0.2"
       },
       "devDependencies": {

--- a/registry/.gitignore
+++ b/registry/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+.env*.local

--- a/registry/api/v1/traces/[traceId].ts
+++ b/registry/api/v1/traces/[traceId].ts
@@ -1,0 +1,139 @@
+// GET    /api/v1/traces/:traceId - Get full trace (including steps)
+// PATCH  /api/v1/traces/:traceId - Update trace (status, completion, etc.)
+// DELETE /api/v1/traces/:traceId - Delete trace and its steps
+
+import { authenticateRequest } from '../../../lib/auth';
+import { HTTP_STATUS, MAX_CONTENT_SIZE } from '../../../lib/constants';
+import { handleCors } from '../../../lib/cors';
+import {
+  badRequest,
+  getRequestId,
+  jsonError,
+  methodNotAllowed,
+  notFound,
+  serverError,
+} from '../../../lib/responses';
+import {
+  deleteTrace,
+  getTrace,
+  type TraceStatus,
+  type TraceUpdate,
+  updateTrace,
+  VALID_STATUSES,
+} from '../../../lib/traces';
+import type { VercelRequest, VercelResponse } from '../../../lib/types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleCors(req, res)) return;
+
+  const requestId = getRequestId(req);
+  res.setHeader('X-Request-Id', requestId);
+
+  const traceId = pickOne(req.query.traceId);
+  if (!traceId || !UUID_RE.test(traceId)) {
+    return badRequest(res, 'INVALID_FIELD', 'traceId must be a UUID', requestId);
+  }
+
+  const payload = await authenticateRequest(req, res);
+  if (!payload) return;
+  const owner = payload.sub;
+
+  if (req.method === 'GET') return handleGet(res, owner, traceId, requestId);
+  if (req.method === 'PATCH') return handlePatch(req, res, owner, traceId, requestId);
+  if (req.method === 'DELETE') return handleDelete(res, owner, traceId, requestId);
+
+  return methodNotAllowed(req, res, 'GET', 'PATCH', 'DELETE');
+}
+
+async function handleGet(res: VercelResponse, owner: string, traceId: string, requestId: string) {
+  try {
+    const trace = await getTrace(owner, traceId);
+    if (!trace) return notFound(res, 'NOT_FOUND', 'Trace not found', requestId);
+    return res.status(HTTP_STATUS.OK).json(trace);
+  } catch (err) {
+    return serverError(res, {
+      operation: 'trace.get',
+      error: err,
+      code: 'UPSTREAM_ERROR',
+      message: 'Failed to get trace',
+      requestId,
+      context: { owner, traceId },
+    });
+  }
+}
+
+async function handlePatch(
+  req: VercelRequest,
+  res: VercelResponse,
+  owner: string,
+  traceId: string,
+  requestId: string
+) {
+  const contentLength = Number(req.headers['content-length'] || 0);
+  if (contentLength > MAX_CONTENT_SIZE) {
+    return jsonError(
+      res,
+      HTTP_STATUS.CONTENT_TOO_LARGE,
+      'CONTENT_TOO_LARGE',
+      `Body exceeds ${MAX_CONTENT_SIZE / 1024}KB`,
+      requestId
+    );
+  }
+
+  const updates = (req.body || {}) as TraceUpdate;
+  if (updates.status && !VALID_STATUSES.includes(updates.status as TraceStatus)) {
+    return badRequest(
+      res,
+      'INVALID_FIELD',
+      `status must be one of: ${VALID_STATUSES.join(', ')}`,
+      requestId
+    );
+  }
+
+  try {
+    const updated = await updateTrace(owner, traceId, updates);
+    if (!updated) return notFound(res, 'NOT_FOUND', 'Trace not found', requestId);
+    return res.status(HTTP_STATUS.OK).json({
+      trace_id: traceId,
+      updated_at: new Date().toISOString(),
+    });
+  } catch (err) {
+    return serverError(res, {
+      operation: 'trace.update',
+      error: err,
+      code: 'UPDATE_ERROR',
+      message: 'Failed to update trace',
+      requestId,
+      context: { owner, traceId },
+    });
+  }
+}
+
+async function handleDelete(
+  res: VercelResponse,
+  owner: string,
+  traceId: string,
+  requestId: string
+) {
+  try {
+    const deleted = await deleteTrace(owner, traceId);
+    if (!deleted) return notFound(res, 'NOT_FOUND', 'Trace not found', requestId);
+    res.status(HTTP_STATUS.NO_CONTENT).end();
+  } catch (err) {
+    return serverError(res, {
+      operation: 'trace.delete',
+      error: err,
+      code: 'DELETE_ERROR',
+      message: 'Failed to delete trace',
+      requestId,
+      context: { owner, traceId },
+    });
+  }
+}
+
+function pickOne(v: string | string[] | undefined): string | undefined {
+  if (Array.isArray(v)) return v[0];
+  return v;
+}

--- a/registry/api/v1/traces/[traceId]/steps.ts
+++ b/registry/api/v1/traces/[traceId]/steps.ts
@@ -1,0 +1,107 @@
+// POST /api/v1/traces/:traceId/steps - Append a single execution step (real-time logging)
+// GET  /api/v1/traces/:traceId/steps - List all steps for a trace
+
+import { authenticateRequest } from '../../../../lib/auth';
+import { HTTP_STATUS } from '../../../../lib/constants';
+import { handleCors } from '../../../../lib/cors';
+import {
+  badRequest,
+  getRequestId,
+  jsonError,
+  methodNotAllowed,
+  notFound,
+  serverError,
+} from '../../../../lib/responses';
+import { appendStep, listSteps, type StepInput } from '../../../../lib/traces';
+import type { VercelRequest, VercelResponse } from '../../../../lib/types';
+
+const MAX_STEP_SIZE = 256 * 1024;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleCors(req, res)) return;
+
+  const requestId = getRequestId(req);
+  res.setHeader('X-Request-Id', requestId);
+
+  const traceId = pickOne(req.query.traceId);
+  if (!traceId || !UUID_RE.test(traceId)) {
+    return badRequest(res, 'INVALID_FIELD', 'traceId must be a UUID', requestId);
+  }
+
+  const payload = await authenticateRequest(req, res);
+  if (!payload) return;
+  const owner = payload.sub;
+
+  if (req.method === 'POST') return handleAppend(req, res, owner, traceId, requestId);
+  if (req.method === 'GET') return handleList(res, owner, traceId, requestId);
+
+  return methodNotAllowed(req, res, 'GET', 'POST');
+}
+
+async function handleAppend(
+  req: VercelRequest,
+  res: VercelResponse,
+  owner: string,
+  traceId: string,
+  requestId: string
+) {
+  const contentLength = Number(req.headers['content-length'] || 0);
+  if (contentLength > MAX_STEP_SIZE) {
+    return jsonError(
+      res,
+      HTTP_STATUS.CONTENT_TOO_LARGE,
+      'CONTENT_TOO_LARGE',
+      `Body exceeds ${MAX_STEP_SIZE / 1024}KB`,
+      requestId
+    );
+  }
+  const step = (req.body || {}) as Partial<StepInput>;
+  if (!step.step_id) {
+    return badRequest(res, 'MISSING_FIELD', 'Missing required field: step_id', requestId);
+  }
+  if (!step.type) {
+    return badRequest(res, 'MISSING_FIELD', 'Missing required field: type', requestId);
+  }
+
+  try {
+    const result = await appendStep(owner, traceId, step as StepInput);
+    if (!result) return notFound(res, 'NOT_FOUND', 'Trace not found', requestId);
+    return res.status(HTTP_STATUS.CREATED).json({
+      trace_id: traceId,
+      step_id: step.step_id,
+      step_number: result.stepNumber,
+    });
+  } catch (err) {
+    return serverError(res, {
+      operation: 'trace.appendStep',
+      error: err,
+      code: 'APPEND_ERROR',
+      message: 'Failed to append step',
+      requestId,
+      context: { owner, traceId },
+    });
+  }
+}
+
+async function handleList(res: VercelResponse, owner: string, traceId: string, requestId: string) {
+  try {
+    const steps = await listSteps(owner, traceId);
+    if (steps === null) return notFound(res, 'NOT_FOUND', 'Trace not found', requestId);
+    return res.status(HTTP_STATUS.OK).json({ trace_id: traceId, steps });
+  } catch (err) {
+    return serverError(res, {
+      operation: 'trace.listSteps',
+      error: err,
+      code: 'UPSTREAM_ERROR',
+      message: 'Failed to list steps',
+      requestId,
+      context: { owner, traceId },
+    });
+  }
+}
+
+function pickOne(v: string | string[] | undefined): string | undefined {
+  if (Array.isArray(v)) return v[0];
+  return v;
+}

--- a/registry/api/v1/traces/index.ts
+++ b/registry/api/v1/traces/index.ts
@@ -1,0 +1,207 @@
+// GET  /api/v1/traces - List the authenticated user's traces (with filters)
+// POST /api/v1/traces - Create a new execution trace
+
+import { authenticateRequest } from '../../../lib/auth';
+import { HTTP_STATUS, MAX_CONTENT_SIZE } from '../../../lib/constants';
+import { handleCors } from '../../../lib/cors';
+import createLogger from '../../../lib/logger';
+import {
+  badRequest,
+  getRequestId,
+  jsonError,
+  methodNotAllowed,
+  serverError,
+} from '../../../lib/responses';
+import {
+  createTrace,
+  listTraces,
+  type TraceInput,
+  type TraceStatus,
+  VALID_STATUSES,
+} from '../../../lib/traces';
+import type { VercelRequest, VercelResponse } from '../../../lib/types';
+
+const log = createLogger('traces/index');
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleCors(req, res)) return;
+
+  const requestId = getRequestId(req);
+  res.setHeader('X-Request-Id', requestId);
+
+  const payload = await authenticateRequest(req, res);
+  if (!payload) return;
+  const owner = payload.sub;
+
+  if (req.method === 'GET') return handleList(req, res, owner, requestId);
+  if (req.method === 'POST') return handleCreate(req, res, owner, requestId);
+
+  return methodNotAllowed(req, res, 'GET', 'POST');
+}
+
+async function handleList(
+  req: VercelRequest,
+  res: VercelResponse,
+  owner: string,
+  requestId: string
+) {
+  const q = req.query as Record<string, string | string[] | undefined>;
+  const dossier = pickOne(q.dossier);
+  const status = pickOne(q.status);
+  const from = pickOne(q.from);
+  const to = pickOne(q.to);
+  const limit = pickOne(q.limit);
+  const offset = pickOne(q.offset);
+
+  if (status && !VALID_STATUSES.includes(status as TraceStatus)) {
+    return badRequest(
+      res,
+      'INVALID_FIELD',
+      `status must be one of: ${VALID_STATUSES.join(', ')}`,
+      requestId
+    );
+  }
+
+  try {
+    const result = await listTraces(owner, {
+      dossier,
+      status: status as TraceStatus | undefined,
+      from,
+      to,
+      limit,
+      offset,
+    });
+    const nextOffset = result.offset + result.limit;
+    const hasMore = nextOffset < result.total;
+    return res.status(HTTP_STATUS.OK).json({
+      traces: result.rows.map((t) => ({
+        trace_id: t.trace_id,
+        dossier: { title: t.dossier_title, version: t.dossier_version },
+        agent: t.agent_name ? { name: t.agent_name, version: t.agent_version } : undefined,
+        started_at: toIso(t.started_at),
+        completed_at: toIso(t.completed_at),
+        status: t.status,
+        duration_ms: t.duration_ms,
+      })),
+      pagination: {
+        total: result.total,
+        limit: result.limit,
+        offset: result.offset,
+        next: hasMore ? `/api/v1/traces?offset=${nextOffset}&limit=${result.limit}` : null,
+      },
+    });
+  } catch (err) {
+    return serverError(res, {
+      operation: 'trace.list',
+      error: err,
+      code: 'UPSTREAM_ERROR',
+      message: 'Failed to list traces',
+      requestId,
+    });
+  }
+}
+
+export type CreateValidationSuccess = { ok: true; data: TraceInput };
+export type CreateValidationFailure = { ok: false; code: string; message: string };
+export type CreateValidationResult = CreateValidationSuccess | CreateValidationFailure;
+
+/** Pure validation: returns a discriminated union instead of writing to `res`. */
+export function validateCreatePayload(body: unknown): CreateValidationResult {
+  const trace = body as Partial<TraceInput> | null | undefined;
+  if (!trace || typeof trace !== 'object') {
+    return { ok: false, code: 'MISSING_FIELD', message: 'Request body must be a JSON object' };
+  }
+  if (!trace.trace_id) {
+    return { ok: false, code: 'MISSING_FIELD', message: 'Missing required field: trace_id' };
+  }
+  if (typeof trace.trace_id !== 'string' || !UUID_RE.test(trace.trace_id)) {
+    return { ok: false, code: 'INVALID_FIELD', message: 'trace_id must be a UUID' };
+  }
+  if (!trace.dossier || typeof trace.dossier !== 'object') {
+    return { ok: false, code: 'MISSING_FIELD', message: 'Missing required field: dossier' };
+  }
+  if (!trace.dossier.title) {
+    return { ok: false, code: 'MISSING_FIELD', message: 'Missing required field: dossier.title' };
+  }
+  if (!trace.dossier.version) {
+    return { ok: false, code: 'MISSING_FIELD', message: 'Missing required field: dossier.version' };
+  }
+  if (!trace.started_at) {
+    return { ok: false, code: 'MISSING_FIELD', message: 'Missing required field: started_at' };
+  }
+  if (Number.isNaN(Date.parse(trace.started_at))) {
+    return { ok: false, code: 'INVALID_FIELD', message: 'started_at must be ISO-8601' };
+  }
+  if (!trace.status) {
+    return { ok: false, code: 'MISSING_FIELD', message: 'Missing required field: status' };
+  }
+  if (!VALID_STATUSES.includes(trace.status as TraceStatus)) {
+    return {
+      ok: false,
+      code: 'INVALID_FIELD',
+      message: `status must be one of: ${VALID_STATUSES.join(', ')}`,
+    };
+  }
+  return { ok: true, data: trace as TraceInput };
+}
+
+async function handleCreate(
+  req: VercelRequest,
+  res: VercelResponse,
+  owner: string,
+  requestId: string
+) {
+  const contentLength = Number(req.headers['content-length'] || 0);
+  if (contentLength > MAX_CONTENT_SIZE) {
+    return jsonError(
+      res,
+      HTTP_STATUS.CONTENT_TOO_LARGE,
+      'CONTENT_TOO_LARGE',
+      `Body exceeds ${MAX_CONTENT_SIZE / 1024}KB`,
+      requestId
+    );
+  }
+
+  const validated = validateCreatePayload(req.body);
+  if (!validated.ok) {
+    return badRequest(res, validated.code, validated.message, requestId);
+  }
+
+  try {
+    const result = await createTrace(owner, validated.data);
+    log.info('Trace created', { requestId, owner, traceId: result.traceId });
+    return res.status(HTTP_STATUS.CREATED).json({
+      trace_id: result.traceId,
+      created_at: toIso(result.createdAt),
+      url: `/api/v1/traces/${result.traceId}`,
+    });
+  } catch (err) {
+    if (isUniqueViolation(err)) {
+      return jsonError(res, 409, 'CONFLICT', 'Trace already exists', requestId);
+    }
+    return serverError(res, {
+      operation: 'trace.create',
+      error: err,
+      code: 'CREATE_ERROR',
+      message: 'Failed to create trace',
+      requestId,
+      context: { owner, traceId: validated.data.trace_id },
+    });
+  }
+}
+
+function pickOne(v: string | string[] | undefined): string | undefined {
+  if (Array.isArray(v)) return v[0];
+  return v;
+}
+
+function toIso(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: string }).code === '23505';
+}

--- a/registry/e2e-trace-test.mjs
+++ b/registry/e2e-trace-test.mjs
@@ -7,8 +7,8 @@
 //   BASE_URL=http://localhost:3000 node e2e-trace-test.mjs
 //   BASE_URL=https://dossier-registry.vercel.app node e2e-trace-test.mjs
 
-import jwt from 'jsonwebtoken';
 import { randomUUID } from 'node:crypto';
+import jwt from 'jsonwebtoken';
 
 const BASE = (process.env.BASE_URL || 'http://localhost:3000').replace(/\/$/, '');
 const SECRET = process.env.JWT_SECRET;
@@ -50,7 +50,11 @@ async function call(method, path, opts = {}) {
   let body = null;
   if (res.status !== 204) {
     const text = await res.text();
-    try { body = text ? JSON.parse(text) : null; } catch { body = text; }
+    try {
+      body = text ? JSON.parse(text) : null;
+    } catch {
+      body = text;
+    }
   }
   return { status: res.status, body, requestId: res.headers.get('x-request-id') };
 }
@@ -64,7 +68,11 @@ console.log(`  trace: ${TRACE_ID}\n`);
 console.log('Auth:');
 {
   const r = await call('POST', '/api/v1/traces', { body: {} });
-  check('POST /api/v1/traces without token → 401 MISSING_TOKEN', r.status === 401 && r.body?.error?.code === 'MISSING_TOKEN', `got ${r.status} ${JSON.stringify(r.body)}`);
+  check(
+    'POST /api/v1/traces without token → 401 MISSING_TOKEN',
+    r.status === 401 && r.body?.error?.code === 'MISSING_TOKEN',
+    `got ${r.status} ${JSON.stringify(r.body)}`
+  );
 }
 
 // ---- create ----
@@ -97,7 +105,11 @@ console.log('\nConflict:');
       status: 'running',
     },
   });
-  check('POST same trace_id → 409 CONFLICT', r.status === 409 && r.body?.error?.code === 'CONFLICT', `got ${r.status} ${JSON.stringify(r.body)}`);
+  check(
+    'POST same trace_id → 409 CONFLICT',
+    r.status === 409 && r.body?.error?.code === 'CONFLICT',
+    `got ${r.status} ${JSON.stringify(r.body)}`
+  );
 }
 
 // ---- list ----
@@ -127,16 +139,31 @@ console.log('\nAppend steps:');
     token: aliceToken,
     body: { step_id: 's1', type: 'action', detail: 'first step' },
   });
-  check('POST /steps (1st) → 201, step_number=1', r1.status === 201 && r1.body?.step_number === 1, `got ${r1.status} ${JSON.stringify(r1.body)}`);
+  check(
+    'POST /steps (1st) → 201, step_number=1',
+    r1.status === 201 && r1.body?.step_number === 1,
+    `got ${r1.status} ${JSON.stringify(r1.body)}`
+  );
 
   const r2 = await call('POST', `/api/v1/traces/${TRACE_ID}/steps`, {
     token: aliceToken,
     body: { step_id: 's2', type: 'validation', detail: 'second step' },
   });
-  check('POST /steps (2nd) → 201, step_number=2', r2.status === 201 && r2.body?.step_number === 2, `got ${r2.status} ${JSON.stringify(r2.body)}`);
+  check(
+    'POST /steps (2nd) → 201, step_number=2',
+    r2.status === 201 && r2.body?.step_number === 2,
+    `got ${r2.status} ${JSON.stringify(r2.body)}`
+  );
 
   const r3 = await call('GET', `/api/v1/traces/${TRACE_ID}/steps`, { token: aliceToken });
-  check('GET /steps → 200, two steps in order', r3.status === 200 && r3.body?.steps?.length === 2 && r3.body.steps[0].step_id === 's1' && r3.body.steps[1].step_id === 's2', `got ${r3.status} ${JSON.stringify(r3.body)}`);
+  check(
+    'GET /steps → 200, two steps in order',
+    r3.status === 200 &&
+      r3.body?.steps?.length === 2 &&
+      r3.body.steps[0].step_id === 's1' &&
+      r3.body.steps[1].step_id === 's2',
+    `got ${r3.status} ${JSON.stringify(r3.body)}`
+  );
 }
 
 // ---- patch ----
@@ -146,31 +173,52 @@ console.log('\nPatch:');
     token: aliceToken,
     body: { status: 'success', completed_at: new Date().toISOString(), duration_ms: 1234 },
   });
-  check('PATCH /api/v1/traces/:id → 200', r.status === 200, `got ${r.status} ${JSON.stringify(r.body)}`);
+  check(
+    'PATCH /api/v1/traces/:id → 200',
+    r.status === 200,
+    `got ${r.status} ${JSON.stringify(r.body)}`
+  );
 
   const r2 = await call('GET', `/api/v1/traces/${TRACE_ID}`, { token: aliceToken });
-  check('GET after patch shows status=success', r2.body?.status === 'success', `got status=${r2.body?.status}`);
+  check(
+    'GET after patch shows status=success',
+    r2.body?.status === 'success',
+    `got status=${r2.body?.status}`
+  );
 }
 
 // ---- cross-owner isolation ----
 console.log('\nOwner isolation:');
 {
   const r = await call('GET', `/api/v1/traces/${TRACE_ID}`, { token: bobToken });
-  check('bob GET alice\'s trace → 404 NOT_FOUND', r.status === 404 && r.body?.error?.code === 'NOT_FOUND', `got ${r.status} ${JSON.stringify(r.body)}`);
+  check(
+    "bob GET alice's trace → 404 NOT_FOUND",
+    r.status === 404 && r.body?.error?.code === 'NOT_FOUND',
+    `got ${r.status} ${JSON.stringify(r.body)}`
+  );
 
   const r2 = await call('DELETE', `/api/v1/traces/${TRACE_ID}`, { token: bobToken });
-  check('bob DELETE alice\'s trace → 404 NOT_FOUND', r2.status === 404 && r2.body?.error?.code === 'NOT_FOUND', `got ${r2.status} ${JSON.stringify(r2.body)}`);
+  check(
+    "bob DELETE alice's trace → 404 NOT_FOUND",
+    r2.status === 404 && r2.body?.error?.code === 'NOT_FOUND',
+    `got ${r2.status} ${JSON.stringify(r2.body)}`
+  );
 
   const r3 = await call('GET', '/api/v1/traces', { token: bobToken });
-  const aliceTraceVisibleToBob = Array.isArray(r3.body?.traces) && r3.body.traces.some((t) => t.trace_id === TRACE_ID);
-  check('bob LIST does not include alice\'s trace', !aliceTraceVisibleToBob);
+  const aliceTraceVisibleToBob =
+    Array.isArray(r3.body?.traces) && r3.body.traces.some((t) => t.trace_id === TRACE_ID);
+  check("bob LIST does not include alice's trace", !aliceTraceVisibleToBob);
 }
 
 // ---- validation ----
 console.log('\nValidation:');
 {
   const r = await call('POST', '/api/v1/traces', { token: aliceToken, body: {} });
-  check('empty body → 400 MISSING_FIELD', r.status === 400 && r.body?.error?.code === 'MISSING_FIELD', `got ${r.status}`);
+  check(
+    'empty body → 400 MISSING_FIELD',
+    r.status === 400 && r.body?.error?.code === 'MISSING_FIELD',
+    `got ${r.status}`
+  );
 }
 {
   const r = await call('POST', '/api/v1/traces', {
@@ -182,7 +230,11 @@ console.log('\nValidation:');
       status: 'running',
     },
   });
-  check('non-UUID trace_id → 400 INVALID_FIELD', r.status === 400 && r.body?.error?.code === 'INVALID_FIELD', `got ${r.status}`);
+  check(
+    'non-UUID trace_id → 400 INVALID_FIELD',
+    r.status === 400 && r.body?.error?.code === 'INVALID_FIELD',
+    `got ${r.status}`
+  );
 }
 
 // ---- delete + verify gone ----

--- a/registry/e2e-trace-test.mjs
+++ b/registry/e2e-trace-test.mjs
@@ -1,0 +1,204 @@
+// End-to-end test for the trace API.
+// Hits a running server (default http://localhost:3000), signs test JWTs with
+// the local JWT_SECRET, exercises every endpoint, and DELETEs everything it
+// created at the end. Exit code is non-zero if any check fails.
+//
+// Usage:
+//   BASE_URL=http://localhost:3000 node e2e-trace-test.mjs
+//   BASE_URL=https://dossier-registry.vercel.app node e2e-trace-test.mjs
+
+import jwt from 'jsonwebtoken';
+import { randomUUID } from 'node:crypto';
+
+const BASE = (process.env.BASE_URL || 'http://localhost:3000').replace(/\/$/, '');
+const SECRET = process.env.JWT_SECRET;
+if (!SECRET) {
+  console.error('JWT_SECRET must be set (source registry/.env.local)');
+  process.exit(1);
+}
+
+const ALICE = `e2e-alice-${randomUUID().slice(0, 8)}`;
+const BOB = `e2e-bob-${randomUUID().slice(0, 8)}`;
+const aliceToken = jwt.sign({ sub: ALICE, email: null, orgs: [] }, SECRET, { expiresIn: '1h' });
+const bobToken = jwt.sign({ sub: BOB, email: null, orgs: [] }, SECRET, { expiresIn: '1h' });
+
+const TRACE_ID = randomUUID();
+
+let pass = 0;
+let fail = 0;
+const failures = [];
+
+function check(name, cond, detail = '') {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    failures.push({ name, detail });
+    console.log(`  ✗ ${name}${detail ? ` — ${detail}` : ''}`);
+  }
+}
+
+async function call(method, path, opts = {}) {
+  const headers = { 'content-type': 'application/json' };
+  if (opts.token) headers.authorization = `Bearer ${opts.token}`;
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers,
+    body: opts.body ? JSON.stringify(opts.body) : undefined,
+  });
+  let body = null;
+  if (res.status !== 204) {
+    const text = await res.text();
+    try { body = text ? JSON.parse(text) : null; } catch { body = text; }
+  }
+  return { status: res.status, body, requestId: res.headers.get('x-request-id') };
+}
+
+console.log(`\nTesting ${BASE}`);
+console.log(`  alice: ${ALICE}`);
+console.log(`  bob:   ${BOB}`);
+console.log(`  trace: ${TRACE_ID}\n`);
+
+// ---- auth gate ----
+console.log('Auth:');
+{
+  const r = await call('POST', '/api/v1/traces', { body: {} });
+  check('POST /api/v1/traces without token → 401 MISSING_TOKEN', r.status === 401 && r.body?.error?.code === 'MISSING_TOKEN', `got ${r.status} ${JSON.stringify(r.body)}`);
+}
+
+// ---- create ----
+console.log('\nCreate:');
+{
+  const r = await call('POST', '/api/v1/traces', {
+    token: aliceToken,
+    body: {
+      trace_id: TRACE_ID,
+      dossier: { title: 'E2E Test Dossier', version: '1.0.0' },
+      agent: { name: 'e2e-runner', version: '1.0' },
+      started_at: new Date().toISOString(),
+      status: 'running',
+    },
+  });
+  check('POST /api/v1/traces → 201', r.status === 201, `got ${r.status} ${JSON.stringify(r.body)}`);
+  check('  response has trace_id', r.body?.trace_id === TRACE_ID);
+  check('  response has url', r.body?.url === `/api/v1/traces/${TRACE_ID}`);
+}
+
+// ---- conflict ----
+console.log('\nConflict:');
+{
+  const r = await call('POST', '/api/v1/traces', {
+    token: aliceToken,
+    body: {
+      trace_id: TRACE_ID,
+      dossier: { title: 'Dup', version: '1.0.0' },
+      started_at: new Date().toISOString(),
+      status: 'running',
+    },
+  });
+  check('POST same trace_id → 409 CONFLICT', r.status === 409 && r.body?.error?.code === 'CONFLICT', `got ${r.status} ${JSON.stringify(r.body)}`);
+}
+
+// ---- list ----
+console.log('\nList:');
+{
+  const r = await call('GET', '/api/v1/traces?status=running', { token: aliceToken });
+  check('GET /api/v1/traces?status=running → 200', r.status === 200, `got ${r.status}`);
+  const found = Array.isArray(r.body?.traces) && r.body.traces.some((t) => t.trace_id === TRACE_ID);
+  check('  list contains our trace', found);
+  check('  pagination has limit/offset/total', typeof r.body?.pagination?.total === 'number');
+}
+
+// ---- get ----
+console.log('\nGet:');
+{
+  const r = await call('GET', `/api/v1/traces/${TRACE_ID}`, { token: aliceToken });
+  check('GET /api/v1/traces/:id → 200', r.status === 200, `got ${r.status}`);
+  check('  body has trace_id', r.body?.trace_id === TRACE_ID);
+  check('  body has dossier', r.body?.dossier?.title === 'E2E Test Dossier');
+  check('  body has empty steps array', Array.isArray(r.body?.steps) && r.body.steps.length === 0);
+}
+
+// ---- append steps ----
+console.log('\nAppend steps:');
+{
+  const r1 = await call('POST', `/api/v1/traces/${TRACE_ID}/steps`, {
+    token: aliceToken,
+    body: { step_id: 's1', type: 'action', detail: 'first step' },
+  });
+  check('POST /steps (1st) → 201, step_number=1', r1.status === 201 && r1.body?.step_number === 1, `got ${r1.status} ${JSON.stringify(r1.body)}`);
+
+  const r2 = await call('POST', `/api/v1/traces/${TRACE_ID}/steps`, {
+    token: aliceToken,
+    body: { step_id: 's2', type: 'validation', detail: 'second step' },
+  });
+  check('POST /steps (2nd) → 201, step_number=2', r2.status === 201 && r2.body?.step_number === 2, `got ${r2.status} ${JSON.stringify(r2.body)}`);
+
+  const r3 = await call('GET', `/api/v1/traces/${TRACE_ID}/steps`, { token: aliceToken });
+  check('GET /steps → 200, two steps in order', r3.status === 200 && r3.body?.steps?.length === 2 && r3.body.steps[0].step_id === 's1' && r3.body.steps[1].step_id === 's2', `got ${r3.status} ${JSON.stringify(r3.body)}`);
+}
+
+// ---- patch ----
+console.log('\nPatch:');
+{
+  const r = await call('PATCH', `/api/v1/traces/${TRACE_ID}`, {
+    token: aliceToken,
+    body: { status: 'success', completed_at: new Date().toISOString(), duration_ms: 1234 },
+  });
+  check('PATCH /api/v1/traces/:id → 200', r.status === 200, `got ${r.status} ${JSON.stringify(r.body)}`);
+
+  const r2 = await call('GET', `/api/v1/traces/${TRACE_ID}`, { token: aliceToken });
+  check('GET after patch shows status=success', r2.body?.status === 'success', `got status=${r2.body?.status}`);
+}
+
+// ---- cross-owner isolation ----
+console.log('\nOwner isolation:');
+{
+  const r = await call('GET', `/api/v1/traces/${TRACE_ID}`, { token: bobToken });
+  check('bob GET alice\'s trace → 404 NOT_FOUND', r.status === 404 && r.body?.error?.code === 'NOT_FOUND', `got ${r.status} ${JSON.stringify(r.body)}`);
+
+  const r2 = await call('DELETE', `/api/v1/traces/${TRACE_ID}`, { token: bobToken });
+  check('bob DELETE alice\'s trace → 404 NOT_FOUND', r2.status === 404 && r2.body?.error?.code === 'NOT_FOUND', `got ${r2.status} ${JSON.stringify(r2.body)}`);
+
+  const r3 = await call('GET', '/api/v1/traces', { token: bobToken });
+  const aliceTraceVisibleToBob = Array.isArray(r3.body?.traces) && r3.body.traces.some((t) => t.trace_id === TRACE_ID);
+  check('bob LIST does not include alice\'s trace', !aliceTraceVisibleToBob);
+}
+
+// ---- validation ----
+console.log('\nValidation:');
+{
+  const r = await call('POST', '/api/v1/traces', { token: aliceToken, body: {} });
+  check('empty body → 400 MISSING_FIELD', r.status === 400 && r.body?.error?.code === 'MISSING_FIELD', `got ${r.status}`);
+}
+{
+  const r = await call('POST', '/api/v1/traces', {
+    token: aliceToken,
+    body: {
+      trace_id: 'not-a-uuid',
+      dossier: { title: 'X', version: '1.0.0' },
+      started_at: new Date().toISOString(),
+      status: 'running',
+    },
+  });
+  check('non-UUID trace_id → 400 INVALID_FIELD', r.status === 400 && r.body?.error?.code === 'INVALID_FIELD', `got ${r.status}`);
+}
+
+// ---- delete + verify gone ----
+console.log('\nDelete:');
+{
+  const r = await call('DELETE', `/api/v1/traces/${TRACE_ID}`, { token: aliceToken });
+  check('DELETE /api/v1/traces/:id → 204', r.status === 204, `got ${r.status}`);
+
+  const r2 = await call('GET', `/api/v1/traces/${TRACE_ID}`, { token: aliceToken });
+  check('GET after delete → 404', r2.status === 404);
+}
+
+// ---- summary ----
+console.log(`\n${pass} passed, ${fail} failed`);
+if (fail > 0) {
+  console.log('\nFailures:');
+  for (const f of failures) console.log(`  - ${f.name}: ${f.detail}`);
+  process.exit(1);
+}

--- a/registry/lib/db.ts
+++ b/registry/lib/db.ts
@@ -1,0 +1,11 @@
+import { neon } from '@neondatabase/serverless';
+
+// DATABASE_URL is set automatically by the Vercel-Neon integration.
+// POSTGRES_URL is a legacy fallback some older integrations use.
+const connectionString = process.env.DATABASE_URL || process.env.POSTGRES_URL;
+
+if (!connectionString && process.env.NODE_ENV !== 'test') {
+  throw new Error('DATABASE_URL (or POSTGRES_URL) must be set');
+}
+
+export const sql = connectionString ? neon(connectionString) : (null as never);

--- a/registry/lib/traces.ts
+++ b/registry/lib/traces.ts
@@ -1,0 +1,279 @@
+// Trace query helpers. Every function is owner-scoped: callers MUST pass the
+// JWT subject as `owner` and never read rows where owner != JWT subject.
+//
+// The full trace blob (conforming to the Dossier execution trace schema
+// authored on the schema-implementation branch) lives in traces.data (JSONB).
+// The columns alongside it are extracted at write time for fast filtering and
+// indexing.
+
+import { sql } from './db';
+
+export const VALID_STATUSES = ['running', 'success', 'failed', 'cancelled'] as const;
+export type TraceStatus = (typeof VALID_STATUSES)[number];
+
+export interface TraceInput {
+  trace_id: string;
+  dossier: { title: string; version: string; [key: string]: unknown };
+  agent?: { name?: string; version?: string; [key: string]: unknown };
+  started_at: string;
+  completed_at?: string;
+  duration_ms?: number;
+  status: TraceStatus;
+  [key: string]: unknown;
+}
+
+export interface TraceUpdate {
+  status?: TraceStatus;
+  completed_at?: string;
+  duration_ms?: number;
+  steps?: StepInput[];
+  [key: string]: unknown;
+}
+
+export interface StepInput {
+  step_id: string;
+  type: string;
+  timestamp?: string;
+  [key: string]: unknown;
+}
+
+export interface TraceListFilters {
+  dossier?: string | null;
+  status?: TraceStatus | null;
+  from?: string | null;
+  to?: string | null;
+  limit?: string | number;
+  offset?: string | number;
+}
+
+export interface TraceListRow {
+  trace_id: string;
+  dossier_title: string;
+  dossier_version: string;
+  agent_name: string | null;
+  agent_version: string | null;
+  started_at: Date | string;
+  completed_at: Date | string | null;
+  status: TraceStatus;
+  duration_ms: number | null;
+}
+
+export interface CreateResult {
+  id: string;
+  traceId: string;
+  createdAt: Date | string;
+}
+
+export async function createTrace(owner: string, trace: TraceInput): Promise<CreateResult> {
+  const startedAt = new Date(trace.started_at);
+  const completedAt = trace.completed_at ? new Date(trace.completed_at) : null;
+  const rows = (await sql`
+    INSERT INTO traces (
+      trace_id, owner,
+      dossier_title, dossier_version, agent_name, agent_version,
+      started_at, completed_at, duration_ms, status,
+      data
+    ) VALUES (
+      ${trace.trace_id}, ${owner},
+      ${trace.dossier.title}, ${trace.dossier.version},
+      ${trace.agent?.name ?? null}, ${trace.agent?.version ?? null},
+      ${startedAt}, ${completedAt}, ${trace.duration_ms ?? null}, ${trace.status},
+      ${JSON.stringify(trace)}::jsonb
+    )
+    RETURNING id, trace_id, created_at
+  `) as Array<{ id: string; trace_id: string; created_at: Date }>;
+  const row = rows[0];
+  return { id: row.id, traceId: row.trace_id, createdAt: row.created_at };
+}
+
+export async function getTrace(
+  owner: string,
+  traceId: string
+): Promise<Record<string, unknown> | null> {
+  const traces = (await sql`
+    SELECT id, data
+    FROM traces
+    WHERE trace_id = ${traceId} AND owner = ${owner}
+    LIMIT 1
+  `) as Array<{ id: string; data: Record<string, unknown> }>;
+  if (traces.length === 0) return null;
+
+  const tracePk = traces[0].id;
+  const steps = (await sql`
+    SELECT data
+    FROM trace_steps
+    WHERE trace_pk = ${tracePk}
+    ORDER BY step_number ASC
+  `) as Array<{ data: Record<string, unknown> }>;
+
+  return { ...traces[0].data, steps: steps.map((s) => s.data) };
+}
+
+export interface ListResult {
+  rows: TraceListRow[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export async function listTraces(
+  owner: string,
+  filters: TraceListFilters = {}
+): Promise<ListResult> {
+  const { dossier = null, status = null, from = null, to = null } = filters;
+  const limit = Math.min(Number.parseInt(String(filters.limit ?? '50'), 10) || 50, 200);
+  const offset = Number.parseInt(String(filters.offset ?? '0'), 10) || 0;
+
+  const fromDate = from ? new Date(from) : null;
+  const toDate = to ? new Date(to) : null;
+
+  const rows = (await sql`
+    SELECT trace_id, dossier_title, dossier_version, agent_name, agent_version,
+           started_at, completed_at, status, duration_ms
+    FROM traces
+    WHERE owner = ${owner}
+      AND (${dossier}::text  IS NULL OR dossier_title = ${dossier})
+      AND (${status}::text   IS NULL OR status        = ${status})
+      AND (${fromDate}::timestamptz IS NULL OR started_at >= ${fromDate})
+      AND (${toDate}::timestamptz   IS NULL OR started_at <= ${toDate})
+    ORDER BY started_at DESC
+    LIMIT ${limit} OFFSET ${offset}
+  `) as TraceListRow[];
+
+  const countRows = (await sql`
+    SELECT COUNT(*)::int AS count
+    FROM traces
+    WHERE owner = ${owner}
+      AND (${dossier}::text  IS NULL OR dossier_title = ${dossier})
+      AND (${status}::text   IS NULL OR status        = ${status})
+      AND (${fromDate}::timestamptz IS NULL OR started_at >= ${fromDate})
+      AND (${toDate}::timestamptz   IS NULL OR started_at <= ${toDate})
+  `) as Array<{ count: number }>;
+
+  return { rows, total: countRows[0].count, limit, offset };
+}
+
+/**
+ * Apply PATCH updates to a trace, scoped to owner.
+ * Merges `updates` into traces.data (JSONB) and refreshes extracted columns.
+ * Bulk-appended steps in `updates.steps` are written to trace_steps and stripped
+ * from the merged data blob (steps are the source of truth in their own table).
+ *
+ * @returns false if no row matched (trace missing or wrong owner)
+ */
+export async function updateTrace(
+  owner: string,
+  traceId: string,
+  updates: TraceUpdate
+): Promise<boolean> {
+  const existing = (await sql`
+    SELECT id, data
+    FROM traces
+    WHERE trace_id = ${traceId} AND owner = ${owner}
+    LIMIT 1
+  `) as Array<{ id: string; data: Record<string, unknown> }>;
+  if (existing.length === 0) return false;
+
+  const tracePk = existing[0].id;
+  const bulkSteps = Array.isArray(updates.steps) ? updates.steps : null;
+
+  // Strip `steps` from the JSONB blob — steps are the source of truth in their own table.
+  const { steps: _steps, ...dataUpdates } = updates;
+  const mergedData = { ...existing[0].data, ...dataUpdates };
+
+  const completedAt = updates.completed_at ? new Date(updates.completed_at) : null;
+  await sql`
+    UPDATE traces
+    SET
+      status       = COALESCE(${updates.status ?? null}, status),
+      completed_at = COALESCE(${completedAt}, completed_at),
+      duration_ms  = COALESCE(${updates.duration_ms ?? null}, duration_ms),
+      data         = ${JSON.stringify(mergedData)}::jsonb,
+      updated_at   = NOW()
+    WHERE id = ${tracePk}
+  `;
+
+  if (bulkSteps && bulkSteps.length > 0) {
+    const last = (await sql`
+      SELECT COALESCE(MAX(step_number), 0)::int AS max
+      FROM trace_steps
+      WHERE trace_pk = ${tracePk}
+    `) as Array<{ max: number }>;
+    let next = last[0].max;
+    for (const step of bulkSteps) {
+      next += 1;
+      const ts = step.timestamp ? new Date(step.timestamp) : new Date();
+      await sql`
+        INSERT INTO trace_steps (trace_pk, step_id, step_number, timestamp, type, data)
+        VALUES (${tracePk}, ${step.step_id}, ${next}, ${ts}, ${step.type}, ${JSON.stringify(step)}::jsonb)
+      `;
+    }
+  }
+
+  return true;
+}
+
+export async function deleteTrace(owner: string, traceId: string): Promise<boolean> {
+  const rows = (await sql`
+    DELETE FROM traces
+    WHERE trace_id = ${traceId} AND owner = ${owner}
+    RETURNING id
+  `) as Array<{ id: string }>;
+  return rows.length > 0;
+}
+
+/**
+ * @returns null if trace not found / not owned by `owner`
+ */
+export async function appendStep(
+  owner: string,
+  traceId: string,
+  step: StepInput
+): Promise<{ stepNumber: number } | null> {
+  const traces = (await sql`
+    SELECT id FROM traces
+    WHERE trace_id = ${traceId} AND owner = ${owner}
+    LIMIT 1
+  `) as Array<{ id: string }>;
+  if (traces.length === 0) return null;
+  const tracePk = traces[0].id;
+
+  const last = (await sql`
+    SELECT COALESCE(MAX(step_number), 0)::int AS max
+    FROM trace_steps
+    WHERE trace_pk = ${tracePk}
+  `) as Array<{ max: number }>;
+  const stepNumber = last[0].max + 1;
+  const ts = step.timestamp ? new Date(step.timestamp) : new Date();
+
+  await sql`
+    INSERT INTO trace_steps (trace_pk, step_id, step_number, timestamp, type, data)
+    VALUES (${tracePk}, ${step.step_id}, ${stepNumber}, ${ts}, ${step.type}, ${JSON.stringify(step)}::jsonb)
+  `;
+
+  return { stepNumber };
+}
+
+/**
+ * @returns null if trace not found / not owned by `owner`
+ */
+export async function listSteps(
+  owner: string,
+  traceId: string
+): Promise<Record<string, unknown>[] | null> {
+  const traces = (await sql`
+    SELECT id FROM traces
+    WHERE trace_id = ${traceId} AND owner = ${owner}
+    LIMIT 1
+  `) as Array<{ id: string }>;
+  if (traces.length === 0) return null;
+  const tracePk = traces[0].id;
+
+  const rows = (await sql`
+    SELECT data
+    FROM trace_steps
+    WHERE trace_pk = ${tracePk}
+    ORDER BY step_number ASC
+  `) as Array<{ data: Record<string, unknown> }>;
+  return rows.map((r) => r.data);
+}

--- a/registry/migrations/001_traces.sql
+++ b/registry/migrations/001_traces.sql
@@ -1,0 +1,44 @@
+-- Dossier Tracing v1.0.0 schema
+-- See trace-schema.json at the repo root for the JSON contract stored in traces.data
+-- All rows are owner-scoped: every query must include WHERE owner = $1
+
+CREATE TABLE IF NOT EXISTS traces (
+  id              BIGSERIAL PRIMARY KEY,
+  trace_id        UUID NOT NULL UNIQUE,
+  owner           TEXT NOT NULL,
+
+  dossier_title   TEXT NOT NULL,
+  dossier_version TEXT NOT NULL,
+  agent_name      TEXT,
+  agent_version   TEXT,
+
+  started_at      TIMESTAMPTZ NOT NULL,
+  completed_at    TIMESTAMPTZ,
+  duration_ms     INTEGER,
+  status          TEXT NOT NULL CHECK (status IN ('running','success','failed','cancelled')),
+
+  data            JSONB NOT NULL,
+
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS traces_owner_started_at_idx ON traces (owner, started_at DESC);
+CREATE INDEX IF NOT EXISTS traces_owner_status_idx     ON traces (owner, status);
+CREATE INDEX IF NOT EXISTS traces_owner_title_idx      ON traces (owner, dossier_title);
+
+CREATE TABLE IF NOT EXISTS trace_steps (
+  id           BIGSERIAL PRIMARY KEY,
+  trace_pk     BIGINT NOT NULL REFERENCES traces(id) ON DELETE CASCADE,
+  step_id      TEXT NOT NULL,
+  step_number  INTEGER NOT NULL,
+  timestamp    TIMESTAMPTZ NOT NULL,
+  type         TEXT NOT NULL,
+  data         JSONB NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  UNIQUE (trace_pk, step_number)
+);
+
+CREATE INDEX IF NOT EXISTS trace_steps_trace_pk_step_number_idx
+  ON trace_steps (trace_pk, step_number);

--- a/registry/package.json
+++ b/registry/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/imboard-ai/ai-dossier/tree/main/registry#readme",
   "dependencies": {
     "@ai-dossier/core": "*",
+    "@neondatabase/serverless": "^1.1.0",
     "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {

--- a/registry/scripts/migrate.sh
+++ b/registry/scripts/migrate.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Apply SQL migrations in order. Idempotent: every migration uses IF NOT EXISTS.
+#
+# Usage:
+#   DATABASE_URL=postgres://... ./scripts/migrate.sh
+#
+# Requires psql in PATH.
+
+set -euo pipefail
+
+if [[ -z "${DATABASE_URL:-${POSTGRES_URL:-}}" ]]; then
+  echo "ERROR: DATABASE_URL (or POSTGRES_URL) must be set" >&2
+  exit 1
+fi
+
+CONN="${DATABASE_URL:-$POSTGRES_URL}"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/migrations"
+
+shopt -s nullglob
+for file in "$DIR"/*.sql; do
+  echo "Applying $(basename "$file")..."
+  psql "$CONN" -v ON_ERROR_STOP=1 -f "$file"
+done
+echo "Done."

--- a/registry/tests/traces.test.ts
+++ b/registry/tests/traces.test.ts
@@ -1,0 +1,509 @@
+// Handler-level tests for the trace API routes.
+// lib/traces is fully mocked so no DB is required.
+// lib/auth is exercised end-to-end with a mocked jsonwebtoken + config.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockReq, createMockRes } from './helpers/mocks';
+
+vi.mock('jsonwebtoken', () => ({
+  default: {
+    sign: () => 'mock-token',
+    verify: () => ({ sub: 'alice', email: null, orgs: [] }),
+  },
+}));
+
+vi.mock('../lib/config', () => ({
+  default: {
+    auth: { jwt: { secret: 'test-secret' } },
+  },
+}));
+
+vi.mock('../lib/traces', () => ({
+  VALID_STATUSES: ['running', 'success', 'failed', 'cancelled'],
+  createTrace: vi.fn(),
+  getTrace: vi.fn(),
+  listTraces: vi.fn(),
+  updateTrace: vi.fn(),
+  deleteTrace: vi.fn(),
+  appendStep: vi.fn(),
+  listSteps: vi.fn(),
+}));
+
+import traceIdHandler from '../api/v1/traces/[traceId]';
+import stepsHandler from '../api/v1/traces/[traceId]/steps';
+import tracesHandler from '../api/v1/traces/index';
+import * as traces from '../lib/traces';
+
+const VALID_UUID = '11111111-2222-3333-4444-555555555555';
+const OTHER_UUID = '99999999-8888-7777-6666-555555555555';
+const OWNER = 'alice';
+
+function authedHeaders(): Record<string, string> {
+  return { authorization: 'Bearer test-token' };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('auth gate (shared across routes)', () => {
+  it('returns 401 MISSING_TOKEN when Authorization header is absent', async () => {
+    const { res, getStatus, getBody } = createMockRes();
+    await tracesHandler(createMockReq({ method: 'POST', body: {} }) as never, res as never);
+    expect(getStatus()).toBe(401);
+    expect(getBody()).toMatchObject({ error: { code: 'MISSING_TOKEN' } });
+  });
+
+  it('returns 401 INVALID_TOKEN when the JWT verify throws', async () => {
+    const jwt = await import('jsonwebtoken');
+    const original = jwt.default.verify;
+    (jwt.default.verify as unknown) = () => {
+      const err = new Error('bad signature');
+      err.name = 'JsonWebTokenError';
+      throw err;
+    };
+    try {
+      const { res, getStatus, getBody } = createMockRes();
+      await tracesHandler(
+        createMockReq({ method: 'POST', body: {}, headers: authedHeaders() }) as never,
+        res as never
+      );
+      expect(getStatus()).toBe(401);
+      expect(getBody()).toMatchObject({ error: { code: 'INVALID_TOKEN' } });
+    } finally {
+      (jwt.default.verify as unknown) = original;
+    }
+  });
+
+  it('returns 401 TOKEN_EXPIRED when the JWT verify throws TokenExpiredError', async () => {
+    const jwt = await import('jsonwebtoken');
+    const original = jwt.default.verify;
+    (jwt.default.verify as unknown) = () => {
+      const err = new Error('jwt expired');
+      err.name = 'TokenExpiredError';
+      throw err;
+    };
+    try {
+      const { res, getStatus, getBody } = createMockRes();
+      await tracesHandler(
+        createMockReq({ method: 'POST', body: {}, headers: authedHeaders() }) as never,
+        res as never
+      );
+      expect(getStatus()).toBe(401);
+      expect(getBody()).toMatchObject({ error: { code: 'TOKEN_EXPIRED' } });
+    } finally {
+      (jwt.default.verify as unknown) = original;
+    }
+  });
+});
+
+// ---- POST /api/v1/traces ----
+
+describe('POST /api/v1/traces', () => {
+  const validBody = () => ({
+    trace_id: VALID_UUID,
+    dossier: { title: 'Setup React', version: '1.0.0' },
+    started_at: '2026-05-12T10:00:00Z',
+    status: 'running' as const,
+  });
+
+  it('rejects missing trace_id with 400 MISSING_FIELD', async () => {
+    const body = validBody() as Partial<ReturnType<typeof validBody>>;
+    delete body.trace_id;
+    const { res, getStatus, getBody } = createMockRes();
+    await tracesHandler(
+      createMockReq({ method: 'POST', body, headers: authedHeaders() }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(400);
+    expect(getBody()).toMatchObject({ error: { code: 'MISSING_FIELD' } });
+  });
+
+  it('rejects non-UUID trace_id with 400 INVALID_FIELD', async () => {
+    const { res, getStatus, getBody } = createMockRes();
+    await tracesHandler(
+      createMockReq({
+        method: 'POST',
+        body: { ...validBody(), trace_id: 'not-a-uuid' },
+        headers: authedHeaders(),
+      }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(400);
+    expect(getBody()).toMatchObject({ error: { code: 'INVALID_FIELD' } });
+  });
+
+  it('rejects missing dossier.title with 400 MISSING_FIELD', async () => {
+    const body = validBody() as { dossier: { title?: string; version: string } };
+    body.dossier = { version: '1.0.0' };
+    const { res, getStatus, getBody } = createMockRes();
+    await tracesHandler(
+      createMockReq({ method: 'POST', body, headers: authedHeaders() }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(400);
+    expect((getBody() as { error: { message: string } }).error.message).toMatch(/dossier\.title/);
+  });
+
+  it('rejects invalid status with 400 INVALID_FIELD', async () => {
+    const { res, getStatus, getBody } = createMockRes();
+    await tracesHandler(
+      createMockReq({
+        method: 'POST',
+        body: { ...validBody(), status: 'frobnicated' },
+        headers: authedHeaders(),
+      }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(400);
+    expect(getBody()).toMatchObject({ error: { code: 'INVALID_FIELD' } });
+  });
+
+  it('creates and returns 201 on the happy path', async () => {
+    (traces.createTrace as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      id: '1',
+      traceId: VALID_UUID,
+      createdAt: new Date('2026-05-12T10:00:01Z'),
+    });
+    const { res, getStatus, getBody } = createMockRes();
+    await tracesHandler(
+      createMockReq({ method: 'POST', body: validBody(), headers: authedHeaders() }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(201);
+    expect(getBody()).toMatchObject({
+      trace_id: VALID_UUID,
+      url: `/api/v1/traces/${VALID_UUID}`,
+    });
+    expect(traces.createTrace).toHaveBeenCalledWith(
+      OWNER,
+      expect.objectContaining({ trace_id: VALID_UUID })
+    );
+  });
+
+  it('maps Postgres unique-violation (23505) to 409 CONFLICT', async () => {
+    (traces.createTrace as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      Object.assign(new Error('dup'), { code: '23505' })
+    );
+    const { res, getStatus, getBody } = createMockRes();
+    await tracesHandler(
+      createMockReq({ method: 'POST', body: validBody(), headers: authedHeaders() }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(409);
+    expect(getBody()).toMatchObject({ error: { code: 'CONFLICT' } });
+  });
+});
+
+// ---- GET /api/v1/traces ----
+
+describe('GET /api/v1/traces', () => {
+  it('returns mapped traces and pagination', async () => {
+    (traces.listTraces as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      rows: [
+        {
+          trace_id: VALID_UUID,
+          dossier_title: 'X',
+          dossier_version: '1.0.0',
+          agent_name: 'Claude',
+          agent_version: '4.7',
+          started_at: new Date('2026-05-12T10:00:00Z'),
+          completed_at: null,
+          status: 'running',
+          duration_ms: null,
+        },
+      ],
+      total: 1,
+      limit: 50,
+      offset: 0,
+    });
+    const { res, getStatus, getBody } = createMockRes();
+    await tracesHandler(
+      createMockReq({ method: 'GET', headers: authedHeaders() }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(200);
+    const body = getBody() as {
+      traces: Array<{ dossier: unknown; agent: unknown }>;
+      pagination: unknown;
+    };
+    expect(body.traces).toHaveLength(1);
+    expect(body.traces[0].dossier).toEqual({ title: 'X', version: '1.0.0' });
+    expect(body.traces[0].agent).toEqual({ name: 'Claude', version: '4.7' });
+    expect(body.pagination).toEqual({ total: 1, limit: 50, offset: 0, next: null });
+  });
+
+  it('rejects invalid status filter with 400', async () => {
+    const { res, getStatus } = createMockRes();
+    await tracesHandler(
+      createMockReq({
+        method: 'GET',
+        query: { status: 'bogus' },
+        headers: authedHeaders(),
+      }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(400);
+    expect(traces.listTraces).not.toHaveBeenCalled();
+  });
+});
+
+// ---- GET / PATCH / DELETE /api/v1/traces/:traceId ----
+
+describe('GET /api/v1/traces/:traceId', () => {
+  it('rejects non-UUID path param with 400', async () => {
+    const { res, getStatus } = createMockRes();
+    await traceIdHandler(
+      createMockReq({
+        method: 'GET',
+        query: { traceId: 'nope' },
+        headers: authedHeaders(),
+      }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(400);
+  });
+
+  it('returns 404 when trace not found / cross-owner', async () => {
+    (traces.getTrace as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    const { res, getStatus, getBody } = createMockRes();
+    await traceIdHandler(
+      createMockReq({
+        method: 'GET',
+        query: { traceId: OTHER_UUID },
+        headers: authedHeaders(),
+      }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(404);
+    expect(getBody()).toMatchObject({ error: { code: 'NOT_FOUND' } });
+    expect(traces.getTrace).toHaveBeenCalledWith(OWNER, OTHER_UUID);
+  });
+
+  it('returns the full trace on happy path', async () => {
+    const fullTrace = {
+      trace_id: VALID_UUID,
+      status: 'success',
+      steps: [{ step_id: 's1', type: 'action' }],
+    };
+    (traces.getTrace as ReturnType<typeof vi.fn>).mockResolvedValueOnce(fullTrace);
+    const { res, getStatus, getBody } = createMockRes();
+    await traceIdHandler(
+      createMockReq({
+        method: 'GET',
+        query: { traceId: VALID_UUID },
+        headers: authedHeaders(),
+      }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(200);
+    expect(getBody()).toEqual(fullTrace);
+  });
+});
+
+describe('PATCH /api/v1/traces/:traceId', () => {
+  it('rejects invalid status with 400', async () => {
+    const { res, getStatus } = createMockRes();
+    await traceIdHandler(
+      createMockReq({
+        method: 'PATCH',
+        query: { traceId: VALID_UUID },
+        body: { status: 'frobnicated' },
+        headers: authedHeaders(),
+      }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(400);
+  });
+
+  it('returns 404 when trace missing', async () => {
+    (traces.updateTrace as ReturnType<typeof vi.fn>).mockResolvedValueOnce(false);
+    const { res, getStatus } = createMockRes();
+    await traceIdHandler(
+      createMockReq({
+        method: 'PATCH',
+        query: { traceId: VALID_UUID },
+        body: { status: 'success' },
+        headers: authedHeaders(),
+      }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(404);
+  });
+
+  it('returns 200 on success and forwards owner + updates', async () => {
+    (traces.updateTrace as ReturnType<typeof vi.fn>).mockResolvedValueOnce(true);
+    const { res, getStatus, getBody } = createMockRes();
+    await traceIdHandler(
+      createMockReq({
+        method: 'PATCH',
+        query: { traceId: VALID_UUID },
+        body: { status: 'success', completed_at: '2026-05-12T10:01:00Z' },
+        headers: authedHeaders(),
+      }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(200);
+    expect(getBody()).toMatchObject({ trace_id: VALID_UUID });
+    expect(traces.updateTrace).toHaveBeenCalledWith(
+      OWNER,
+      VALID_UUID,
+      expect.objectContaining({ status: 'success' })
+    );
+  });
+});
+
+describe('DELETE /api/v1/traces/:traceId', () => {
+  it('returns 404 when trace missing or owned by another user', async () => {
+    (traces.deleteTrace as ReturnType<typeof vi.fn>).mockResolvedValueOnce(false);
+    const { res, getStatus } = createMockRes();
+    await traceIdHandler(
+      createMockReq({
+        method: 'DELETE',
+        query: { traceId: VALID_UUID },
+        headers: authedHeaders(),
+      }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(404);
+  });
+
+  it('returns 204 on success', async () => {
+    (traces.deleteTrace as ReturnType<typeof vi.fn>).mockResolvedValueOnce(true);
+    const { res, getStatus } = createMockRes();
+    await traceIdHandler(
+      createMockReq({
+        method: 'DELETE',
+        query: { traceId: VALID_UUID },
+        headers: authedHeaders(),
+      }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(204);
+  });
+});
+
+// ---- POST / GET /api/v1/traces/:traceId/steps ----
+
+describe('POST /api/v1/traces/:traceId/steps', () => {
+  it('rejects missing step_id with 400', async () => {
+    const { res, getStatus, getBody } = createMockRes();
+    await stepsHandler(
+      createMockReq({
+        method: 'POST',
+        query: { traceId: VALID_UUID },
+        body: { type: 'action' },
+        headers: authedHeaders(),
+      }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(400);
+    expect((getBody() as { error: { message: string } }).error.message).toMatch(/step_id/);
+  });
+
+  it('rejects missing type with 400', async () => {
+    const { res, getStatus, getBody } = createMockRes();
+    await stepsHandler(
+      createMockReq({
+        method: 'POST',
+        query: { traceId: VALID_UUID },
+        body: { step_id: 's1' },
+        headers: authedHeaders(),
+      }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(400);
+    expect((getBody() as { error: { message: string } }).error.message).toMatch(/type/);
+  });
+
+  it('returns 404 when trace missing / cross-owner', async () => {
+    (traces.appendStep as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    const { res, getStatus } = createMockRes();
+    await stepsHandler(
+      createMockReq({
+        method: 'POST',
+        query: { traceId: VALID_UUID },
+        body: { step_id: 's1', type: 'action' },
+        headers: authedHeaders(),
+      }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(404);
+  });
+
+  it('returns 201 with assigned step_number on success', async () => {
+    (traces.appendStep as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ stepNumber: 7 });
+    const { res, getStatus, getBody } = createMockRes();
+    await stepsHandler(
+      createMockReq({
+        method: 'POST',
+        query: { traceId: VALID_UUID },
+        body: { step_id: 's1', type: 'action' },
+        headers: authedHeaders(),
+      }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(201);
+    expect(getBody()).toEqual({ trace_id: VALID_UUID, step_id: 's1', step_number: 7 });
+    expect(traces.appendStep).toHaveBeenCalledWith(
+      OWNER,
+      VALID_UUID,
+      expect.objectContaining({ step_id: 's1' })
+    );
+  });
+});
+
+describe('GET /api/v1/traces/:traceId/steps', () => {
+  it('returns 404 when trace missing', async () => {
+    (traces.listSteps as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    const { res, getStatus } = createMockRes();
+    await stepsHandler(
+      createMockReq({
+        method: 'GET',
+        query: { traceId: VALID_UUID },
+        headers: authedHeaders(),
+      }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(404);
+  });
+
+  it('returns step array on success', async () => {
+    (traces.listSteps as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { step_id: 's1' },
+      { step_id: 's2' },
+    ]);
+    const { res, getStatus, getBody } = createMockRes();
+    await stepsHandler(
+      createMockReq({
+        method: 'GET',
+        query: { traceId: VALID_UUID },
+        headers: authedHeaders(),
+      }) as never,
+      res as never
+    );
+    expect(getStatus()).toBe(200);
+    expect((getBody() as { steps: unknown[] }).steps).toHaveLength(2);
+  });
+});
+
+// ---- pure validation helper ----
+
+describe('validateCreatePayload (pure)', () => {
+  it('accepts a well-formed trace', async () => {
+    const { validateCreatePayload } = await import('../api/v1/traces/index');
+    const result = validateCreatePayload({
+      trace_id: VALID_UUID,
+      dossier: { title: 'X', version: '1.0.0' },
+      started_at: '2026-05-12T10:00:00Z',
+      status: 'running',
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects null body', async () => {
+    const { validateCreatePayload } = await import('../api/v1/traces/index');
+    const result = validateCreatePayload(null);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/registry/vercel.json
+++ b/registry/vercel.json
@@ -1,11 +1,11 @@
 {
   "installCommand": "cd .. && npm install",
   "buildCommand": "cd .. && npm run -w @ai-dossier/core build",
-  "outputDirectory": ".",
+  "outputDirectory": "public",
   "rewrites": [
     {
-      "source": "/api/v1/dossiers/:path*",
-      "destination": "/api/v1/dossiers/[...name]?name=:path*"
+      "source": "/api/v1/dossiers/:path(.*)",
+      "destination": "/api/v1/dossiers/[...name]?name=:path"
     },
     {
       "source": "/auth/login",


### PR DESCRIPTION
## Summary

Adds owner-scoped CRUD for Dossier execution traces to the registry. Traces and their steps live in Postgres (via `@neondatabase/serverless`); schema in `registry/migrations/001_traces.sql`. Auth, CORS, response envelope, request-id plumbing, and structured logging all reuse the existing registry conventions in `lib/*`.

## Routes

| Method | Path | Purpose |
|---|---|---|
| POST   | `/api/v1/traces` | Create a trace |
| GET    | `/api/v1/traces` | List current user's traces (filters: `dossier`, `status`, `from`, `to`; paginated) |
| GET    | `/api/v1/traces/:traceId` | Get full trace including steps |
| PATCH  | `/api/v1/traces/:traceId` | Update trace (status, completion, bulk-append steps) |
| DELETE | `/api/v1/traces/:traceId` | Delete trace + cascade-delete its steps |
| POST   | `/api/v1/traces/:traceId/steps` | Append a single step (real-time logging) |
| GET    | `/api/v1/traces/:traceId/steps` | List steps |

Validation follows the existing `dossiers/index.ts` pattern: a pure `validateCreatePayload()` returning a discriminated union, with the handler mapping failures via `lib/responses.ts` helpers (`badRequest`, `notFound`, `serverError`, `jsonError`, `methodNotAllowed`).

## Owner scoping

Every trace / step query includes `WHERE owner = $1` where `$1` is `jwt.sub`. Cross-owner reads return 404 (not 403) to avoid leaking trace-id existence.

## Storage decision

- **`@neondatabase/serverless`** rather than `@vercel/postgres` (the latter is deprecated, and Vercel's Postgres integration now provisions Neon under the hood).
- **No Prisma.** Stays JS/TS-native tagged-template, no code-gen step.
- **Two tables:** `traces` (with extracted indexed columns + JSONB blob of the full trace) and `trace_steps` (`UNIQUE (trace_pk, step_number)` enforces ordering integrity).

## Not done in this PR

- **No DB provisioned.** The Neon database has not been created on Vercel and the migration has not been applied anywhere.
- **No deploy.** Nothing pushed to preview or production.
- **Non-interactive agent auth deferred.** Long-running agents writing traces still need a manually-obtained JWT — there is no CLI/device-code flow yet. Scoped out per design discussion.
- **Trace schema source dependency.** The `trace-schema.json` contract authored on `claude/dossier-schema-implementation-*` is unmerged. This PR enforces required fields manually; once the schema branch merges, validation can switch to a generated type from `@ai-dossier/core`. The PRs can merge in either order.
- **Pre-existing `registry/api/v1/search.ts` TS errors** on `main` are out of scope and untouched by this PR.

## Test plan

- [x] `npm test --workspace=@ai-dossier/registry` — 13 test files / 183 cases / 0 failures (27 new cases in `tests/traces.test.ts`)
- [x] `npx biome check registry/` — clean
- [x] `npx tsc --noEmit` in registry — no new errors introduced (3 pre-existing errors in `search.ts` remain)
- [ ] Apply migration against a Neon preview database
- [ ] Smoke-test against a Vercel preview deployment
- [ ] Promote to production (manual, requires explicit approval)

## Notes for reviewers

- Tests mock `../lib/traces` so no DB is required to run them. Pure validation (`validateCreatePayload`) is also exported for isolated testing.
- `lib/db.ts` throws at module-load time if `DATABASE_URL` (or `POSTGRES_URL`) is missing, except under `NODE_ENV=test` where it's expected to be mocked out.
- `package-lock.json` diff includes some `libc` field removals on existing rollup entries — incidental npm housekeeping during `npm install`, not feature-related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)