### PR TITLE
fix(ci): install npm 11+ to local prefix for trusted-publishing auth

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -157,14 +157,19 @@ jobs:
       # Trusted-publishing AUTH (OIDC token used as the npm publish
       # credential) requires npm 11.5+. Node 22's bundled npm is 10.9.7,
       # which can sign provenance attestations but cannot authenticate
-      # the publish PUT, so the registry returns 404. Install npm 11+ via
-      # corepack — `npm install -g npm@latest` is broken on the current
-      # GH Actions toolcache image (arborist's promise-retry is missing).
-      - name: Install npm 11+ via corepack
+      # the publish PUT, so the registry returns 404.
+      #
+      # `npm install -g npm@latest` is broken on the current GH Actions
+      # toolcache image (arborist's promise-retry is missing on the
+      # global rebuild path). `corepack prepare npm@latest --activate`
+      # doesn't shadow the bundled npm either. Workaround: install npm
+      # into a local prefix (no global rebuild step) and prepend it to
+      # PATH so the version that runs the publish steps is 11+.
+      - name: Install npm 11+ to local prefix
         run: |
-          corepack enable
-          corepack prepare npm@latest --activate
-          npm --version
+          npm install --prefix /tmp/npm-latest npm@latest
+          echo "/tmp/npm-latest/node_modules/.bin" >> $GITHUB_PATH
+          /tmp/npm-latest/node_modules/.bin/npm --version
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

Third attempt at unblocking the publish workflow. The corepack-based fix in #394 didn't actually upgrade `npm --version` on the runner (still 10.9.7) — corepack only shadows the bundled npm when `packageManager` is set in package.json.

This change installs npm 11+ into `/tmp/npm-latest` via `npm install --prefix` (avoiding the broken global rebuild path that bit #393's revert) and prepends it to PATH.

## Diagnosis confirmed

Verified npm.com trusted publisher config for all four `@ai-dossier/*` packages — entries are present and correct:
- Repo: `imboard-ai/ai-dossier`
- Workflow: `publish-packages.yml`
- No environment

So the 404 in #393/#394 wasn't a misconfigured trusted publisher — it was bundled npm 10.9.7 failing to perform OIDC auth on the publish PUT (it can sign provenance but not authenticate). npm 11.5+ is needed for the OIDC-as-auth feature.

## Why local prefix install

| Approach | Outcome |
|---|---|
| `npm install -g npm@latest` | Hits broken arborist rebuild on toolcache (#393 reverted this) |
| `corepack prepare npm@latest --activate` | Doesn't shadow bundled npm without `packageManager` field (#394 was insufficient) |
| `npm install --prefix /tmp/npm-latest npm@latest` + PATH | No global rebuild → doesn't hit the broken codepath; PATH override gives 11+ at the version that runs publish |

## Test plan

- [ ] CI lint / tests pass on this PR
- [ ] After merge: `gh workflow run publish-packages.yml -f version=skip` → `Install npm 11+ to local prefix` step reports 11.x, `Publish @ai-dossier/core` succeeds with OIDC auth, all four packages published

🤖 Generated with [Claude Code](https://claude.com/claude-code)