### PR TITLE
feat(traces): record verified checksum + version + signer metadata

### DIFF
--- a/mcp-server/src/orchestration/dossier-trace-info.ts
+++ b/mcp-server/src/orchestration/dossier-trace-info.ts
@@ -1,0 +1,38 @@
+// Extracts the audit-metadata block we record on every trace step from a
+// parsed dossier frontmatter. The checksum we record is the **same value**
+// that lives in the dossier's own `checksum.hash` field, so an archived
+// trace can be cross-referenced against the dossier file directly.
+//
+// Signature: we capture the algorithm + signer metadata (who, when, key id)
+// — NOT the signature bytes / public key. Those are reproducible by
+// re-fetching the dossier at the recorded version + checksum.
+
+import type { DossierFrontmatter, DossierTraceInfo } from '@ai-dossier/core';
+
+export function extractDossierTraceInfo(
+  fallbackName: string,
+  frontmatter: DossierFrontmatter | null
+): DossierTraceInfo {
+  if (!frontmatter) {
+    return { title: fallbackName, version: 'unknown' };
+  }
+  const info: DossierTraceInfo = {
+    title: frontmatter.title || fallbackName,
+    version: frontmatter.version || 'unknown',
+  };
+  if (frontmatter.checksum?.hash) {
+    info.checksum = {
+      algorithm: frontmatter.checksum.algorithm,
+      hash: frontmatter.checksum.hash,
+    };
+  }
+  if (frontmatter.signature) {
+    info.signature = {
+      algorithm: frontmatter.signature.algorithm,
+    };
+    if (frontmatter.signature.signed_by) info.signature.signed_by = frontmatter.signature.signed_by;
+    if (frontmatter.signature.key_id) info.signature.key_id = frontmatter.signature.key_id;
+    if (frontmatter.signature.signed_at) info.signature.signed_at = frontmatter.signature.signed_at;
+  }
+  return info;
+}

--- a/mcp-server/src/orchestration/session.ts
+++ b/mcp-server/src/orchestration/session.ts
@@ -4,6 +4,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import type { DossierTraceInfo } from '@ai-dossier/core';
 import type { PhaseEntry } from './types';
 
 export interface JourneyStep {
@@ -14,6 +15,12 @@ export interface JourneyStep {
   status: 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
   injectedContext?: string;
   collectedOutputs?: Record<string, unknown>;
+  /**
+   * Cached at the time the step's dossier was first read (in startJourney
+   * or when advancing in stepComplete). Recorded into the trace so we
+   * know which exact dossier version + body hash ran for each step.
+   */
+  dossierMeta?: DossierTraceInfo;
 }
 
 export interface JourneySession {

--- a/mcp-server/src/tools/__tests__/startJourney-recorder.test.ts
+++ b/mcp-server/src/tools/__tests__/startJourney-recorder.test.ts
@@ -10,8 +10,15 @@ vi.mock('node:fs', () => ({
   readFileSync: vi.fn(() => '# Body'),
 }));
 
+// Per-test override hook; default returns a minimal frontmatter so the
+// recorder's required `title` field is non-empty.
+const mockParse = vi.fn((raw: string) => ({
+  body: raw,
+  frontmatter: { title: 'Mock Title', version: '1.0.0' },
+}));
+
 vi.mock('@ai-dossier/core', () => ({
-  parseDossierContent: vi.fn((raw: string) => ({ body: raw })),
+  parseDossierContent: (raw: string) => mockParse(raw),
 }));
 
 vi.mock('../../utils/logger', () => ({
@@ -73,12 +80,86 @@ describe('startJourney → TraceRecorder.create', () => {
     const arg = mockCreate.mock.calls[0][0];
     expect(arg.trace_id).toBe(result.journey_id);
     expect(arg.status).toBe('running');
-    expect(arg.dossier.title).toBe('entry-dossier');
+    // title comes from the parsed frontmatter, not the graph entry name
+    expect(arg.dossier.title).toBe('Mock Title');
+    expect(arg.dossier.version).toBe('1.0.0');
     expect(arg.agent.name).toBe('mcp-server');
     expect(typeof arg.agent.host).toBe('string');
     expect(arg.agent.host.length).toBeGreaterThan(0);
     expect(typeof arg.started_at).toBe('string');
     expect(new Date(arg.started_at).toString()).not.toBe('Invalid Date');
+  });
+
+  it('records the verified body checksum from the dossier frontmatter', async () => {
+    mockParse.mockReturnValueOnce({
+      body: '# body',
+      frontmatter: {
+        title: 'Signed Dossier',
+        version: '2.1.0',
+        checksum: {
+          algorithm: 'sha256',
+          hash: 'deadbeefcafebabe1234567890abcdef',
+        },
+      },
+    } as never);
+    storeGraph('graph-signed', makePlan(['signed-dossier']));
+    await startJourney({ graph_id: 'graph-signed' });
+
+    const arg = mockCreate.mock.calls[0][0];
+    expect(arg.dossier.title).toBe('Signed Dossier');
+    expect(arg.dossier.version).toBe('2.1.0');
+    expect(arg.dossier.checksum).toEqual({
+      algorithm: 'sha256',
+      hash: 'deadbeefcafebabe1234567890abcdef',
+    });
+    // No signature recorded when the frontmatter has none.
+    expect(arg.dossier.signature).toBeUndefined();
+  });
+
+  it('records signature metadata (no signature bytes) when the dossier is signed', async () => {
+    mockParse.mockReturnValueOnce({
+      body: '# body',
+      frontmatter: {
+        title: 'Trusted Dossier',
+        version: '1.0.0',
+        checksum: { algorithm: 'sha256', hash: 'abc123' },
+        signature: {
+          algorithm: 'ed25519',
+          signature: 'BASE64-SIGNATURE-BYTES-NOT-RECORDED',
+          public_key: 'PUBKEY-NOT-RECORDED',
+          signed_by: 'Yuval Dimnik <yuval.dimnik@gmail.com>',
+          key_id: 'test-key-2026',
+          signed_at: '2026-05-13T20:00:00Z',
+        },
+      },
+    } as never);
+    storeGraph('graph-trusted', makePlan(['trusted-dossier']));
+    await startJourney({ graph_id: 'graph-trusted' });
+
+    const arg = mockCreate.mock.calls[0][0];
+    expect(arg.dossier.signature).toEqual({
+      algorithm: 'ed25519',
+      signed_by: 'Yuval Dimnik <yuval.dimnik@gmail.com>',
+      key_id: 'test-key-2026',
+      signed_at: '2026-05-13T20:00:00Z',
+    });
+    // Crucially the signature bytes + public key are NOT in the trace.
+    const sig = arg.dossier.signature as Record<string, unknown>;
+    expect(sig.signature).toBeUndefined();
+    expect(sig.public_key).toBeUndefined();
+  });
+
+  it('falls back to entry name + "unknown" version when the file does not parse', async () => {
+    mockParse.mockImplementationOnce(() => {
+      throw new Error('not a valid dossier');
+    });
+    storeGraph('graph-broken', makePlan(['broken-dossier']));
+    await startJourney({ graph_id: 'graph-broken' });
+
+    const arg = mockCreate.mock.calls[0][0];
+    expect(arg.dossier.title).toBe('broken-dossier');
+    expect(arg.dossier.version).toBe('unknown');
+    expect(arg.dossier.checksum).toBeUndefined();
   });
 
   it('does not call recorder.create when graph_id is missing', async () => {

--- a/mcp-server/src/tools/__tests__/stepComplete-recorder.test.ts
+++ b/mcp-server/src/tools/__tests__/stepComplete-recorder.test.ts
@@ -12,8 +12,15 @@ vi.mock('node:fs', () => ({
   readFileSync: vi.fn(() => '# Body'),
 }));
 
+// Per-test override hook; default returns frontmatter so the audit
+// metadata (version + checksum + signature) lands on each appendStep.
+const mockParse = vi.fn((raw: string) => ({
+  body: raw,
+  frontmatter: { title: 'Mock Title', version: '1.0.0' },
+}));
+
 vi.mock('@ai-dossier/core', () => ({
-  parseDossierContent: vi.fn((raw: string) => ({ body: raw })),
+  parseDossierContent: (raw: string) => mockParse(raw),
 }));
 
 vi.mock('../../utils/logger', () => ({
@@ -115,6 +122,63 @@ describe('stepComplete → TraceRecorder', () => {
 
     expect(mockRecorder.complete).toHaveBeenCalledTimes(1);
     expect(mockRecorder.complete.mock.calls[0][1].status).toBe('failed');
+  });
+
+  it('records dossier_meta (version + checksum) on each appendStep', async () => {
+    // Different frontmatter per dossier so we can prove the cached metadata
+    // is per-step, not just the entry dossier's metadata reused.
+    mockParse
+      .mockReturnValueOnce({
+        body: '# a',
+        frontmatter: {
+          title: 'Dossier A',
+          version: '1.0.0',
+          checksum: { algorithm: 'sha256', hash: 'aaa-hash' },
+        },
+      } as never)
+      .mockReturnValueOnce({
+        body: '# b',
+        frontmatter: {
+          title: 'Dossier B',
+          version: '2.5.0',
+          checksum: { algorithm: 'sha256', hash: 'bbb-hash' },
+          signature: {
+            algorithm: 'ed25519',
+            signature: 'sig-bytes-ignored',
+            signed_by: 'tester',
+            key_id: 'k1',
+            signed_at: '2026-05-13T20:00:00Z',
+          },
+        },
+      } as never);
+
+    storeGraph('g-meta', makePlan(['a', 'b']));
+    const start = (await startJourney({ graph_id: 'g-meta' })) as { journey_id: string };
+    await stepComplete({ journey_id: start.journey_id, status: 'completed' });
+    await stepComplete({ journey_id: start.journey_id, status: 'completed' });
+
+    expect(mockRecorder.appendStep).toHaveBeenCalledTimes(2);
+
+    const stepA = mockRecorder.appendStep.mock.calls[0][1];
+    expect(stepA.dossier_meta).toEqual({
+      title: 'Dossier A',
+      version: '1.0.0',
+      checksum: { algorithm: 'sha256', hash: 'aaa-hash' },
+    });
+
+    const stepB = mockRecorder.appendStep.mock.calls[1][1];
+    expect(stepB.dossier_meta.title).toBe('Dossier B');
+    expect(stepB.dossier_meta.version).toBe('2.5.0');
+    expect(stepB.dossier_meta.checksum).toEqual({ algorithm: 'sha256', hash: 'bbb-hash' });
+    expect(stepB.dossier_meta.signature).toEqual({
+      algorithm: 'ed25519',
+      signed_by: 'tester',
+      key_id: 'k1',
+      signed_at: '2026-05-13T20:00:00Z',
+    });
+    // Signature bytes + public key are NEVER recorded.
+    expect(stepB.dossier_meta.signature.signature).toBeUndefined();
+    expect(stepB.dossier_meta.signature.public_key).toBeUndefined();
   });
 
   it('does not finalize on an intermediate (non-final) completed step', async () => {

--- a/mcp-server/src/tools/startJourney.ts
+++ b/mcp-server/src/tools/startJourney.ts
@@ -5,7 +5,8 @@
 
 import { readFileSync } from 'node:fs';
 import { hostname } from 'node:os';
-import { parseDossierContent } from '@ai-dossier/core';
+import { type DossierFrontmatter, parseDossierContent } from '@ai-dossier/core';
+import { extractDossierTraceInfo } from '../orchestration/dossier-trace-info';
 import { getRecorder } from '../orchestration/recorder';
 import { createSession, stepsFromPhases, updateSession } from '../orchestration/session';
 import type { PhaseEntry } from '../orchestration/types';
@@ -37,25 +38,33 @@ export interface StartJourneyError {
 }
 
 /**
- * Fetch the markdown body of a dossier step.
- * Local dossiers are read from disk; registry dossiers return empty string as fallback.
+ * Fetch the body + parsed frontmatter of a dossier step. The frontmatter
+ * is returned (when parseable) so callers can record audit metadata
+ * (version, checksum, signature) in the execution trace.
+ *
+ * Local dossiers are read from disk; registry dossiers return an empty
+ * body + null frontmatter as fallback.
  */
-function fetchDossierBody(entry: Pick<PhaseEntry, 'source' | 'path' | 'name'>): string {
+export function fetchDossierContent(entry: Pick<PhaseEntry, 'source' | 'path' | 'name'>): {
+  body: string;
+  frontmatter: DossierFrontmatter | null;
+} {
   if (entry.source === 'local' && entry.path) {
     try {
       const raw = readFileSync(entry.path, 'utf8');
       try {
-        return parseDossierContent(raw).body;
+        const parsed = parseDossierContent(raw);
+        return { body: parsed.body, frontmatter: parsed.frontmatter };
       } catch {
-        return raw;
+        return { body: raw, frontmatter: null };
       }
     } catch {
       logger.warn('Could not read dossier file', { path: entry.path });
-      return '';
+      return { body: '', frontmatter: null };
     }
   }
   // Registry dossiers: body is not available without a download step
-  return '';
+  return { body: '', frontmatter: null };
 }
 
 /**
@@ -103,7 +112,14 @@ export async function startJourney(
   updateSession(session);
 
   const first = entries[0];
-  const body = fetchDossierBody(first);
+  const { body, frontmatter } = fetchDossierContent(first);
+
+  // Cache audit metadata on the session step so stepComplete can include
+  // the same checksum/version on the appendStep payload — without
+  // re-reading the file or trusting Claude's report.
+  const dossierMeta = extractDossierTraceInfo(first.name, frontmatter);
+  session.steps[0].dossierMeta = dossierMeta;
+  updateSession(session);
 
   logger.info('Journey started', {
     journeyId: session.id,
@@ -115,7 +131,7 @@ export async function startJourney(
   // Fire-and-forget: opens a trace if DOSSIER_TRACE_URL/TOKEN are set.
   getRecorder().create({
     trace_id: session.id,
-    dossier: { title: first.name, version: 'unknown' },
+    dossier: dossierMeta,
     agent: { name: 'mcp-server', host: hostname() },
     started_at: session.startedAt.toISOString(),
     status: 'running',

--- a/mcp-server/src/tools/stepComplete.ts
+++ b/mcp-server/src/tools/stepComplete.ts
@@ -4,7 +4,8 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { parseDossierContent } from '@ai-dossier/core';
+import { type DossierFrontmatter, parseDossierContent } from '@ai-dossier/core';
+import { extractDossierTraceInfo } from '../orchestration/dossier-trace-info';
 import { finalizeTrace, getRecorder } from '../orchestration/recorder';
 import type { JourneyStep, JourneySummary } from '../orchestration/session';
 import {
@@ -41,20 +42,24 @@ export interface StepCompleteError {
 
 export type StepCompleteOutput = StepCompleteRunning | StepCompleteDone;
 
-function fetchDossierBody(step: JourneyStep): string {
+function fetchDossierContent(step: JourneyStep): {
+  body: string;
+  frontmatter: DossierFrontmatter | null;
+} {
   if (step.source === 'local' && step.path) {
     try {
       const raw = readFileSync(step.path, 'utf8');
       try {
-        return parseDossierContent(raw).body;
+        const parsed = parseDossierContent(raw);
+        return { body: parsed.body, frontmatter: parsed.frontmatter };
       } catch {
-        return raw;
+        return { body: raw, frontmatter: null };
       }
     } catch {
-      return '';
+      return { body: '', frontmatter: null };
     }
   }
-  return '';
+  return { body: '', frontmatter: null };
 }
 
 export async function stepComplete(
@@ -93,13 +98,16 @@ export async function stepComplete(
   }
   currentStep.status = status;
 
-  // Fire-and-forget: append this step to the trace.
+  // Fire-and-forget: append this step to the trace. `dossier_meta` carries
+  // the version + checksum + signature metadata captured when the step's
+  // dossier was first read, so the trace pins exactly which content ran.
   const recorder = getRecorder();
   recorder.appendStep(session.id, {
     step_id: `${currentStep.dossier}-${session.currentStepIndex}`,
     type: status,
     timestamp: new Date().toISOString(),
     dossier: currentStep.dossier,
+    dossier_meta: currentStep.dossierMeta ?? null,
     index: session.currentStepIndex,
     outputs: outputs ?? null,
   });
@@ -146,9 +154,12 @@ export async function stepComplete(
   const context = buildOutputContext(session.outputs);
   nextStep.injectedContext = context;
 
-  updateSession(session);
+  const { body, frontmatter } = fetchDossierContent(nextStep);
+  // Cache audit metadata on the step so the next stepComplete includes
+  // the same checksum/version when this step finishes.
+  nextStep.dossierMeta = extractDossierTraceInfo(nextStep.dossier, frontmatter);
 
-  const body = fetchDossierBody(nextStep);
+  updateSession(session);
 
   logger.info('Journey advanced to next step', {
     journeyId: journey_id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,10 +27,10 @@
     },
     "cli": {
       "name": "@ai-dossier/cli",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@ai-dossier/core": "^1.3.2",
+        "@ai-dossier/core": "^1.3.3",
         "commander": "^12.1.0"
       },
       "bin": {
@@ -48,7 +48,7 @@
     },
     "mcp-server": {
       "name": "@ai-dossier/mcp-server",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ai-dossier/core": "^1.2.0",
@@ -6611,7 +6611,7 @@
     },
     "packages/core": {
       "name": "@ai-dossier/core",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.927.0",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -104,6 +104,7 @@ export type {
 export { resolveTraceConfig } from './trace-config';
 // Trace recorder exports (opt-in execution tracing — see registry /api/v1/traces)
 export type {
+  DossierTraceInfo,
   StepInput as TraceStepInput,
   TraceInput,
   TraceRecorder,

--- a/packages/core/src/trace-recorder.ts
+++ b/packages/core/src/trace-recorder.ts
@@ -6,9 +6,34 @@
 export const VALID_TRACE_STATUSES = ['running', 'success', 'failed', 'cancelled'] as const;
 export type TraceStatus = (typeof VALID_TRACE_STATUSES)[number];
 
+/**
+ * Audit metadata about a dossier as it appeared at execution time. The
+ * `checksum` MUST be the same hash that was verified before the agent
+ * ran (i.e. the value from the dossier's own `checksum.hash` field), so
+ * a stored trace can be cross-referenced against the original file.
+ *
+ * Signature: we record metadata about who signed it (algorithm, signer,
+ * key id, when), not the signature bytes themselves — the latter are
+ * reproducible by re-fetching the dossier at the recorded version.
+ */
+export interface DossierTraceInfo {
+  title: string;
+  version: string;
+  /** The body-content hash that was verified at run time. */
+  checksum?: { algorithm: string; hash: string };
+  /** Metadata about the dossier's signature (omit signature bytes). */
+  signature?: {
+    algorithm: string;
+    signed_by?: string;
+    key_id?: string;
+    signed_at?: string;
+  };
+  [key: string]: unknown;
+}
+
 export interface TraceInput {
   trace_id: string;
-  dossier: { title: string; version: string; [key: string]: unknown };
+  dossier: DossierTraceInfo;
   agent?: { name?: string; version?: string; [key: string]: unknown };
   started_at: string;
   completed_at?: string;


### PR DESCRIPTION
## Summary

Closes the audit gap that the docs guide acknowledged but the code didn't yet fix: traces now pin **exactly which dossier content ran**, not just its registry name.

Per #398 follow-up — the recorded `checksum.hash` is the **same value** the verifier checked before the agent ran (i.e. the dossier's own `frontmatter.checksum.hash`). A stored trace + an archived `.ds.md` file can be cross-referenced directly without recomputing anything.

## What changes in a trace

Each `recorder.create()` (entry dossier) and `recorder.appendStep()` (every subsequent step) now carries:

```jsonc
"dossier_meta": {
  "title":   "Setup Tracing",       // from frontmatter — falls back to graph entry name
  "version": "1.0.0",               // from frontmatter — "unknown" if unparseable
  "checksum": {                     // omitted when frontmatter has no checksum
    "algorithm": "sha256",
    "hash": "bd7a1985..."            // EXACTLY the verified hash
  },
  "signature": {                    // omitted when the dossier is unsigned
    "algorithm": "ed25519",
    "signed_by": "Yuval Dimnik <…>",
    "key_id":    "test-key-2026",
    "signed_at": "2026-05-13T20:00:00Z"
    //  signature bytes + public_key are NOT recorded — reproducible by
    //  re-fetching the dossier at the recorded version + checksum.
  }
}
```

## Implementation

| File | Change |
|---|---|
| `packages/core/src/trace-recorder.ts` | New `DossierTraceInfo` type with explicit optional `checksum` / `signature` fields. `TraceInput.dossier` switches from an index-signature shape to this typed shape. |
| `mcp-server/src/orchestration/dossier-trace-info.ts` | New helper `extractDossierTraceInfo(name, frontmatter)` — builds the metadata block from a parsed frontmatter. Drops signature bytes + public key explicitly. |
| `mcp-server/src/orchestration/session.ts` | `JourneyStep` gains optional `dossierMeta` field for caching across the start → step → … → complete lifecycle. |
| `mcp-server/src/tools/startJourney.ts` | `fetchDossierBody` → `fetchDossierContent` (returns body + frontmatter). Caches metadata on the entry step. Passes it to `recorder.create()`. |
| `mcp-server/src/tools/stepComplete.ts` | Same refactor. Caches metadata on the next step when advancing. Passes the cached metadata of the just-completed step to `recorder.appendStep()`. |

## Tests

| Scenario | New tests |
|---|---|
| Entry dossier with checksum only | `startJourney-recorder.test.ts` — title, version, checksum threaded through |
| Entry dossier signed | Signature metadata recorded; signature bytes + public_key explicitly asserted **absent** |
| Entry dossier unparseable | Falls back to graph-entry name + `"unknown"` version |
| Multi-step journey with different metadata per step | `stepComplete-recorder.test.ts` — `appendStep` carries each step's own `dossier_meta`, not just the entry's |

Total: 4 new tests; 134 mcp-server / 456 cli / 284 core / 189 registry tests still green.

## Compatibility

- `TraceInput.dossier` type is stricter (named fields instead of arbitrary `[key]: unknown`), but the [key]: unknown index signature stays on `DossierTraceInfo` itself, so existing callers passing arbitrary extra fields still type-check.
- Registry-side: no schema change. `dossier_meta` lands in `traces.data` JSONB on create + `trace_steps.data` JSONB on append. The CLI's `traces show` already returns the full JSONB so it'll surface the new fields automatically.

## Out of scope

- Re-verifying the trace's recorded checksum against the live registry copy of the dossier at read time. A future "trace audit" command could do that, but for now the trace is just a record — verification happens at run time (before this code runs).
- Computing a frontmatter-inclusive hash (the open question in #398). The hash we record is what the verifier checked — body-only. Same as today's verification model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)