### PR TITLE
fix(cli): use package specifier in login smoke require

### DIFF
--- a/cli/test/smoke/login.smoke.mjs
+++ b/cli/test/smoke/login.smoke.mjs
@@ -22,11 +22,12 @@ if (!BIN) {
 }
 
 // Import the prompt constant from the same package the binary belongs to so
-// the marker stays in sync with the production string. Resolved relative to
-// the binary path so this works for both workspace builds and unpacked
-// tarballs in CI.
+// the marker stays in sync with the production string. Use a package
+// specifier rather than a relative path so it resolves regardless of whether
+// the binary is a workspace file (`cli/bin/ai-dossier`) or an installed
+// symlink (`node_modules/.bin/ai-dossier` → `@ai-dossier/cli/bin/...`).
 const requireFromBin = createRequire(path.resolve(BIN));
-const { LOGIN_CODE_PROMPT } = requireFromBin('../dist/oauth.js');
+const { LOGIN_CODE_PROMPT } = requireFromBin('@ai-dossier/cli/dist/oauth.js');
 if (typeof LOGIN_CODE_PROMPT !== 'string') {
   console.error('FAIL: could not load LOGIN_CODE_PROMPT from CLI build');
   process.exit(2);


### PR DESCRIPTION
## Summary

Unblocks the pre-publish smoke job, which has been failing on every publish run (regression noticed when triggering publish for #391).

The Tier 2 smoke installs the cli tarball into a temp fixture project. Modern npm leaves `node_modules/.bin/ai-dossier` as a **symlink** to `../@ai-dossier/cli/bin/ai-dossier`. The previous `requireFromBin('../dist/oauth.js')` resolved relative to the symlink path and looked for `node_modules/dist/oauth.js` — which doesn't exist. The actual file is at `node_modules/@ai-dossier/cli/dist/oauth.js`.

Switching to `requireFromBin('@ai-dossier/cli/dist/oauth.js')` uses Node's package resolution, which walks up to find `node_modules/@ai-dossier/cli/` regardless of whether the binary is a workspace file or a symlinked install.

## Verification

Reproduced the CI harness locally:

```
$ npm install (cli + core tarballs into /tmp/smoke-fix)
$ ls -l /tmp/smoke-fix/node_modules/.bin/ai-dossier
... -> ../@ai-dossier/cli/bin/ai-dossier   ← same symlink shape as CI

$ node login.smoke.mjs /tmp/smoke-fix/node_modules/.bin/ai-dossier
PASS: ai-dossier login exited cleanly within timeout
```

## Test plan

- [x] Local smoke (symlinked install) passes
- [ ] CI lint / test / test-examples pass on this PR
- [ ] After merge: re-trigger publish-packages workflow with `version=patch`; the smoke job should now go green and publish should proceed

🤖 Generated with [Claude Code](https://claude.com/claude-code)