### PR TITLE
feat: trace-config resolver + setup-tracing dossier (eat-our-own-dog-food UX)

### DIFF
--- a/examples/setup/setup-tracing.ds.md
+++ b/examples/setup/setup-tracing.ds.md
@@ -1,0 +1,171 @@
+---dossier
+{
+  "dossier_schema_version": "1.0.0",
+  "title": "Setup Tracing",
+  "version": "1.0.0",
+  "protocol_version": "1.0",
+  "status": "Draft",
+  "last_updated": "2026-05-13",
+  "objective": "Turn on execution tracing for dossier runs by writing a tracing block to the user (or project) Dossier config. After this dossier runs, `mcp-server` will start emitting traces to the configured registry on every journey, with no further setup required.",
+  "category": [
+    "setup",
+    "monitoring"
+  ],
+  "tags": [
+    "tracing",
+    "configuration",
+    "mcp",
+    "observability"
+  ],
+  "tools_required": [],
+  "risk_level": "medium",
+  "requires_approval": false,
+  "risk_factors": [
+    "modifies_files"
+  ],
+  "destructive_operations": [
+    "Writes ~/.dossier/config.json (preserves existing keys) or .dossierrc.json in the current project directory"
+  ],
+  "estimated_duration": {
+    "min_minutes": 1,
+    "max_minutes": 3
+  },
+  "inputs": {
+    "required": [],
+    "optional": [
+      {
+        "name": "url",
+        "description": "Custom logger URL. Omit to use the user's logged-in registry (the default behavior).",
+        "type": "string",
+        "default": "",
+        "example": "https://obs.imboard.corp"
+      },
+      {
+        "name": "scope",
+        "description": "Where to write the tracing block. 'user' writes ~/.dossier/config.json (default, applies to all projects). 'project' writes .dossierrc.json in the current directory (applies only to this project, can be checked into git).",
+        "type": "string",
+        "default": "user",
+        "example": "user"
+      }
+    ]
+  },
+  "outputs": {
+    "files": [
+      {
+        "path": "~/.dossier/config.json",
+        "description": "User config with tracing.enabled = true (when scope=user). Other keys preserved."
+      },
+      {
+        "path": ".dossierrc.json",
+        "description": "Project config with tracing block (when scope=project, in the current project directory)."
+      }
+    ]
+  },
+  "checksum": {
+    "algorithm": "sha256",
+    "hash": "bd7a1985c7f19d3591eff31f1e5f89746627333500a13509e872829741dd3903"
+  }
+}
+---
+
+# Setup Tracing
+
+This dossier configures execution tracing for your dossier runs. After it
+finishes, every journey that the dossier MCP server orchestrates will emit
+a trace to the configured registry, visible via `ai-dossier traces list`.
+
+The dossier deliberately handles the **environment-aware bits** — which
+config file to touch, which token to reuse — so the platform can't be
+locked to a single Claude / MCP-host shape.
+
+## What it does, briefly
+
+1. Verifies the user is logged in (`~/.dossier/credentials.json`).
+2. Picks a target file based on `scope` (user-level by default).
+3. Reads the existing JSON (preserving every other key).
+4. Sets `tracing.enabled = true` and `tracing.url` (if a custom URL was
+   given).
+5. Writes the file back with `mode: 0o600`.
+6. Tells the user to restart their MCP host so the new env takes effect.
+
+## Prerequisites
+
+- `~/.dossier/credentials.json` exists and has a non-expired `public`
+  entry (or the registry the user wants traces to go to). If not, instruct
+  the user to run `ai-dossier login` first and stop.
+- For `scope=project`, the current working directory should be the project
+  root. Confirm with the user before writing if cwd doesn't look like a
+  project.
+
+## Step-by-step
+
+**Step 1: Verify login.**
+
+Read `~/.dossier/credentials.json`. If it doesn't exist, the file is
+empty, or `expires_at` is in the past for the relevant registry entry,
+stop and report:
+
+> ❌ Not logged in (or token expired). Run `ai-dossier login` first.
+
+**Step 2: Resolve target path.**
+
+- If `scope` input is `"project"` (or the user explicitly asks for project
+  scope), the target is `<cwd>/.dossierrc.json`.
+- Otherwise, the target is `~/.dossier/config.json`.
+
+Print the resolved path back to the user before continuing.
+
+**Step 3: Read existing file (if any).**
+
+If the target file exists, read it and parse as JSON. If parsing fails,
+stop and ask the user to fix or remove the file manually — never
+overwrite a file you can't parse.
+
+If the target file does not exist, start from an empty object `{}`.
+
+**Step 4: Merge the tracing block.**
+
+Set `tracing.enabled` to `true`. If the optional `url` input was given,
+set `tracing.url` to that value. Otherwise leave `tracing.url` absent so
+the resolver falls back to the logged-in registry's URL.
+
+Preserve every other key in the file as-is (do NOT touch `defaultLlm`,
+`registries`, `theme`, etc.).
+
+**Step 5: Write the file.**
+
+Write the merged JSON back with `mode: 0o600` (user-readable only). The
+existing config directory `~/.dossier/` is already mode `0o700` so this
+just inherits the same security posture.
+
+**Step 6: Verify by re-reading.**
+
+Read the file back, parse it, confirm `tracing.enabled === true`, print
+the effective tracing block to the user.
+
+**Step 7: Tell the user what to do next.**
+
+> ✅ Tracing enabled. Restart your MCP host (Claude Desktop / Code) so
+> the dossier MCP server picks up the new config. After your next
+> journey runs, `ai-dossier traces list` will show it.
+
+## Validation
+
+After step 6, the success condition is a single re-read of the target
+file showing `tracing.enabled === true`. If any of the file operations
+errored (permission denied, disk full), stop and report the underlying
+error verbatim — don't try to recover.
+
+## Out of scope
+
+- This dossier does NOT write a token into the config file. The token is
+  always resolved from `~/.dossier/credentials.json` (via the user's
+  existing `ai-dossier login`) or `DOSSIER_TRACE_TOKEN` env var at
+  runtime.
+- This dossier does NOT modify the user's MCP host config (Claude
+  Desktop / Code settings). The resolver inside `mcp-server` reads the
+  Dossier config directly, so no host-side edits are needed.
+- For self-hosted org loggers that need a different auth scheme (not the
+  registry JWT), fork this dossier and update step 4 to also set
+  `tracing.token_env_var` or similar — but be careful not to write secrets
+  to the file directly.

--- a/mcp-server/src/orchestration/recorder.ts
+++ b/mcp-server/src/orchestration/recorder.ts
@@ -1,15 +1,26 @@
-// Singleton TraceRecorder for the MCP server. Lazily constructed from
-// env vars (DOSSIER_TRACE_URL, DOSSIER_TRACE_TOKEN). Tests can inject a
-// mock via setRecorder() to assert calls without hitting the network.
+// Singleton TraceRecorder for the MCP server. Lazily constructed from the
+// resolved trace config (env > project > user > defaults — see
+// @ai-dossier/core/trace-config). Tests can inject a mock via setRecorder().
 
-import { createTraceRecorder, type TraceRecorder, type TraceStatus } from '@ai-dossier/core';
+import {
+  createTraceRecorder,
+  resolveTraceConfig,
+  type TraceRecorder,
+  type TraceStatus,
+} from '@ai-dossier/core';
 import type { JourneySession } from './session';
 
 let recorder: TraceRecorder | null = null;
 
 export function getRecorder(): TraceRecorder {
   if (!recorder) {
-    recorder = createTraceRecorder();
+    const config = resolveTraceConfig();
+    if (config.enabled && config.url && config.token) {
+      recorder = createTraceRecorder({ url: config.url, token: config.token });
+    } else {
+      // Returns a disabled (no-op) recorder when no config is in effect.
+      recorder = createTraceRecorder({ url: '', token: '' });
+    }
   }
   return recorder;
 }

--- a/mcp-server/src/tools/__tests__/journey.test.ts
+++ b/mcp-server/src/tools/__tests__/journey.test.ts
@@ -22,6 +22,12 @@ vi.mock('@ai-dossier/core', () => ({
     appendStep: vi.fn().mockResolvedValue(undefined),
     complete: vi.fn().mockResolvedValue(undefined),
   })),
+  resolveTraceConfig: vi.fn(() => ({
+    enabled: false,
+    url: null,
+    token: null,
+    sources: { enabled: { layer: 'default' }, url: null, token: null },
+  })),
 }));
 
 // Mock logger

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,10 +27,10 @@
     },
     "cli": {
       "name": "@ai-dossier/cli",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@ai-dossier/core": "^1.3.1",
+        "@ai-dossier/core": "^1.3.2",
         "commander": "^12.1.0"
       },
       "bin": {
@@ -48,7 +48,7 @@
     },
     "mcp-server": {
       "name": "@ai-dossier/mcp-server",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ai-dossier/core": "^1.2.0",
@@ -6611,7 +6611,7 @@
     },
     "packages/core": {
       "name": "@ai-dossier/core",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.927.0",

--- a/packages/core/src/__tests__/trace-config.test.ts
+++ b/packages/core/src/__tests__/trace-config.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest';
+import { resolveTraceConfig } from '../trace-config';
+
+/** Build an injectable readFile from a path→content map (everything else returns null). */
+function fakeFs(files: Record<string, string>): (path: string) => string | null {
+  return (path) => files[path] ?? null;
+}
+
+const HOME = '/h';
+const USER_CONFIG = '/h/.dossier/config.json';
+const USER_CREDS = '/h/.dossier/credentials.json';
+const PROJECT_RC = '/work/proj/.dossierrc.json';
+
+describe('resolveTraceConfig', () => {
+  it('returns disabled with default URL when nothing is configured', () => {
+    const result = resolveTraceConfig({
+      home: HOME,
+      cwd: '/work/proj',
+      env: {},
+      readFile: fakeFs({}),
+    });
+    expect(result.enabled).toBe(false);
+    expect(result.url).toBe('https://dossier-registry.vercel.app');
+    expect(result.token).toBeNull();
+    expect(result.sources.enabled.layer).toBe('default');
+    expect(result.sources.url?.layer).toBe('default');
+    expect(result.sources.token).toBeNull();
+  });
+
+  it('reads enabled + token from credentials when user config opts in', () => {
+    const result = resolveTraceConfig({
+      home: HOME,
+      cwd: '/tmp',
+      env: {},
+      readFile: fakeFs({
+        [USER_CONFIG]: JSON.stringify({ tracing: { enabled: true } }),
+        [USER_CREDS]: JSON.stringify({
+          public: { token: 'creds-token', expires_at: '2099-01-01' },
+        }),
+      }),
+    });
+    expect(result.enabled).toBe(true);
+    expect(result.url).toBe('https://dossier-registry.vercel.app');
+    expect(result.token).toBe('creds-token');
+    expect(result.sources.enabled.layer).toBe('user');
+    expect(result.sources.token?.layer).toBe('credentials');
+  });
+
+  it('env vars take precedence over project + user', () => {
+    const result = resolveTraceConfig({
+      home: HOME,
+      cwd: '/work/proj',
+      env: {
+        DOSSIER_TRACE_ENABLED: 'true',
+        DOSSIER_TRACE_URL: 'https://env.example',
+        DOSSIER_TRACE_TOKEN: 'env-token',
+      },
+      readFile: fakeFs({
+        [PROJECT_RC]: JSON.stringify({ tracing: { enabled: false, url: 'https://proj.test' } }),
+        [USER_CONFIG]: JSON.stringify({ tracing: { enabled: false, url: 'https://user.test' } }),
+      }),
+    });
+    expect(result.enabled).toBe(true);
+    expect(result.url).toBe('https://env.example');
+    expect(result.token).toBe('env-token');
+    expect(result.sources.enabled.layer).toBe('env');
+    expect(result.sources.url?.layer).toBe('env');
+    expect(result.sources.token?.layer).toBe('env');
+  });
+
+  it('DOSSIER_TRACE_ENABLED=false overrides user config that says true', () => {
+    const result = resolveTraceConfig({
+      home: HOME,
+      cwd: '/tmp',
+      env: { DOSSIER_TRACE_ENABLED: 'false' },
+      readFile: fakeFs({
+        [USER_CONFIG]: JSON.stringify({ tracing: { enabled: true } }),
+        [USER_CREDS]: JSON.stringify({ public: { token: 't' } }),
+      }),
+    });
+    expect(result.enabled).toBe(false);
+    expect(result.sources.enabled.layer).toBe('env');
+  });
+
+  it('project config overrides user config but not env', () => {
+    const result = resolveTraceConfig({
+      home: HOME,
+      cwd: '/work/proj',
+      env: {},
+      readFile: fakeFs({
+        [PROJECT_RC]: JSON.stringify({ tracing: { enabled: true, url: 'https://team.test' } }),
+        [USER_CONFIG]: JSON.stringify({ tracing: { enabled: false, url: 'https://my.test' } }),
+        [USER_CREDS]: JSON.stringify({ public: { token: 't' } }),
+      }),
+    });
+    expect(result.enabled).toBe(true);
+    expect(result.url).toBe('https://team.test');
+    expect(result.sources.enabled.layer).toBe('project');
+    expect(result.sources.url?.layer).toBe('project');
+  });
+
+  it('walks up from cwd to find .dossierrc.json', () => {
+    const result = resolveTraceConfig({
+      home: HOME,
+      cwd: '/work/proj/deep/nested/dir',
+      env: {},
+      readFile: fakeFs({
+        [PROJECT_RC]: JSON.stringify({ tracing: { enabled: true, url: 'https://walked.test' } }),
+        [USER_CREDS]: JSON.stringify({ public: { token: 't' } }),
+      }),
+    });
+    expect(result.enabled).toBe(true);
+    expect(result.url).toBe('https://walked.test');
+    expect(result.sources.url?.path).toBe(PROJECT_RC);
+  });
+
+  it('matches credentials by registry URL when the user has multiple', () => {
+    const result = resolveTraceConfig({
+      home: HOME,
+      cwd: '/tmp',
+      env: {},
+      readFile: fakeFs({
+        [USER_CONFIG]: JSON.stringify({
+          tracing: { enabled: true, url: 'https://corp.example' },
+          registries: {
+            public: { url: 'https://dossier-registry.vercel.app', default: true },
+            corp: { url: 'https://corp.example' },
+          },
+        }),
+        [USER_CREDS]: JSON.stringify({
+          public: { token: 'public-token' },
+          corp: { token: 'corp-token' },
+        }),
+      }),
+    });
+    expect(result.url).toBe('https://corp.example');
+    expect(result.token).toBe('corp-token');
+  });
+
+  it('falls back to public credentials when no registry URL matches', () => {
+    const result = resolveTraceConfig({
+      home: HOME,
+      cwd: '/tmp',
+      env: {},
+      readFile: fakeFs({
+        [USER_CONFIG]: JSON.stringify({
+          tracing: { enabled: true, url: 'https://unknown.test' },
+        }),
+        [USER_CREDS]: JSON.stringify({ public: { token: 'public-token' } }),
+      }),
+    });
+    expect(result.url).toBe('https://unknown.test');
+    expect(result.token).toBe('public-token');
+  });
+
+  it('result.enabled is false when enabled flag is set but no token is resolvable', () => {
+    const result = resolveTraceConfig({
+      home: HOME,
+      cwd: '/tmp',
+      env: {},
+      readFile: fakeFs({
+        [USER_CONFIG]: JSON.stringify({ tracing: { enabled: true } }),
+        // no credentials file
+      }),
+    });
+    expect(result.enabled).toBe(false);
+    expect(result.token).toBeNull();
+    expect(result.sources.enabled.layer).toBe('user'); // the flag was on, but token resolution failed
+  });
+
+  it('uses configured default registry URL when no explicit tracing URL is set', () => {
+    const result = resolveTraceConfig({
+      home: HOME,
+      cwd: '/tmp',
+      env: {},
+      readFile: fakeFs({
+        [USER_CONFIG]: JSON.stringify({
+          tracing: { enabled: true },
+          defaultRegistry: 'corp',
+          registries: {
+            corp: { url: 'https://corp.example' },
+          },
+        }),
+        [USER_CREDS]: JSON.stringify({ corp: { token: 'corp-token' } }),
+      }),
+    });
+    expect(result.url).toBe('https://corp.example');
+    expect(result.token).toBe('corp-token');
+  });
+
+  it('handles malformed JSON gracefully (falls through to defaults)', () => {
+    const result = resolveTraceConfig({
+      home: HOME,
+      cwd: '/tmp',
+      env: {},
+      readFile: fakeFs({
+        [USER_CONFIG]: 'not-json{{{',
+        [USER_CREDS]: '{{ also broken',
+      }),
+    });
+    expect(result.enabled).toBe(false);
+    expect(result.url).toBe('https://dossier-registry.vercel.app');
+    expect(result.token).toBeNull();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -94,6 +94,14 @@ export {
   VerifierRegistry,
   VerifyResult,
 } from './signers';
+// Trace config resolver (precedence: env > project > user > defaults)
+export type {
+  ConfigLayer as TraceConfigLayer,
+  ResolvedTraceConfig,
+  TraceConfigOptions,
+  TraceConfigSource,
+} from './trace-config';
+export { resolveTraceConfig } from './trace-config';
 // Trace recorder exports (opt-in execution tracing — see registry /api/v1/traces)
 export type {
   StepInput as TraceStepInput,

--- a/packages/core/src/trace-config.ts
+++ b/packages/core/src/trace-config.ts
@@ -1,0 +1,205 @@
+// Trace config resolver.
+//
+// Resolves which URL + token the TraceRecorder should use, walking a
+// precedence stack: env > project (.dossierrc.json) > user (~/.dossier/
+// config.json) > defaults. The token can also come from the CLI
+// credentials store (~/.dossier/credentials.json) when not set elsewhere.
+//
+// Tracing is OPT-IN: the resolver returns { enabled: false } unless
+// `tracing.enabled === true` is found in env or one of the config files,
+// even if a URL and token happen to be available.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, parse } from 'node:path';
+
+const DEFAULT_TRACE_URL = 'https://dossier-registry.vercel.app';
+
+export type ConfigLayer = 'env' | 'project' | 'user' | 'credentials' | 'default';
+
+export interface TraceConfigSource {
+  layer: ConfigLayer;
+  path?: string;
+}
+
+export interface ResolvedTraceConfig {
+  enabled: boolean;
+  url: string | null;
+  token: string | null;
+  sources: {
+    enabled: TraceConfigSource;
+    url: TraceConfigSource | null;
+    token: TraceConfigSource | null;
+  };
+}
+
+export interface TraceConfigOptions {
+  /** Override CWD for project-config lookup (mostly for tests). */
+  cwd?: string;
+  /** Override $HOME for user-config lookup (mostly for tests). */
+  home?: string;
+  /** Override process.env (mostly for tests). */
+  env?: NodeJS.ProcessEnv;
+  /** File reader injection (mostly for tests). */
+  readFile?: (path: string) => string | null;
+}
+
+interface TracingBlock {
+  enabled?: boolean;
+  url?: string;
+}
+
+interface ParsedConfig {
+  tracing?: TracingBlock;
+  registries?: Record<string, { url: string; default?: boolean }>;
+  defaultRegistry?: string;
+  [key: string]: unknown;
+}
+
+interface CredentialsStore {
+  [registryName: string]: {
+    token?: string;
+    expires_at?: string;
+  };
+}
+
+/**
+ * Resolve the effective trace configuration from the precedence stack.
+ * The returned object always includes `sources` so callers can show the
+ * user which layer won (useful for diagnostic commands).
+ */
+export function resolveTraceConfig(opts: TraceConfigOptions = {}): ResolvedTraceConfig {
+  const env = opts.env ?? process.env;
+  const cwd = opts.cwd ?? process.cwd();
+  const home = opts.home ?? homedir();
+  const readFile = opts.readFile ?? defaultReadFile;
+
+  const userConfigPath = join(home, '.dossier', 'config.json');
+  const userConfig = parseJson<ParsedConfig>(readFile(userConfigPath));
+  const projectConfigPath = findProjectConfig(cwd, readFile);
+  const projectConfig = projectConfigPath
+    ? parseJson<ParsedConfig>(readFile(projectConfigPath))
+    : null;
+
+  // --- enabled ---
+  let enabled = false;
+  let enabledSource: TraceConfigSource = { layer: 'default' };
+  if (env.DOSSIER_TRACE_ENABLED != null) {
+    enabled = env.DOSSIER_TRACE_ENABLED.toLowerCase() === 'true';
+    enabledSource = { layer: 'env' };
+  } else if (projectConfig?.tracing?.enabled != null) {
+    enabled = Boolean(projectConfig.tracing.enabled);
+    enabledSource = { layer: 'project', path: projectConfigPath ?? undefined };
+  } else if (userConfig?.tracing?.enabled != null) {
+    enabled = Boolean(userConfig.tracing.enabled);
+    enabledSource = { layer: 'user', path: userConfigPath };
+  }
+
+  // --- url ---
+  let url: string | null = null;
+  let urlSource: TraceConfigSource | null = null;
+  if (env.DOSSIER_TRACE_URL) {
+    url = env.DOSSIER_TRACE_URL;
+    urlSource = { layer: 'env' };
+  } else if (projectConfig?.tracing?.url) {
+    url = projectConfig.tracing.url;
+    urlSource = { layer: 'project', path: projectConfigPath ?? undefined };
+  } else if (userConfig?.tracing?.url) {
+    url = userConfig.tracing.url;
+    urlSource = { layer: 'user', path: userConfigPath };
+  } else {
+    url = pickDefaultRegistryUrl(userConfig) ?? DEFAULT_TRACE_URL;
+    urlSource = { layer: 'default' };
+  }
+
+  // --- token ---
+  let token: string | null = null;
+  let tokenSource: TraceConfigSource | null = null;
+  if (env.DOSSIER_TRACE_TOKEN) {
+    token = env.DOSSIER_TRACE_TOKEN;
+    tokenSource = { layer: 'env' };
+  } else {
+    const credsPath = join(home, '.dossier', 'credentials.json');
+    const creds = parseJson<CredentialsStore>(readFile(credsPath));
+    if (creds) {
+      // Prefer credentials whose registry URL matches the resolved tracing URL.
+      const matched = findMatchingCredentials(creds, userConfig, url);
+      if (matched?.token) {
+        token = matched.token;
+        tokenSource = { layer: 'credentials', path: credsPath };
+      } else if (creds.public?.token) {
+        token = creds.public.token;
+        tokenSource = { layer: 'credentials', path: credsPath };
+      }
+    }
+  }
+
+  return {
+    enabled: enabled && Boolean(url) && Boolean(token),
+    url,
+    token,
+    sources: { enabled: enabledSource, url: urlSource, token: tokenSource },
+  };
+}
+
+function defaultReadFile(path: string): string | null {
+  try {
+    return existsSync(path) ? readFileSync(path, 'utf8') : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseJson<T>(contents: string | null): T | null {
+  if (!contents) return null;
+  try {
+    return JSON.parse(contents) as T;
+  } catch {
+    return null;
+  }
+}
+
+function findProjectConfig(
+  startDir: string,
+  readFile: (path: string) => string | null
+): string | null {
+  let dir = startDir;
+  const root = parse(dir).root;
+  while (dir !== root) {
+    const rcFile = join(dir, '.dossierrc.json');
+    if (readFile(rcFile) != null) return rcFile;
+    dir = dirname(dir);
+  }
+  return null;
+}
+
+function pickDefaultRegistryUrl(userConfig: ParsedConfig | null): string | null {
+  if (!userConfig?.registries) return null;
+  const defaultName = userConfig.defaultRegistry;
+  if (defaultName && userConfig.registries[defaultName]) {
+    return userConfig.registries[defaultName].url;
+  }
+  const flagged = Object.values(userConfig.registries).find((r) => r.default);
+  if (flagged) return flagged.url;
+  const first = Object.values(userConfig.registries)[0];
+  return first?.url ?? null;
+}
+
+function findMatchingCredentials(
+  creds: CredentialsStore,
+  userConfig: ParsedConfig | null,
+  resolvedUrl: string | null
+): { token?: string } | null {
+  if (!resolvedUrl || !userConfig?.registries) return null;
+  const target = normalizeUrl(resolvedUrl);
+  for (const [name, entry] of Object.entries(userConfig.registries)) {
+    if (normalizeUrl(entry.url) === target && creds[name]) {
+      return creds[name];
+    }
+  }
+  return null;
+}
+
+function normalizeUrl(u: string): string {
+  return u.replace(/\/+$/, '').toLowerCase();
+}


### PR DESCRIPTION
## Summary

Closes the "how does a user turn on tracing without editing JSON files" gap — and does it the platform's own way (a dossier handles the environment-aware setup, instead of baking that logic into the CLI).

Three slices:

| Commit | What |
|---|---|
| `d0ba1ec` feat(core) | `resolveTraceConfig()` with precedence env > `.dossierrc.json` > `~/.dossier/config.json` > defaults. Token falls back to `~/.dossier/credentials.json` (matched by registry URL). Pure, fully tested (11 new tests). |
| `a1aed2e` feat(mcp) | mcp-server's `getRecorder()` now uses the resolver instead of reading `DOSSIER_TRACE_*` env vars directly. Users can flip tracing on by setting `tracing.enabled = true` in their Dossier config — no MCP-host-specific editing. |
| `ecd4c63` feat(examples) | `examples/setup/setup-tracing.ds.md` — the Dossier that owns the actual setup UX. Asks user about scope (user/project) and optional custom logger URL, writes the config block, tells user to restart their MCP host. |

## Architectural shift

User flagged that hardcoding "discover environment, navigate host configs, write files" into the CLI was the wrong abstraction — that's **exactly what a dossier is for**.

Result: **zero new CLI commands**. The CLI doesn't need to know about Claude Desktop vs Claude Code vs Cursor. The dossier handles all of that, and orgs can fork it to match their own environment (different logger, different auth flow, different MCP host) without forking the CLI.

```
User:        ai-dossier run setup-tracing@1.0
                ↓
Claude:      executes the dossier's instructions
                ↓
              reads ~/.dossier/credentials.json (login check)
              asks user about scope + custom URL
              writes tracing block to ~/.dossier/config.json
                ↓
mcp-server:  next launch → resolveTraceConfig() reads the new block → enabled
```

## Resolver precedence (effective behavior)

| Source | What it sets |
|---|---|
| `process.env.DOSSIER_TRACE_ENABLED / URL / TOKEN` | Highest — for CI / Vercel / shell scripts |
| `.dossierrc.json` walked up from cwd | `tracing.enabled`, `tracing.url` — per-project, checkable into git |
| `~/.dossier/config.json` `tracing` block | `tracing.enabled`, `tracing.url` — per-user, written by the setup dossier |
| Defaults | URL = logged-in registry (or hardcoded fallback), token from credentials store |

Tokens are **never written to config files** — only env or credentials store. Avoids file-mode footguns.

The resolved config exposes a `sources` field showing which layer won at each step — useful for a future `traces status` diagnostic.

## Test plan

- [x] `npm test -w @ai-dossier/core` → 284 pass (11 new for the resolver, covering every precedence path + edge cases like malformed JSON)
- [x] `npm test -w @ai-dossier/mcp-server` → 130 pass (existing tests updated for the new core mock)
- [x] `npm test -w cli` → 456 pass
- [x] `npm test -w @ai-dossier/registry` → 189 pass
- [x] `make build-all` clean
- [x] `ai-dossier lint examples/setup/setup-tracing.ds.md` → no issues
- [ ] CI green on this PR
- [ ] After merge: publish setup-tracing dossier to the registry, then `ai-dossier search setup-tracing` resolves it
- [ ] After publish: `ai-dossier run setup-tracing` round-trips and writes the expected block

## What's NOT in this PR

- The published-to-registry copy of the dossier. The file lands in `examples/setup/` for review; publishing is a separate, post-merge action (matches the recent pattern of #385 which moved a dossier from repo to registry-only after publishing).
- `ai-dossier traces status` and `ai-dossier traces disable` helpers. We discussed these but decided the dossier handles enable; status/disable can be a tiny follow-up if useful (or, in the spirit of this PR, become dossiers too).
- OTLP / Datadog / non-registry trace sinks. The resolver supports custom URLs but the recorder still POSTs the dossier-registry contract. Pluggable formats is a bigger feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)