### PR TITLE
feat: team-visible execution traces (agent.host + org-scoped reads + CLI)

### DIFF
--- a/cli/src/__tests__/registry-client.test.ts
+++ b/cli/src/__tests__/registry-client.test.ts
@@ -77,6 +77,60 @@ describe('RegistryClient', () => {
     });
   });
 
+  describe('listTraces', () => {
+    it('should call /traces with bearer auth and no params by default', async () => {
+      await client.listTraces();
+      const [url, init] = vi.mocked(fetch).mock.calls[0];
+      expect(url).toContain('/api/v1/traces');
+      expect((init as RequestInit).headers).toMatchObject({
+        Authorization: 'Bearer test-token',
+      });
+    });
+
+    it('passes status, dossier, from, to, limit, offset, org as query params', async () => {
+      await client.listTraces({
+        status: 'failed',
+        dossier: 'full-cycle',
+        from: '2026-05-01',
+        to: '2026-05-13',
+        limit: 25,
+        offset: 50,
+        org: 'imboard-ai',
+      });
+      const url = vi.mocked(fetch).mock.calls[0][0] as string;
+      expect(url).toContain('status=failed');
+      expect(url).toContain('dossier=full-cycle');
+      expect(url).toContain('from=2026-05-01');
+      expect(url).toContain('to=2026-05-13');
+      expect(url).toContain('limit=25');
+      expect(url).toContain('offset=50');
+      expect(url).toContain('org=imboard-ai');
+    });
+
+    it('omits unset params from the URL', async () => {
+      await client.listTraces();
+      const url = vi.mocked(fetch).mock.calls[0][0] as string;
+      expect(url).not.toContain('status=');
+      expect(url).not.toContain('org=');
+    });
+  });
+
+  describe('getTrace', () => {
+    it('should call /traces/:id', async () => {
+      await client.getTrace('abc-123');
+      const url = vi.mocked(fetch).mock.calls[0][0] as string;
+      expect(url).toContain('/api/v1/traces/abc-123');
+      expect(url).not.toContain('org=');
+    });
+
+    it('threads org through as query param', async () => {
+      await client.getTrace('abc-123', { org: 'imboard-ai' });
+      const url = vi.mocked(fetch).mock.calls[0][0] as string;
+      expect(url).toContain('/api/v1/traces/abc-123');
+      expect(url).toContain('org=imboard-ai');
+    });
+  });
+
   describe('getDossier', () => {
     it('should call correct endpoint', async () => {
       await client.getDossier('my-dossier');

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -36,6 +36,7 @@ import { registerRunCommand } from './commands/run';
 import { registerSearchCommand } from './commands/search';
 import { registerSignCommand } from './commands/sign';
 import { registerSkillExportCommand } from './commands/skill-export';
+import { registerTracesCommand } from './commands/traces';
 import { registerValidateCommand } from './commands/validate';
 import { registerVerifyCommand } from './commands/verify';
 import { registerWhoamiCommand } from './commands/whoami';
@@ -105,6 +106,7 @@ registerConfigCommand(program);
 registerCacheCommand(program);
 registerHistoryCommand(program);
 registerDoctorCommand(program);
+registerTracesCommand(program);
 
 // Hidden
 registerPromptHookCommand(program);

--- a/cli/src/commands/traces.ts
+++ b/cli/src/commands/traces.ts
@@ -1,0 +1,227 @@
+import type { Command } from 'commander';
+import { resolveRegistries } from '../config';
+import { isExpired, loadCredentials } from '../credentials';
+import {
+  getClientForRegistry,
+  type ListTracesResult,
+  RegistryError,
+  type TraceListItem,
+} from '../registry-client';
+
+interface ListOptions {
+  status?: string;
+  dossier?: string;
+  from?: string;
+  to?: string;
+  limit?: string;
+  offset?: string;
+  org?: string;
+  json?: boolean;
+  registry?: string;
+}
+
+interface ShowOptions {
+  org?: string;
+  json?: boolean;
+  registry?: string;
+}
+
+/** Registers the `traces` command tree (list, show). */
+export function registerTracesCommand(program: Command): void {
+  const tracesCmd = program
+    .command('traces')
+    .description('Inspect execution traces in the registry');
+
+  tracesCmd
+    .command('list')
+    .description('List your execution traces (or org traces with --org)')
+    .option('--status <status>', 'Filter: running, success, failed, cancelled')
+    .option('--dossier <name>', 'Filter by dossier title')
+    .option('--from <date>', 'Only traces started at or after this ISO date')
+    .option('--to <date>', 'Only traces started at or before this ISO date')
+    .option('--org <name>', 'Show traces from anyone in this org (must be a member)')
+    .option('--limit <n>', 'Page size (max 200)', '50')
+    .option('--offset <n>', 'Pagination offset', '0')
+    .option('--registry <name>', 'Registry to query', 'public')
+    .option('--json', 'Output raw JSON')
+    .action(async (options: ListOptions) => {
+      const client = mustGetAuthedClient(options.registry);
+
+      let result: ListTracesResult;
+      try {
+        result = await client.listTraces({
+          status: options.status,
+          dossier: options.dossier,
+          from: options.from,
+          to: options.to,
+          org: options.org,
+          limit: options.limit ? Math.max(1, Number.parseInt(options.limit, 10)) : undefined,
+          offset: options.offset ? Math.max(0, Number.parseInt(options.offset, 10)) : undefined,
+        });
+      } catch (err) {
+        handleRegistryError(err);
+        return;
+      }
+
+      if (options.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+
+      if (result.traces.length === 0) {
+        const where = options.org ? ` for org '${options.org}'` : '';
+        console.log(`\n  No traces found${where}.\n`);
+        return;
+      }
+
+      printTracesTable(result.traces);
+      const { total, offset, limit } = result.pagination;
+      const shown = Math.min(limit, result.traces.length);
+      console.log(
+        `\n  ${shown} of ${total} traces  (offset ${offset}, limit ${limit})${
+          result.pagination.next ? '  — more available' : ''
+        }\n`
+      );
+    });
+
+  tracesCmd
+    .command('show')
+    .description('Show a single execution trace with its steps')
+    .argument('<trace_id>', 'Trace UUID')
+    .option('--org <name>', "Read a teammate's trace via org membership")
+    .option('--registry <name>', 'Registry to query', 'public')
+    .option('--json', 'Output raw JSON')
+    .action(async (traceId: string, options: ShowOptions) => {
+      const client = mustGetAuthedClient(options.registry);
+
+      let trace: Record<string, unknown>;
+      try {
+        trace = await client.getTrace(traceId, { org: options.org });
+      } catch (err) {
+        handleRegistryError(err);
+        return;
+      }
+
+      if (options.json) {
+        console.log(JSON.stringify(trace, null, 2));
+        return;
+      }
+
+      printTraceDetail(trace);
+    });
+}
+
+function mustGetAuthedClient(
+  registryName: string | undefined
+): ReturnType<typeof getClientForRegistry> {
+  const name = registryName || 'public';
+  const creds = loadCredentials(name);
+  if (!creds) {
+    console.error(`\n❌ Not logged in to registry '${name}'. Run \`ai-dossier login\` first.\n`);
+    process.exit(1);
+  }
+  if (isExpired(creds)) {
+    console.error(
+      `\n❌ Credentials for '${name}' have expired. Run \`ai-dossier login\` to refresh.\n`
+    );
+    process.exit(1);
+  }
+  const registry = resolveRegistries().find((r) => r.name === name);
+  if (!registry) {
+    console.error(`\n❌ Registry '${name}' not configured.\n`);
+    process.exit(1);
+  }
+  return getClientForRegistry(registry.url, creds.token);
+}
+
+function handleRegistryError(err: unknown): never {
+  if (err instanceof RegistryError) {
+    const codeStr = err.code ? ` [${err.code}]` : '';
+    console.error(`\n❌ ${err.message}${codeStr}\n`);
+  } else if (err instanceof Error) {
+    console.error(`\n❌ ${err.message}\n`);
+  } else {
+    console.error('\n❌ Unknown error\n');
+  }
+  process.exit(1);
+}
+
+function printTracesTable(rows: TraceListItem[]): void {
+  // Compute column widths
+  const headers = ['STATUS', 'DOSSIER', 'STARTED', 'DURATION', 'TRACE_ID'];
+  const data = rows.map((t) => [
+    statusIcon(t.status),
+    `${t.dossier.title}@${t.dossier.version}`,
+    shortDate(t.started_at),
+    durationLabel(t.duration_ms),
+    t.trace_id.slice(0, 8),
+  ]);
+  const widths = headers.map((h, i) => Math.max(h.length, ...data.map((row) => row[i].length)));
+
+  const fmt = (cells: string[]) => cells.map((c, i) => c.padEnd(widths[i])).join('  ');
+  console.log(`\n  ${fmt(headers)}`);
+  console.log(`  ${widths.map((w) => '-'.repeat(w)).join('  ')}`);
+  for (const row of data) console.log(`  ${fmt(row)}`);
+}
+
+function printTraceDetail(trace: Record<string, unknown>): void {
+  const dossier = trace.dossier as { title?: string; version?: string } | undefined;
+  const agent = trace.agent as { name?: string; host?: string; version?: string } | undefined;
+  const steps = Array.isArray(trace.steps) ? trace.steps : [];
+
+  console.log(`\n  Trace ${trace.trace_id}`);
+  if (dossier) console.log(`    Dossier:    ${dossier.title}@${dossier.version}`);
+  if (agent) {
+    const parts: string[] = [];
+    if (agent.name) parts.push(agent.name);
+    if (agent.version) parts.push(`v${agent.version}`);
+    if (agent.host) parts.push(`(${agent.host})`);
+    console.log(`    Agent:      ${parts.join(' ')}`);
+  }
+  console.log(`    Status:     ${statusIcon(trace.status as string)} ${trace.status}`);
+  console.log(`    Started:    ${shortDate(trace.started_at as string)}`);
+  if (trace.completed_at) console.log(`    Completed:  ${shortDate(trace.completed_at as string)}`);
+  if (trace.duration_ms != null)
+    console.log(`    Duration:   ${durationLabel(trace.duration_ms as number)}`);
+
+  if (steps.length > 0) {
+    console.log(`\n  Steps (${steps.length}):`);
+    for (const step of steps as Array<Record<string, unknown>>) {
+      const ts = step.timestamp ? shortDate(step.timestamp as string) : '';
+      console.log(`    ${ts}  ${step.type ?? '?'}  ${step.step_id ?? ''}`);
+    }
+  }
+  console.log('');
+}
+
+function statusIcon(status: string): string {
+  switch (status) {
+    case 'success':
+      return 'OK   ';
+    case 'failed':
+      return 'FAIL ';
+    case 'running':
+      return '...  ';
+    case 'cancelled':
+      return 'X    ';
+    default:
+      return status.padEnd(5);
+  }
+}
+
+function shortDate(iso: string | null | undefined): string {
+  if (!iso) return '-';
+  // 2026-05-13T14:32:00Z → 2026-05-13 14:32
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toISOString().replace('T', ' ').slice(0, 16);
+}
+
+function durationLabel(ms: number | null | undefined): string {
+  if (ms == null) return '-';
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const min = Math.floor(ms / 60_000);
+  const sec = Math.floor((ms % 60_000) / 1000);
+  return `${min}m${sec}s`;
+}

--- a/cli/src/registry-client.ts
+++ b/cli/src/registry-client.ts
@@ -57,6 +57,36 @@ interface DossierListItem {
   tags?: string[];
 }
 
+interface ListTracesOptions {
+  status?: string;
+  dossier?: string;
+  from?: string;
+  to?: string;
+  limit?: number;
+  offset?: number;
+  org?: string;
+}
+
+interface TraceListItem {
+  trace_id: string;
+  dossier: { title: string; version: string };
+  agent?: { name?: string; version?: string; host?: string };
+  started_at: string;
+  completed_at: string | null;
+  status: 'running' | 'success' | 'failed' | 'cancelled';
+  duration_ms: number | null;
+}
+
+interface ListTracesResult {
+  traces: TraceListItem[];
+  pagination: {
+    total: number;
+    limit: number;
+    offset: number;
+    next: string | null;
+  };
+}
+
 interface ListDossiersResult {
   dossiers?: DossierListItem[];
   data?: DossierListItem[];
@@ -273,6 +303,43 @@ class RegistryClient {
   }
 
   /**
+   * List execution traces. Defaults to the authenticated user's own traces;
+   * pass `org` to list traces from anyone in that org (requires membership).
+   */
+  async listTraces(options: ListTracesOptions = {}): Promise<ListTracesResult> {
+    const params: Record<string, unknown> = {};
+    if (options.status) params.status = options.status;
+    if (options.dossier) params.dossier = options.dossier;
+    if (options.from) params.from = options.from;
+    if (options.to) params.to = options.to;
+    if (options.limit != null) params.limit = options.limit;
+    if (options.offset != null) params.offset = options.offset;
+    if (options.org) params.org = options.org;
+
+    const response = await fetch(this._buildUrl('/traces', params), {
+      headers: this._buildHeaders(),
+    });
+    return this._handleResponse<ListTracesResult>(response);
+  }
+
+  /**
+   * Fetch a single execution trace by id (includes all its steps inline).
+   * Pass `org` to read a trace from another member of that org (requires membership).
+   */
+  async getTrace(
+    traceId: string,
+    options: { org?: string } = {}
+  ): Promise<Record<string, unknown>> {
+    const params: Record<string, unknown> = {};
+    if (options.org) params.org = options.org;
+
+    const response = await fetch(this._buildUrl(`/traces/${traceId}`, params), {
+      headers: this._buildHeaders(),
+    });
+    return this._handleResponse<Record<string, unknown>>(response);
+  }
+
+  /**
    * Get current user info.
    */
   async getMe(): Promise<Record<string, unknown>> {
@@ -324,4 +391,7 @@ export type {
   SearchResult,
   ListDossiersOptions,
   SearchOptions,
+  ListTracesOptions,
+  ListTracesResult,
+  TraceListItem,
 };

--- a/mcp-server/src/tools/__tests__/startJourney-recorder.test.ts
+++ b/mcp-server/src/tools/__tests__/startJourney-recorder.test.ts
@@ -74,7 +74,9 @@ describe('startJourney → TraceRecorder.create', () => {
     expect(arg.trace_id).toBe(result.journey_id);
     expect(arg.status).toBe('running');
     expect(arg.dossier.title).toBe('entry-dossier');
-    expect(arg.agent).toEqual({ name: 'mcp-server' });
+    expect(arg.agent.name).toBe('mcp-server');
+    expect(typeof arg.agent.host).toBe('string');
+    expect(arg.agent.host.length).toBeGreaterThan(0);
     expect(typeof arg.started_at).toBe('string');
     expect(new Date(arg.started_at).toString()).not.toBe('Invalid Date');
   });

--- a/mcp-server/src/tools/startJourney.ts
+++ b/mcp-server/src/tools/startJourney.ts
@@ -4,6 +4,7 @@
  */
 
 import { readFileSync } from 'node:fs';
+import { hostname } from 'node:os';
 import { parseDossierContent } from '@ai-dossier/core';
 import { getRecorder } from '../orchestration/recorder';
 import { createSession, stepsFromPhases, updateSession } from '../orchestration/session';
@@ -115,7 +116,7 @@ export async function startJourney(
   getRecorder().create({
     trace_id: session.id,
     dossier: { title: first.name, version: 'unknown' },
-    agent: { name: 'mcp-server' },
+    agent: { name: 'mcp-server', host: hostname() },
     started_at: session.startedAt.toISOString(),
     status: 'running',
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,10 +27,10 @@
     },
     "cli": {
       "name": "@ai-dossier/cli",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@ai-dossier/core": "^1.2.0",
+        "@ai-dossier/core": "^1.3.1",
         "commander": "^12.1.0"
       },
       "bin": {
@@ -48,7 +48,7 @@
     },
     "mcp-server": {
       "name": "@ai-dossier/mcp-server",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ai-dossier/core": "^1.2.0",
@@ -6611,7 +6611,7 @@
     },
     "packages/core": {
       "name": "@ai-dossier/core",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.927.0",

--- a/registry/api/v1/traces/[traceId].ts
+++ b/registry/api/v1/traces/[traceId].ts
@@ -40,16 +40,33 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (!payload) return;
   const owner = payload.sub;
 
-  if (req.method === 'GET') return handleGet(res, owner, traceId, requestId);
+  if (req.method === 'GET') return handleGet(req, res, payload, traceId, requestId);
   if (req.method === 'PATCH') return handlePatch(req, res, owner, traceId, requestId);
   if (req.method === 'DELETE') return handleDelete(res, owner, traceId, requestId);
 
   return methodNotAllowed(req, res, 'GET', 'PATCH', 'DELETE');
 }
 
-async function handleGet(res: VercelResponse, owner: string, traceId: string, requestId: string) {
+async function handleGet(
+  req: VercelRequest,
+  res: VercelResponse,
+  payload: { sub: string; orgs: string[] },
+  traceId: string,
+  requestId: string
+) {
+  const org = pickOne(req.query.org);
+  if (org && !payload.orgs.includes(org)) {
+    return jsonError(
+      res,
+      HTTP_STATUS.FORBIDDEN,
+      'FORBIDDEN',
+      `You are not a member of org '${org}'`,
+      requestId
+    );
+  }
+
   try {
-    const trace = await getTrace(owner, traceId);
+    const trace = await getTrace(payload.sub, traceId, { org });
     if (!trace) return notFound(res, 'NOT_FOUND', 'Trace not found', requestId);
     return res.status(HTTP_STATUS.OK).json(trace);
   } catch (err) {
@@ -59,7 +76,7 @@ async function handleGet(res: VercelResponse, owner: string, traceId: string, re
       code: 'UPSTREAM_ERROR',
       message: 'Failed to get trace',
       requestId,
-      context: { owner, traceId },
+      context: { owner: payload.sub, traceId },
     });
   }
 }

--- a/registry/api/v1/traces/[traceId]/steps.ts
+++ b/registry/api/v1/traces/[traceId]/steps.ts
@@ -34,7 +34,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const owner = payload.sub;
 
   if (req.method === 'POST') return handleAppend(req, res, owner, traceId, requestId);
-  if (req.method === 'GET') return handleList(res, owner, traceId, requestId);
+  if (req.method === 'GET') return handleList(req, res, payload, traceId, requestId);
 
   return methodNotAllowed(req, res, 'GET', 'POST');
 }
@@ -84,9 +84,26 @@ async function handleAppend(
   }
 }
 
-async function handleList(res: VercelResponse, owner: string, traceId: string, requestId: string) {
+async function handleList(
+  req: VercelRequest,
+  res: VercelResponse,
+  payload: { sub: string; orgs: string[] },
+  traceId: string,
+  requestId: string
+) {
+  const org = pickOne(req.query.org);
+  if (org && !payload.orgs.includes(org)) {
+    return jsonError(
+      res,
+      HTTP_STATUS.FORBIDDEN,
+      'FORBIDDEN',
+      `You are not a member of org '${org}'`,
+      requestId
+    );
+  }
+
   try {
-    const steps = await listSteps(owner, traceId);
+    const steps = await listSteps(payload.sub, traceId, { org });
     if (steps === null) return notFound(res, 'NOT_FOUND', 'Trace not found', requestId);
     return res.status(HTTP_STATUS.OK).json({ trace_id: traceId, steps });
   } catch (err) {
@@ -96,7 +113,7 @@ async function handleList(res: VercelResponse, owner: string, traceId: string, r
       code: 'UPSTREAM_ERROR',
       message: 'Failed to list steps',
       requestId,
-      context: { owner, traceId },
+      context: { owner: payload.sub, traceId },
     });
   }
 }

--- a/registry/api/v1/traces/index.ts
+++ b/registry/api/v1/traces/index.ts
@@ -19,7 +19,7 @@ import {
   type TraceStatus,
   VALID_STATUSES,
 } from '../../../lib/traces';
-import type { VercelRequest, VercelResponse } from '../../../lib/types';
+import type { JwtPayload, VercelRequest, VercelResponse } from '../../../lib/types';
 
 const log = createLogger('traces/index');
 
@@ -33,10 +33,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const payload = await authenticateRequest(req, res);
   if (!payload) return;
-  const owner = payload.sub;
 
-  if (req.method === 'GET') return handleList(req, res, owner, requestId);
-  if (req.method === 'POST') return handleCreate(req, res, owner, requestId);
+  if (req.method === 'GET') return handleList(req, res, payload, requestId);
+  if (req.method === 'POST') return handleCreate(req, res, payload, requestId);
 
   return methodNotAllowed(req, res, 'GET', 'POST');
 }
@@ -44,7 +43,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 async function handleList(
   req: VercelRequest,
   res: VercelResponse,
-  owner: string,
+  payload: JwtPayload,
   requestId: string
 ) {
   const q = req.query as Record<string, string | string[] | undefined>;
@@ -54,6 +53,7 @@ async function handleList(
   const to = pickOne(q.to);
   const limit = pickOne(q.limit);
   const offset = pickOne(q.offset);
+  const org = pickOne(q.org);
 
   if (status && !VALID_STATUSES.includes(status as TraceStatus)) {
     return badRequest(
@@ -64,14 +64,25 @@ async function handleList(
     );
   }
 
+  if (org && !payload.orgs.includes(org)) {
+    return jsonError(
+      res,
+      HTTP_STATUS.FORBIDDEN,
+      'FORBIDDEN',
+      `You are not a member of org '${org}'`,
+      requestId
+    );
+  }
+
   try {
-    const result = await listTraces(owner, {
+    const result = await listTraces(payload.sub, {
       dossier,
       status: status as TraceStatus | undefined,
       from,
       to,
       limit,
       offset,
+      org,
     });
     const nextOffset = result.offset + result.limit;
     const hasMore = nextOffset < result.total;
@@ -150,9 +161,10 @@ export function validateCreatePayload(body: unknown): CreateValidationResult {
 async function handleCreate(
   req: VercelRequest,
   res: VercelResponse,
-  owner: string,
+  payload: JwtPayload,
   requestId: string
 ) {
+  const owner = payload.sub;
   const contentLength = Number(req.headers['content-length'] || 0);
   if (contentLength > MAX_CONTENT_SIZE) {
     return jsonError(
@@ -170,7 +182,7 @@ async function handleCreate(
   }
 
   try {
-    const result = await createTrace(owner, validated.data);
+    const result = await createTrace(owner, payload.orgs, validated.data);
     log.info('Trace created', { requestId, owner, traceId: result.traceId });
     return res.status(HTTP_STATUS.CREATED).json({
       trace_id: result.traceId,

--- a/registry/lib/traces.ts
+++ b/registry/lib/traces.ts
@@ -1,5 +1,12 @@
-// Trace query helpers. Every function is owner-scoped: callers MUST pass the
-// JWT subject as `owner` and never read rows where owner != JWT subject.
+// Trace query helpers.
+//
+// **Writes** (create/update/delete/appendStep) are owner-scoped: callers MUST
+// pass the JWT subject as `owner` and the row must match it.
+//
+// **Reads** (get/list/listSteps) accept an optional `org` argument. When set,
+// the lookup matches any trace whose `orgs` array contains that org instead
+// of matching `owner`. Handlers MUST verify the requested org is in the
+// caller's JWT `orgs` claim before passing it through.
 //
 // The full trace blob (conforming to the Dossier execution trace schema
 // authored on the schema-implementation branch) lives in traces.data (JSONB).
@@ -44,6 +51,21 @@ export interface TraceListFilters {
   to?: string | null;
   limit?: string | number;
   offset?: string | number;
+  /**
+   * If set, query traces from any owner whose `orgs` array contains this org
+   * instead of querying by owner. Callers MUST verify the value is present in
+   * the caller's JWT `orgs` claim before passing it through.
+   */
+  org?: string | null;
+}
+
+export interface ReadScope {
+  /**
+   * Either an org name (read traces from any owner in this org) or undefined
+   * (default: read traces owned by `owner`). Handlers MUST verify the org is
+   * in the caller's JWT `orgs` claim before passing it through.
+   */
+  org?: string;
 }
 
 export interface TraceListRow {
@@ -64,17 +86,23 @@ export interface CreateResult {
   createdAt: Date | string;
 }
 
-export async function createTrace(owner: string, trace: TraceInput): Promise<CreateResult> {
+export async function createTrace(
+  owner: string,
+  orgs: string[],
+  trace: TraceInput
+): Promise<CreateResult> {
   const startedAt = new Date(trace.started_at);
   const completedAt = trace.completed_at ? new Date(trace.completed_at) : null;
+  // Empty array becomes NULL so it's clearly distinguishable from "no orgs set".
+  const orgsValue = orgs.length > 0 ? orgs : null;
   const rows = (await sql`
     INSERT INTO traces (
-      trace_id, owner,
+      trace_id, owner, orgs,
       dossier_title, dossier_version, agent_name, agent_version,
       started_at, completed_at, duration_ms, status,
       data
     ) VALUES (
-      ${trace.trace_id}, ${owner},
+      ${trace.trace_id}, ${owner}, ${orgsValue},
       ${trace.dossier.title}, ${trace.dossier.version},
       ${trace.agent?.name ?? null}, ${trace.agent?.version ?? null},
       ${startedAt}, ${completedAt}, ${trace.duration_ms ?? null}, ${trace.status},
@@ -88,12 +116,18 @@ export async function createTrace(owner: string, trace: TraceInput): Promise<Cre
 
 export async function getTrace(
   owner: string,
-  traceId: string
+  traceId: string,
+  scope: ReadScope = {}
 ): Promise<Record<string, unknown> | null> {
+  const orgScope = scope.org ?? null;
   const traces = (await sql`
     SELECT id, data
     FROM traces
-    WHERE trace_id = ${traceId} AND owner = ${owner}
+    WHERE trace_id = ${traceId}
+      AND (
+        (${orgScope}::text IS NULL AND owner = ${owner})
+        OR (${orgScope}::text IS NOT NULL AND ${orgScope} = ANY(orgs))
+      )
     LIMIT 1
   `) as Array<{ id: string; data: Record<string, unknown> }>;
   if (traces.length === 0) return null;
@@ -120,7 +154,7 @@ export async function listTraces(
   owner: string,
   filters: TraceListFilters = {}
 ): Promise<ListResult> {
-  const { dossier = null, status = null, from = null, to = null } = filters;
+  const { dossier = null, status = null, from = null, to = null, org = null } = filters;
   const limit = Math.min(Number.parseInt(String(filters.limit ?? '50'), 10) || 50, 200);
   const offset = Number.parseInt(String(filters.offset ?? '0'), 10) || 0;
 
@@ -131,7 +165,11 @@ export async function listTraces(
     SELECT trace_id, dossier_title, dossier_version, agent_name, agent_version,
            started_at, completed_at, status, duration_ms
     FROM traces
-    WHERE owner = ${owner}
+    WHERE
+      (
+        (${org}::text IS NULL AND owner = ${owner})
+        OR (${org}::text IS NOT NULL AND ${org} = ANY(orgs))
+      )
       AND (${dossier}::text  IS NULL OR dossier_title = ${dossier})
       AND (${status}::text   IS NULL OR status        = ${status})
       AND (${fromDate}::timestamptz IS NULL OR started_at >= ${fromDate})
@@ -143,7 +181,11 @@ export async function listTraces(
   const countRows = (await sql`
     SELECT COUNT(*)::int AS count
     FROM traces
-    WHERE owner = ${owner}
+    WHERE
+      (
+        (${org}::text IS NULL AND owner = ${owner})
+        OR (${org}::text IS NOT NULL AND ${org} = ANY(orgs))
+      )
       AND (${dossier}::text  IS NULL OR dossier_title = ${dossier})
       AND (${status}::text   IS NULL OR status        = ${status})
       AND (${fromDate}::timestamptz IS NULL OR started_at >= ${fromDate})
@@ -255,15 +297,21 @@ export async function appendStep(
 }
 
 /**
- * @returns null if trace not found / not owned by `owner`
+ * @returns null if trace not found / not visible under the given scope
  */
 export async function listSteps(
   owner: string,
-  traceId: string
+  traceId: string,
+  scope: ReadScope = {}
 ): Promise<Record<string, unknown>[] | null> {
+  const orgScope = scope.org ?? null;
   const traces = (await sql`
     SELECT id FROM traces
-    WHERE trace_id = ${traceId} AND owner = ${owner}
+    WHERE trace_id = ${traceId}
+      AND (
+        (${orgScope}::text IS NULL AND owner = ${owner})
+        OR (${orgScope}::text IS NOT NULL AND ${orgScope} = ANY(orgs))
+      )
     LIMIT 1
   `) as Array<{ id: string }>;
   if (traces.length === 0) return null;

--- a/registry/migrations/002_traces_orgs.sql
+++ b/registry/migrations/002_traces_orgs.sql
@@ -1,0 +1,8 @@
+-- Team visibility: store the user's org memberships at write time so
+-- other members of the same orgs can read the trace. Reads stay opt-in
+-- (`?org=<name>`); writes/updates/deletes remain owner-scoped only.
+
+ALTER TABLE traces ADD COLUMN IF NOT EXISTS orgs TEXT[];
+
+CREATE INDEX IF NOT EXISTS traces_orgs_idx
+  ON traces USING GIN (orgs);

--- a/registry/tests/traces.test.ts
+++ b/registry/tests/traces.test.ts
@@ -177,6 +177,7 @@ describe('POST /api/v1/traces', () => {
     });
     expect(traces.createTrace).toHaveBeenCalledWith(
       OWNER,
+      expect.any(Array),
       expect.objectContaining({ trace_id: VALID_UUID })
     );
   });
@@ -277,7 +278,7 @@ describe('GET /api/v1/traces/:traceId', () => {
     );
     expect(getStatus()).toBe(404);
     expect(getBody()).toMatchObject({ error: { code: 'NOT_FOUND' } });
-    expect(traces.getTrace).toHaveBeenCalledWith(OWNER, OTHER_UUID);
+    expect(traces.getTrace).toHaveBeenCalledWith(OWNER, OTHER_UUID, { org: undefined });
   });
 
   it('returns the full trace on happy path', async () => {
@@ -505,5 +506,147 @@ describe('validateCreatePayload (pure)', () => {
     const { validateCreatePayload } = await import('../api/v1/traces/index');
     const result = validateCreatePayload(null);
     expect(result.ok).toBe(false);
+  });
+});
+
+// ---- Org-scoped reads ----
+
+describe('Org-scoped reads', () => {
+  async function withOrgs<T>(orgs: string[], fn: () => Promise<T>): Promise<T> {
+    const jwt = await import('jsonwebtoken');
+    const original = jwt.default.verify;
+    (jwt.default.verify as unknown) = () => ({ sub: OWNER, email: null, orgs });
+    try {
+      return await fn();
+    } finally {
+      (jwt.default.verify as unknown) = original;
+    }
+  }
+
+  it('createTrace receives JWT orgs and writes them through', async () => {
+    await withOrgs(['imboard-ai', 'other-org'], async () => {
+      (traces.createTrace as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        id: '1',
+        traceId: VALID_UUID,
+        createdAt: new Date('2026-05-13T10:00:01Z'),
+      });
+      const { res, getStatus } = createMockRes();
+      await tracesHandler(
+        createMockReq({
+          method: 'POST',
+          body: {
+            trace_id: VALID_UUID,
+            dossier: { title: 'X', version: '1.0.0' },
+            started_at: '2026-05-13T10:00:00Z',
+            status: 'running',
+          },
+          headers: authedHeaders(),
+        }) as never,
+        res as never
+      );
+      expect(getStatus()).toBe(201);
+      expect(traces.createTrace).toHaveBeenCalledWith(
+        OWNER,
+        ['imboard-ai', 'other-org'],
+        expect.objectContaining({ trace_id: VALID_UUID })
+      );
+    });
+  });
+
+  it('GET /api/v1/traces?org=imboard-ai threads the org through listTraces', async () => {
+    await withOrgs(['imboard-ai'], async () => {
+      (traces.listTraces as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        rows: [],
+        total: 0,
+        limit: 50,
+        offset: 0,
+      });
+      const { res, getStatus } = createMockRes();
+      await tracesHandler(
+        createMockReq({
+          method: 'GET',
+          query: { org: 'imboard-ai' },
+          headers: authedHeaders(),
+        }) as never,
+        res as never
+      );
+      expect(getStatus()).toBe(200);
+      expect(traces.listTraces).toHaveBeenCalledWith(
+        OWNER,
+        expect.objectContaining({ org: 'imboard-ai' })
+      );
+    });
+  });
+
+  it('GET /api/v1/traces?org=X returns 403 when X is not in JWT orgs', async () => {
+    await withOrgs(['imboard-ai'], async () => {
+      const { res, getStatus, getBody } = createMockRes();
+      await tracesHandler(
+        createMockReq({
+          method: 'GET',
+          query: { org: 'other-org' },
+          headers: authedHeaders(),
+        }) as never,
+        res as never
+      );
+      expect(getStatus()).toBe(403);
+      expect(getBody()).toMatchObject({ error: { code: 'FORBIDDEN' } });
+      expect(traces.listTraces).not.toHaveBeenCalled();
+    });
+  });
+
+  it('GET /api/v1/traces/:id?org=imboard-ai threads the org through getTrace', async () => {
+    await withOrgs(['imboard-ai'], async () => {
+      (traces.getTrace as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        trace_id: VALID_UUID,
+        status: 'success',
+        steps: [],
+      });
+      const { res, getStatus } = createMockRes();
+      await traceIdHandler(
+        createMockReq({
+          method: 'GET',
+          query: { traceId: VALID_UUID, org: 'imboard-ai' },
+          headers: authedHeaders(),
+        }) as never,
+        res as never
+      );
+      expect(getStatus()).toBe(200);
+      expect(traces.getTrace).toHaveBeenCalledWith(OWNER, VALID_UUID, { org: 'imboard-ai' });
+    });
+  });
+
+  it('GET /api/v1/traces/:id?org=X returns 403 when X is not in JWT orgs', async () => {
+    await withOrgs(['imboard-ai'], async () => {
+      const { res, getStatus, getBody } = createMockRes();
+      await traceIdHandler(
+        createMockReq({
+          method: 'GET',
+          query: { traceId: VALID_UUID, org: 'other-org' },
+          headers: authedHeaders(),
+        }) as never,
+        res as never
+      );
+      expect(getStatus()).toBe(403);
+      expect(getBody()).toMatchObject({ error: { code: 'FORBIDDEN' } });
+      expect(traces.getTrace).not.toHaveBeenCalled();
+    });
+  });
+
+  it('GET /api/v1/traces/:id/steps?org=X returns 403 when X is not in JWT orgs', async () => {
+    await withOrgs(['imboard-ai'], async () => {
+      const { res, getStatus, getBody } = createMockRes();
+      await stepsHandler(
+        createMockReq({
+          method: 'GET',
+          query: { traceId: VALID_UUID, org: 'other-org' },
+          headers: authedHeaders(),
+        }) as never,
+        res as never
+      );
+      expect(getStatus()).toBe(403);
+      expect(getBody()).toMatchObject({ error: { code: 'FORBIDDEN' } });
+      expect(traces.listSteps).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Builds the team observability layer on top of the trace API (#389) and recorder (#391). After this lands, two engineers in the same org can each `ai-dossier traces list --org imboard-ai` and see each other's runs.

Three slices, one PR:

| Commit | What |
|---|---|
| `6faf801` feat(mcp) | `agent.host = os.hostname()` recorded per trace. Distinguishes "two projects from two servers" when the same user runs the same dossier from different machines. |
| `26958e7` feat(registry) | `orgs TEXT[]` column + migration 002. Writes populate from `jwt.orgs`; reads accept `?org=<name>` with membership check (403 if not a member). |
| `f22fed3` feat(cli) | `ai-dossier traces list` / `traces show` commands. Defaults to own traces; `--org` opts in to team visibility. Pretty table + `--json`. |

## Design choices (locked in via the design discussion)

- **Org write**: store the full `jwt.orgs` array (not just primary) so multi-org users' traces are visible to every org they're in
- **List default**: own traces only — `--org` is opt-in, no surprise expansion
- **Recorder API**: unchanged — org is derived server-side from JWT, not passed by the client
- **Writes/updates/deletes**: stay strictly owner-scoped — no team-write surface

## Auth model after this PR

| Operation | Visibility |
|---|---|
| Create / update / delete / append-step | Owner only (`owner = jwt.sub`) |
| GET single / list / list-steps | Owner OR any org member if `?org=X` and `X ∈ jwt.orgs` |

Existing rows (pre-migration) keep `orgs = NULL` and remain owner-only readable.

## CLI surface

```
ai-dossier traces list [--status running|success|failed|cancelled]
                        [--dossier NAME] [--from DATE] [--to DATE]
                        [--org NAME] [--limit N] [--offset N] [--json]

ai-dossier traces show <trace_id> [--org NAME] [--json]
```

Sample table output:
```
  STATUS  DOSSIER                      STARTED           DURATION  TRACE_ID
  ------  ---------------------------  ----------------  --------  --------
  OK      full-cycle-issue@1.0.0       2026-05-13 14:32  45.2s     a1b2c3d4
  FAIL    full-cycle-issue@1.0.0       2026-05-13 14:18  3.1s      99887766
```

## Tests

- **mcp-server (130 → still 130)**: existing recorder test updated to assert `agent.host` is a non-empty string
- **registry (183 → 189, +6)**: new `Org-scoped reads` describe block covers create-with-orgs, list/get with `?org=` happy path, and 403 paths for list/get/steps when requested org isn't in JWT
- **cli (451 → 456, +5)**: new `listTraces` + `getTrace` describe blocks on RegistryClient

## Migration

`registry/migrations/002_traces_orgs.sql` — idempotent (`IF NOT EXISTS`). Adds the column + GIN index. Run via `registry/scripts/migrate.sh` after merge, before the next prod deploy serves org-scoped queries.

## Out of scope

- Cross-org aggregation (single-org reads only)
- Web UI / dashboard
- Metrics rollups (p50, failure rate over time)
- `DOSSIER_TRACE_ORG` env override for clients (we have the alt design but decided server-derivation is cleaner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)