### PR TITLE
fix(ci): use corepack to install npm 11+ for trusted-publishing auth

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -154,12 +154,17 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      # Node 22 ships npm 10.x, which supports `npm publish --provenance`
-      # (OIDC trusted publishing) natively. Self-upgrading to npm@latest on
-      # the GH Actions toolcache image currently fails with a corrupted
-      # arborist install (missing promise-retry), so we just use bundled npm.
-      - name: Print npm version
-        run: npm --version
+      # Trusted-publishing AUTH (OIDC token used as the npm publish
+      # credential) requires npm 11.5+. Node 22's bundled npm is 10.9.7,
+      # which can sign provenance attestations but cannot authenticate
+      # the publish PUT, so the registry returns 404. Install npm 11+ via
+      # corepack — `npm install -g npm@latest` is broken on the current
+      # GH Actions toolcache image (arborist's promise-retry is missing).
+      - name: Install npm 11+ via corepack
+        run: |
+          corepack enable
+          corepack prepare npm@latest --activate
+          npm --version
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

Reverts the npm-install removal from #393 — which mistakenly assumed bundled npm was new enough — and replaces it with a working install path via corepack.

## Diagnosis

Looking at the post-#393 publish run (#25799333838), npm was printed as **10.9.7** (Node 22.22.2's bundled version). Trusted-publishing **auth** (where the OIDC token authenticates the publish PUT) requires **npm 11.5+**. Bundled npm 10.x can only sign the sigstore attestation, so we saw:

```
npm notice publish Signed provenance statement [...]
npm notice publish Provenance statement published to transparency log [...]
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@ai-dossier%2fcore
```

The 404 is npm's response when an authenticated scoped publish is rejected (security through obscurity, returning 404 rather than 401/403).

## Why corepack instead of restoring `npm install -g`

`npm install -g npm@latest` is broken on the current GH Actions Node 22.22.2 toolcache image — arborist's `promise-retry` transitive is missing, so any self-install of npm fails. Corepack manages package-manager versions independently of the bundled npm and bypasses that path.

```yaml
- name: Install npm 11+ via corepack
  run: |
    corepack enable
    corepack prepare npm@latest --activate
    npm --version
```

## State left over from the failed run

Main has `7a2868b chore: bump version to 0.8.1` from the earlier failed dispatch (core 1.3.1, cli 0.8.1, mcp-server 1.3.1) and tag `v0.8.1`, but npm still has 1.3.0/0.8.0/1.3.0. Re-trigger after this merge with **`version=skip`** so the workflow skips the bump and publishes the already-bumped versions.

## Test plan

- [ ] CI lint / tests / test-examples pass on this PR
- [ ] After merge: `gh workflow run publish-packages.yml -f version=skip` → `publish` job authenticates and uploads core 1.3.1, cli 0.8.1, mcp-server 1.3.1 to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)