### PR TITLE
fix(cli): TTL-based version resolution to kill silent cache staleness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- TTL-based version resolution for versionless dossier references (`run`, `create`, `install-skill`): stale versionless requests auto-update silently within a configurable window (default 300s). Resolution metadata lives under `~/.dossier/cache/.resolution/<name>.json`.
+- New `--max-age <seconds>` flag on `run`, `create`, and `install-skill` (default 300, `0` = always re-check the registry).
+- `--fresh` flag on `create` (already supported on `run` and `install-skill`) to bypass the resolution cache for one call.
+- New config key `cache.resolutionTtlSeconds` (default `300`) in `~/.dossier/config.json`.
+- New subcommand `ai-dossier cache resolutions` (with `--json`) to inspect cached versionless → version mappings.
+- Stale-cache fallback: when the registry is unreachable and a cached version exists, the CLI uses the highest-semver cached copy and prints a loud stderr warning rather than failing.
+
+### Removed
+- Cosmetic "Update available: ...@X (run --pull to update)" warning at the end of `run`. Versionless requests now auto-update within the TTL window, so the warning is no longer needed.
+
 ## [v1.3.0 / v0.8.0] - 2026-03-07
 
 ### Fixed

--- a/cli/README.md
+++ b/cli/README.md
@@ -225,7 +225,7 @@ ai-dossier pull org/dossier-a org/dossier-b
 ai-dossier pull org/my-dossier --force
 ```
 
-Pulled dossiers are cached locally with checksum verification. Subsequent `pull` calls skip the download if the version is already cached (use `--force` to override).
+Pulled dossiers are cached locally with checksum verification. Subsequent `pull` calls skip the download if the version is already cached (use `--force` to override). See [Cache and Version Resolution](#cache-and-version-resolution) for how versionless names are resolved and how to control freshness.
 
 ### Export
 
@@ -240,6 +240,71 @@ ai-dossier export org/my-dossier -o ./local-copy.ds.md
 
 # Print to stdout (for piping)
 ai-dossier export org/my-dossier --stdout
+```
+
+---
+
+## Cache and Version Resolution
+
+The CLI maintains a local cache at `~/.dossier/cache/`:
+
+- **Content cache** — `~/.dossier/cache/<name>/<version>.ds.md` (the dossier bytes, content-addressable by version).
+- **Resolution cache** — `~/.dossier/cache/.resolution/<name>.json` (which version a versionless name resolves to, with TTL).
+
+### How versionless names resolve
+
+Pinned references (`org/my-dossier@1.2.3`) are content-addressable and never expire — they bypass the resolver entirely.
+
+Versionless references (`org/my-dossier`) are resolved through a **TTL'd resolution cache**:
+
+1. If a recent resolution exists (within TTL) → reuse it (no registry call).
+2. Otherwise → call the registry, write the resolved version to the resolution cache, return it.
+3. If the registry is unreachable → fall back to the highest-semver cached version and print a loud stderr warning. If nothing is cached, fail with a clear error.
+
+This applies to `ai-dossier run`, `ai-dossier create`, and `ai-dossier install-skill`.
+
+### Controlling freshness
+
+| Flag | Effect |
+|------|--------|
+| (none) | Use cached resolution if newer than `cache.resolutionTtlSeconds` (default 300s). |
+| `--max-age <seconds>` | Override TTL for this call. `0` forces a registry check. |
+| `--fresh` | Skip the resolution cache and the content cache; fetch fresh from the registry. |
+| `--pull` (`run` only) | Refresh the content cache (re-download) but still resolve via the resolver. |
+
+```bash
+# Default: use cached resolution if within 300s
+ai-dossier run org/my-dossier
+
+# Force a registry re-check
+ai-dossier run org/my-dossier --max-age 0
+
+# Skip the entire cache for this call
+ai-dossier run org/my-dossier --fresh
+```
+
+Configure the default TTL:
+
+```bash
+dossier config cache.resolutionTtlSeconds 600
+```
+
+### `cache` subcommand
+
+```bash
+# Show all cached dossiers (content cache)
+ai-dossier cache list
+ai-dossier cache list --size --json
+
+# Show cached versionless → version resolutions (with timestamps)
+ai-dossier cache resolutions
+ai-dossier cache resolutions --json
+
+# Remove cached entries
+ai-dossier cache clean <name>             # all versions of a dossier
+ai-dossier cache clean <name> --ver 1.2.0 # specific version
+ai-dossier cache clean --older-than 30    # entries older than N days
+ai-dossier cache clean --all              # everything (prompts; use -y to skip)
 ```
 
 ---

--- a/cli/src/__tests__/cache-resolver.test.ts
+++ b/cli/src/__tests__/cache-resolver.test.ts
@@ -1,0 +1,234 @@
+import fs from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { highestCachedSemver, listResolutions, resolveCachedVersion } from '../cache-resolver';
+import * as config from '../config';
+import * as multiRegistry from '../multi-registry';
+
+vi.mock('node:fs');
+vi.mock('../config');
+vi.mock('../multi-registry');
+
+const mockedFs = vi.mocked(fs);
+
+function makeRegistryResult(version: string, registry = 'public') {
+  return {
+    result: {
+      name: 'org/x',
+      version,
+      _registry: registry,
+    } as any,
+    errors: [],
+  };
+}
+
+describe('cache-resolver', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.mocked(config.getConfig).mockReturnValue(300);
+    mockedFs.existsSync.mockReturnValue(false);
+    mockedFs.readFileSync.mockReturnValue('');
+    mockedFs.writeFileSync.mockReturnValue(undefined);
+    mockedFs.mkdirSync.mockReturnValue(undefined);
+    mockedFs.readdirSync.mockReturnValue([] as any);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  describe('resolveCachedVersion', () => {
+    it('calls registry and writes resolution file when no cache exists', async () => {
+      mockedFs.existsSync.mockReturnValue(false);
+      vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue(
+        makeRegistryResult('1.2.3')
+      );
+
+      const result = await resolveCachedVersion('org/x');
+
+      expect(result).toEqual({ version: '1.2.3', source: 'registry', registry: 'public' });
+      expect(multiRegistry.multiRegistryGetDossier).toHaveBeenCalledWith('org/x');
+      expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('.resolution/org/x.json'),
+        expect.stringContaining('"resolved_version": "1.2.3"'),
+        expect.any(Object)
+      );
+    });
+
+    it('returns cached resolution within TTL without calling registry', async () => {
+      const recentTimestamp = new Date(Date.now() - 60_000).toISOString();
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readFileSync.mockReturnValue(
+        JSON.stringify({
+          resolved_version: '1.0.0',
+          resolved_at: recentTimestamp,
+          source_registry: 'public',
+        })
+      );
+
+      const result = await resolveCachedVersion('org/x');
+
+      expect(result).toEqual({ version: '1.0.0', source: 'cache', registry: 'public' });
+      expect(multiRegistry.multiRegistryGetDossier).not.toHaveBeenCalled();
+    });
+
+    it('re-resolves when resolution is past TTL', async () => {
+      const oldTimestamp = new Date(Date.now() - 10 * 60_000).toISOString(); // 10 min ago
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readFileSync.mockReturnValue(
+        JSON.stringify({
+          resolved_version: '1.0.0',
+          resolved_at: oldTimestamp,
+          source_registry: 'public',
+        })
+      );
+      vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue(
+        makeRegistryResult('1.1.0')
+      );
+
+      const result = await resolveCachedVersion('org/x');
+
+      expect(result.version).toBe('1.1.0');
+      expect(result.source).toBe('registry');
+      expect(multiRegistry.multiRegistryGetDossier).toHaveBeenCalled();
+    });
+
+    it('skips resolution cache entirely when fresh=true', async () => {
+      const recentTimestamp = new Date(Date.now() - 10_000).toISOString();
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readFileSync.mockReturnValue(
+        JSON.stringify({ resolved_version: '1.0.0', resolved_at: recentTimestamp })
+      );
+      vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue(
+        makeRegistryResult('2.0.0')
+      );
+
+      const result = await resolveCachedVersion('org/x', { fresh: true });
+
+      expect(result.version).toBe('2.0.0');
+      expect(multiRegistry.multiRegistryGetDossier).toHaveBeenCalled();
+    });
+
+    it('forces re-resolution when maxAgeSeconds=0', async () => {
+      const veryRecent = new Date().toISOString();
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readFileSync.mockReturnValue(
+        JSON.stringify({ resolved_version: '1.0.0', resolved_at: veryRecent })
+      );
+      vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue(
+        makeRegistryResult('1.5.0')
+      );
+
+      const result = await resolveCachedVersion('org/x', { maxAgeSeconds: 0 });
+
+      expect(result.version).toBe('1.5.0');
+      expect(multiRegistry.multiRegistryGetDossier).toHaveBeenCalled();
+    });
+
+    it('falls back to highest cached semver with stderr warning when registry unreachable', async () => {
+      // No resolution file. Content cache has versions on disk.
+      mockedFs.existsSync.mockImplementation((p: any) => {
+        const ps = String(p);
+        // resolution file: missing. content cache dir + version files: present.
+        if (ps.includes('.resolution/')) return false;
+        return true;
+      });
+      mockedFs.readdirSync.mockReturnValue([
+        '1.0.0.meta.json',
+        '1.1.0.meta.json',
+        '1.2.0.meta.json',
+      ] as any);
+      vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
+        result: null,
+        errors: [{ registry: 'public', error: 'network unreachable' }],
+      } as any);
+
+      const result = await resolveCachedVersion('org/x');
+
+      expect(result.version).toBe('1.2.0');
+      expect(result.source).toBe('stale-cache');
+      expect(result.warning).toContain('Registry unreachable');
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Registry unreachable'));
+    });
+
+    it('throws when registry unreachable and nothing is cached', async () => {
+      mockedFs.existsSync.mockReturnValue(false);
+      vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
+        result: null,
+        errors: [{ registry: 'public', error: 'network down' }],
+      } as any);
+
+      await expect(resolveCachedVersion('org/x')).rejects.toThrow(/registry unreachable/i);
+    });
+
+    it('throws when registry throws and nothing is cached', async () => {
+      mockedFs.existsSync.mockReturnValue(false);
+      vi.mocked(multiRegistry.multiRegistryGetDossier).mockRejectedValue(new Error('ETIMEDOUT'));
+
+      await expect(resolveCachedVersion('org/x')).rejects.toThrow(/ETIMEDOUT/);
+    });
+  });
+
+  describe('highestCachedSemver', () => {
+    it('returns null when cache dir does not exist', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+      expect(highestCachedSemver('org/x')).toBeNull();
+    });
+
+    it('returns highest semver from .meta.json files (matched by .ds.md)', () => {
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readdirSync.mockReturnValue([
+        '0.9.0.meta.json',
+        '1.10.0.meta.json', // 1.10.0 > 1.2.0 (numeric, not lexicographic)
+        '1.2.0.meta.json',
+      ] as any);
+
+      expect(highestCachedSemver('org/x')).toBe('1.10.0');
+    });
+
+    it('ignores versions where .ds.md is missing', () => {
+      mockedFs.existsSync.mockImplementation((p: any) => {
+        const ps = String(p);
+        // Cache dir exists; only 1.0.0 has both .meta and .ds.md
+        if (ps.endsWith('org/x')) return true;
+        if (ps.endsWith('1.0.0.ds.md')) return true;
+        if (ps.endsWith('2.0.0.ds.md')) return false;
+        return true;
+      });
+      mockedFs.readdirSync.mockReturnValue(['1.0.0.meta.json', '2.0.0.meta.json'] as any);
+
+      expect(highestCachedSemver('org/x')).toBe('1.0.0');
+    });
+  });
+
+  describe('listResolutions', () => {
+    it('returns [] when resolution dir does not exist', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+      expect(listResolutions()).toEqual([]);
+    });
+
+    it('walks and parses resolution files', () => {
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readdirSync.mockImplementation(
+        (_dir: any, opts: any) =>
+          (opts?.withFileTypes
+            ? [{ name: 'foo.json', isDirectory: () => false }]
+            : ['foo.json']) as any
+      );
+      mockedFs.readFileSync.mockReturnValue(
+        JSON.stringify({
+          resolved_version: '1.0.0',
+          resolved_at: '2026-05-17T10:00:00Z',
+          source_registry: 'public',
+        })
+      );
+
+      const entries = listResolutions();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].name).toBe('foo');
+      expect(entries[0].record.resolved_version).toBe('1.0.0');
+    });
+  });
+});

--- a/cli/src/__tests__/commands/create.test.ts
+++ b/cli/src/__tests__/commands/create.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as cacheResolver from '../../cache-resolver';
 import { registerCreateCommand } from '../../commands/create';
 import * as multiRegistry from '../../multi-registry';
 import * as registryClient from '../../registry-client';
@@ -11,6 +12,7 @@ vi.mock('node:child_process');
 vi.mock('../../config');
 vi.mock('../../multi-registry');
 vi.mock('../../registry-client');
+vi.mock('../../cache-resolver');
 vi.mock('../../helpers', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../helpers')>();
   return {
@@ -27,6 +29,18 @@ const { detectLlm } = await import('../../helpers');
 describe('create command', () => {
   beforeEach(() => {
     vi.mocked(registryClient.parseNameVersion).mockImplementation(parseNameVersionImpl);
+    vi.mocked(cacheResolver.resolveCachedVersion).mockResolvedValue({
+      version: '1.0.0',
+      source: 'registry',
+      registry: 'public',
+    });
+    // Auto-mock returns undefined; the production code uses `!== null` to detect
+    // cache misses, so undefined would be a false cache hit. Default to "no cache".
+    vi.mocked(cacheResolver.readCachedContent).mockReturnValue(null);
+    vi.mocked(cacheResolver.writeCachedContent).mockImplementation(() => undefined);
+    vi.mocked(cacheResolver.parseMaxAgeOption).mockImplementation((raw: string | undefined) =>
+      raw === undefined ? undefined : Number(raw)
+    );
   });
 
   it('should exit 2 when LLM not detected', async () => {
@@ -45,10 +59,8 @@ describe('create command', () => {
       throw new Error('ENOENT');
     });
 
-    vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
-      result: null,
-      errors: [],
-    } as any);
+    // Resolver returns a version but content fetch fails — exercises the
+    // "Template not found" branch in create.ts.
     vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
       result: null,
       errors: [],

--- a/cli/src/__tests__/commands/run.test.ts
+++ b/cli/src/__tests__/commands/run.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as cacheResolver from '../../cache-resolver';
 import { registerRunCommand } from '../../commands/run';
 import * as config from '../../config';
 import * as helpers from '../../helpers';
@@ -16,11 +17,13 @@ vi.mock('../../multi-registry');
 vi.mock('../../registry-client');
 vi.mock('../../helpers');
 vi.mock('../../run-log');
+vi.mock('../../cache-resolver');
 
 const mockedFs = vi.mocked(fs);
 
 describe('run command', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.mocked(spawnSync).mockReset();
     vi.mocked(registryClient.parseNameVersion).mockImplementation(parseNameVersionImpl);
     vi.mocked(helpers.runVerification).mockResolvedValue({ passed: true, checks: [] });
@@ -34,6 +37,13 @@ describe('run command', () => {
       return `/home/.dossier/cache/${name}`;
     });
     vi.mocked(config.getConfig).mockReturnValue(undefined);
+    // cache-resolver helpers used by run.ts after the resolveCachedVersion call.
+    // The module is fully mocked, so these need explicit stubs or they return undefined
+    // and break the URL-detection branch below.
+    vi.mocked(cacheResolver.cachedContentPath).mockImplementation(
+      (name: string, version: string) => `/home/.dossier/cache/${name}/${version}.ds.md`
+    );
+    vi.mocked(cacheResolver.writeCachedContent).mockImplementation(() => {});
     // Mock TOCTOU mitigation temp file operations
     mockedFs.mkdtempSync.mockReturnValue('/tmp/dossier-run-test');
     mockedFs.writeFileSync.mockReturnValue(undefined);
@@ -87,13 +97,12 @@ describe('run command', () => {
     expect(spawnSync).not.toHaveBeenCalled();
   });
 
-  it('should exit 1 when registry dossier not found', async () => {
+  it('should exit 1 when registry dossier not found (resolver throws)', async () => {
     mockedFs.existsSync.mockReturnValue(false);
     mockedFs.readdirSync.mockReturnValue([]);
-    vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
-      result: null,
-      errors: [],
-    } as any);
+    vi.mocked(cacheResolver.resolveCachedVersion).mockRejectedValue(
+      new Error('Failed to resolve missing/dossier: registry unreachable and no cached version')
+    );
 
     const program = createTestProgram();
     registerRunCommand(program);
@@ -102,7 +111,7 @@ describe('run command', () => {
       program.parseAsync(['node', 'dossier', 'run', 'missing/dossier'])
     ).rejects.toThrow();
 
-    expect(helpers.printRegistryNotFoundError).toHaveBeenCalledWith('missing/dossier', []);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Failed to resolve'));
   });
 
   it('should exit 2 when no LLM detected', async () => {
@@ -190,28 +199,31 @@ describe('run command', () => {
     );
   });
 
-  it('should show stale cache warning when meta has newer version', async () => {
-    // Set up as registry name (not local file)
+  it('auto-resolves to the registry version when a stale version is cached (regression: #401)', async () => {
+    // Cache has 1.0.0 on disk, but registry says 1.1.0 is current.
+    // Old behavior: silently used 1.0.0 + cosmetic "Update available" warning.
+    // New behavior: resolveCachedVersion returns 1.1.0 — we re-fetch and execute that.
+    vi.mocked(cacheResolver.resolveCachedVersion).mockResolvedValue({
+      version: '1.1.0',
+      source: 'registry',
+      registry: 'public',
+    });
+    // 1.1.0 content file is not yet cached — forces a registry fetch.
     mockedFs.existsSync.mockImplementation((p: any) => {
       const ps = String(p);
-      // Not a local file, but cache dir + content file exist
-      if (ps.includes('cache/org/test')) return true;
-      if (ps.endsWith('.ds.md') && ps.includes('cache')) return true;
+      if (ps.endsWith('1.0.0.ds.md')) return true;
+      if (ps.endsWith('1.1.0.ds.md')) return false;
       return false;
     });
-    mockedFs.readdirSync.mockReturnValue(['1.0.0.meta.json'] as any);
-    mockedFs.readFileSync.mockImplementation((p: any) => {
-      const ps = String(p);
-      if (ps.includes('.meta.json')) {
-        return JSON.stringify({
-          cached_at: '2026-03-06T10:00:00Z',
-          version: '1.0.0',
-          latest_known_version: '2.0.0',
-          latest_checked_at: new Date().toISOString(),
-        });
-      }
-      return '---dossier\n{"title":"Test"}\n---\nBody';
-    });
+    vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
+      result: {
+        content: '---dossier\n{"title":"Test"}\n---\nBody',
+        digest: null,
+        _registry: 'public',
+      },
+      errors: [],
+    } as any);
+    mockedFs.readFileSync.mockReturnValue('---dossier\n{"title":"Test"}\n---\nBody');
     vi.mocked(spawnSync).mockReturnValue({ status: 0 } as any);
 
     const program = createTestProgram();
@@ -219,6 +231,57 @@ describe('run command', () => {
 
     await program.parseAsync(['node', 'dossier', 'run', 'org/test']);
 
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Update available'));
+    expect(cacheResolver.resolveCachedVersion).toHaveBeenCalledWith(
+      'org/test',
+      expect.objectContaining({ fresh: undefined })
+    );
+    expect(multiRegistry.multiRegistryGetContent).toHaveBeenCalledWith('org/test', '1.1.0');
+    expect(runLog.appendRunLog).toHaveBeenCalledWith(
+      expect.objectContaining({ resolved_version: '1.1.0' })
+    );
+  });
+
+  it('uses cached content when resolver returns a version that is already on disk', async () => {
+    vi.mocked(cacheResolver.resolveCachedVersion).mockResolvedValue({
+      version: '1.2.3',
+      source: 'cache',
+      registry: 'public',
+    });
+    mockedFs.existsSync.mockImplementation((p: any) => {
+      const ps = String(p);
+      // 1.2.3 content file exists in cache.
+      if (ps.endsWith('1.2.3.ds.md')) return true;
+      return false;
+    });
+    mockedFs.readFileSync.mockReturnValue('---dossier\n{"title":"Test"}\n---\nBody');
+    vi.mocked(spawnSync).mockReturnValue({ status: 0 } as any);
+
+    const program = createTestProgram();
+    registerRunCommand(program);
+
+    await program.parseAsync(['node', 'dossier', 'run', 'org/test']);
+
+    expect(multiRegistry.multiRegistryGetContent).not.toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Using cached'));
+  });
+
+  it('does not call the version resolver for pinned name@version', async () => {
+    mockedFs.existsSync.mockImplementation((p: any) => {
+      const ps = String(p);
+      if (ps.endsWith('2.5.0.ds.md')) return true;
+      return false;
+    });
+    mockedFs.readFileSync.mockReturnValue('---dossier\n{"title":"Test"}\n---\nBody');
+    vi.mocked(spawnSync).mockReturnValue({ status: 0 } as any);
+
+    const program = createTestProgram();
+    registerRunCommand(program);
+
+    await program.parseAsync(['node', 'dossier', 'run', 'org/test@2.5.0']);
+
+    expect(cacheResolver.resolveCachedVersion).not.toHaveBeenCalled();
+    expect(runLog.appendRunLog).toHaveBeenCalledWith(
+      expect.objectContaining({ resolved_version: '2.5.0' })
+    );
   });
 });

--- a/cli/src/cache-resolver.ts
+++ b/cli/src/cache-resolver.ts
@@ -1,0 +1,373 @@
+/**
+ * Versionless dossier name → resolved version mapping with TTL.
+ *
+ * Pinned versions (name@1.2.3) are content-addressable and never go stale.
+ * Versionless names (name) are the only thing that ages, so the TTL belongs
+ * on resolution, not on cached content bytes.
+ *
+ * Resolution cache lives at ~/.dossier/cache/.resolution/<name>.json, one
+ * tiny file per dossier with { resolved_version, resolved_at, source_registry }.
+ *
+ * On registry failure, falls back to the highest-semver version already in
+ * ~/.dossier/cache/<name>/ and prints a loud stderr warning so the staleness
+ * is never silent.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getConfig } from './config';
+import { safeDossierPath } from './helpers';
+import { multiRegistryGetDossier } from './multi-registry';
+
+export const DEFAULT_RESOLUTION_TTL_SECONDS = 300;
+export const CACHE_DIR = path.join(os.homedir(), '.dossier', 'cache');
+export const RESOLUTION_DIR = path.join(CACHE_DIR, '.resolution');
+
+export interface ResolutionRecord {
+  resolved_version: string;
+  resolved_at: string;
+  source_registry?: string;
+}
+
+export type ResolutionSource = 'cache' | 'registry' | 'stale-cache';
+
+export interface ResolvedVersion {
+  version: string;
+  source: ResolutionSource;
+  registry?: string;
+  /** Present only when source === 'stale-cache' — explains why we did not reach the registry. */
+  warning?: string;
+}
+
+export interface ResolveOptions {
+  /** Skip the resolution cache and force a registry call. */
+  fresh?: boolean;
+  /** Override the TTL for this call. 0 forces a registry call. */
+  maxAgeSeconds?: number;
+}
+
+function resolutionFilePath(dossierName: string): string {
+  const safeDir = safeDossierPath(RESOLUTION_DIR, dossierName);
+  return `${safeDir}.json`;
+}
+
+function readResolution(dossierName: string): ResolutionRecord | null {
+  const file = resolutionFilePath(dossierName);
+  try {
+    if (!fs.existsSync(file)) return null;
+    const raw = fs.readFileSync(file, 'utf8');
+    const parsed = JSON.parse(raw) as ResolutionRecord;
+    if (!parsed.resolved_version || !parsed.resolved_at) {
+      if (process.env.DOSSIER_DEBUG) {
+        process.stderr.write(
+          `[cache-resolver] resolution file ${file} missing required fields; ignoring\n`
+        );
+      }
+      return null;
+    }
+    return parsed;
+  } catch (err) {
+    // Corrupted resolution file — warn (always) and fall through to re-resolve.
+    // Silent fallback would hide a real corruption issue from operators.
+    process.stderr.write(
+      `⚠️  Resolution cache file unreadable (${file}): ${(err as Error).message}. Re-resolving from registry.\n`
+    );
+    return null;
+  }
+}
+
+function writeResolution(dossierName: string, record: ResolutionRecord): void {
+  const file = resolutionFilePath(dossierName);
+  const targetDir = path.dirname(file);
+  // Node's mkdir({recursive:true,mode}) only applies `mode` to the leaf directory it creates.
+  // For org-scoped names (org/sub/name) we must chmod each intermediate dir under
+  // RESOLUTION_DIR to 0o700 so resolution metadata never becomes world-readable.
+  fs.mkdirSync(targetDir, { recursive: true, mode: 0o700 });
+  let cursor = targetDir;
+  while (cursor.startsWith(RESOLUTION_DIR) && cursor !== path.dirname(RESOLUTION_DIR)) {
+    try {
+      fs.chmodSync(cursor, 0o700);
+    } catch {
+      // best-effort; if chmod fails (e.g. not owner) we still proceed
+    }
+    if (cursor === RESOLUTION_DIR) break;
+    cursor = path.dirname(cursor);
+  }
+  // Defend against symlink swap: if a non-regular file (symlink, fifo, etc.) sits at
+  // the target path, refuse to write through it. lstat does not follow symlinks.
+  try {
+    const st = fs.lstatSync(file);
+    if (!st.isFile()) {
+      fs.unlinkSync(file);
+    }
+  } catch {
+    // ENOENT — fine, fresh write
+  }
+  fs.writeFileSync(file, JSON.stringify(record, null, 2), { encoding: 'utf8', mode: 0o600 });
+}
+
+function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] || 0) - (pb[i] || 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/** Highest-semver version currently cached on disk for this name, or null. */
+export function highestCachedSemver(dossierName: string): string | null {
+  try {
+    const dir = safeDossierPath(CACHE_DIR, dossierName);
+    if (!fs.existsSync(dir)) return null;
+    const versions = fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith('.meta.json'))
+      .map((f) => f.replace('.meta.json', ''))
+      .filter((v) => fs.existsSync(path.join(dir, `${v}.ds.md`)))
+      .sort(compareSemver);
+    return versions.length > 0 ? versions[versions.length - 1] : null;
+  } catch {
+    return null;
+  }
+}
+
+function getConfiguredTtlSeconds(): number {
+  const raw = getConfig('cache.resolutionTtlSeconds');
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0) return raw;
+  return DEFAULT_RESOLUTION_TTL_SECONDS;
+}
+
+function formatAge(ageMs: number): string {
+  const seconds = Math.round(ageMs / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+/**
+ * Resolve a versionless dossier name to a concrete version.
+ *
+ * Flow:
+ *   1. If !fresh and a resolution file exists and is within TTL → return cached resolution.
+ *   2. Otherwise call the registry. On success → write resolution file → return.
+ *   3. On registry failure → fall back to highest-semver cached version with a
+ *      loud stderr warning. If nothing is cached, rethrow.
+ *
+ * Callers should pass an already-stripped name (without @version suffix). For
+ * pinned versions, skip this resolver entirely.
+ */
+export async function resolveCachedVersion(
+  dossierName: string,
+  opts: ResolveOptions = {}
+): Promise<ResolvedVersion> {
+  const ttl = opts.maxAgeSeconds ?? getConfiguredTtlSeconds();
+
+  if (!opts.fresh && ttl > 0) {
+    const cached = readResolution(dossierName);
+    if (cached) {
+      const ageMs = Date.now() - new Date(cached.resolved_at).getTime();
+      if (ageMs >= 0 && ageMs < ttl * 1000) {
+        if (process.env.DOSSIER_DEBUG) {
+          process.stderr.write(
+            `[cache-resolver] '${dossierName}' served from resolution cache: ` +
+              `version=${cached.resolved_version}, age=${formatAge(ageMs)}, ttl=${ttl}s, registry=${cached.source_registry ?? 'unknown'}\n`
+          );
+        }
+        return {
+          version: cached.resolved_version,
+          source: 'cache',
+          registry: cached.source_registry,
+        };
+      }
+      if (process.env.DOSSIER_DEBUG) {
+        process.stderr.write(
+          `[cache-resolver] '${dossierName}' resolution cache expired (age=${formatAge(ageMs)}, ttl=${ttl}s); re-resolving\n`
+        );
+      }
+    } else if (process.env.DOSSIER_DEBUG) {
+      process.stderr.write(
+        `[cache-resolver] '${dossierName}' has no resolution cache; calling registry\n`
+      );
+    }
+  } else if (process.env.DOSSIER_DEBUG) {
+    process.stderr.write(
+      `[cache-resolver] '${dossierName}' bypassing resolution cache (fresh=${opts.fresh ?? false}, ttl=${ttl}s)\n`
+    );
+  }
+
+  let registryError: Error | null = null;
+  try {
+    const { result, errors } = await multiRegistryGetDossier(dossierName);
+    if (result?.version) {
+      writeResolution(dossierName, {
+        resolved_version: result.version,
+        resolved_at: new Date().toISOString(),
+        source_registry: result._registry,
+      });
+      if (process.env.DOSSIER_DEBUG) {
+        process.stderr.write(
+          `[cache-resolver] '${dossierName}' resolved from registry '${result._registry}' to version ${result.version}\n`
+        );
+      }
+      return { version: result.version, source: 'registry', registry: result._registry };
+    }
+    const message = errors.length > 0 ? errors.map((e) => e.error).join('; ') : 'no result';
+    registryError = new Error(message);
+  } catch (err) {
+    registryError = err as Error;
+  }
+
+  // Registry unreachable — try stale fallback.
+  const fallback = highestCachedSemver(dossierName);
+  const lastKnown = readResolution(dossierName);
+  if (fallback) {
+    const ageHint = lastKnown
+      ? ` (last successful check: ${formatAge(Date.now() - new Date(lastKnown.resolved_at).getTime())})`
+      : ' (no record of last successful check)';
+    const warning =
+      `Registry unreachable — falling back to cached ${dossierName}@${fallback}${ageHint}.\n` +
+      `   Cause: ${registryError?.message ?? 'unknown'}\n` +
+      `   This may be stale. To force a fresh check once registry is reachable, re-run with --fresh ` +
+      `(or --max-age 0).`;
+    process.stderr.write(`⚠️  ${warning}\n`);
+    return {
+      version: fallback,
+      source: 'stale-cache',
+      registry: lastKnown?.source_registry,
+      warning,
+    };
+  }
+
+  throw new Error(
+    `Failed to resolve ${dossierName}: registry unreachable and no cached version available.\n` +
+      `   Underlying error: ${registryError?.message ?? 'unknown'}\n` +
+      `   Try:\n` +
+      `     1. Check network connectivity\n` +
+      `     2. Verify registry is configured:  dossier config --list-registries\n` +
+      `     3. Pin a known-good version:       dossier run ${dossierName}@<version>\n` +
+      `     4. Re-run with --fresh once the registry is reachable.`
+  );
+}
+
+/** Exposed for the `cache resolutions` subcommand. */
+export function listResolutions(): Array<{ name: string; record: ResolutionRecord }> {
+  if (!fs.existsSync(RESOLUTION_DIR)) return [];
+
+  const entries: Array<{ name: string; record: ResolutionRecord }> = [];
+
+  function walk(dir: string, prefix: string): void {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full, prefix ? `${prefix}/${entry.name}` : entry.name);
+      } else if (entry.name.endsWith('.json')) {
+        try {
+          const record = JSON.parse(fs.readFileSync(full, 'utf8')) as ResolutionRecord;
+          if (record.resolved_version && record.resolved_at) {
+            const name = entry.name.replace(/\.json$/, '');
+            entries.push({ name: prefix ? `${prefix}/${name}` : name, record });
+          }
+        } catch {
+          // skip invalid entries
+        }
+      }
+    }
+  }
+
+  walk(RESOLUTION_DIR, '');
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  return entries;
+}
+
+/** Exposed for tests and the `cache clean` flow — remove all resolution files. */
+export function clearResolutions(): void {
+  if (fs.existsSync(RESOLUTION_DIR)) {
+    fs.rmSync(RESOLUTION_DIR, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Path to a cached dossier's content file (without checking existence).
+ * Centralises the `<cache>/<name>/<version>.ds.md` layout used by
+ * run/create/install-skill/pull so layout changes happen in one place.
+ */
+export function cachedContentPath(dossierName: string, version: string): string {
+  return path.join(safeDossierPath(CACHE_DIR, dossierName), `${version}.ds.md`);
+}
+
+/**
+ * Return cached dossier content as a string, or null if not cached.
+ * Single source of truth for the `existsSync(contentFile) ? read : miss`
+ * block that previously lived in run.ts, create.ts, and install-skill.ts.
+ */
+export function readCachedContent(dossierName: string, version: string): string | null {
+  const file = cachedContentPath(dossierName, version);
+  if (!fs.existsSync(file)) return null;
+  try {
+    return fs.readFileSync(file, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write a dossier's content + .meta.json to the cache.
+ *
+ * The .meta.json shape (`cached_at` + `version` + `source_registry`) is the
+ * one read by `cache list` / `cache clean` and was previously duplicated
+ * verbatim in run.ts, create.ts, install-skill.ts, and pull.ts.
+ *
+ * Best-effort by default (errors swallowed, matching create.ts/install-skill.ts).
+ * Pass `throwOnError: true` for callers that want to surface write failures
+ * (pull.ts wants this — a failed download cache write is a hard failure).
+ */
+export function writeCachedContent(
+  dossierName: string,
+  version: string,
+  content: string,
+  sourceRegistry: string | undefined,
+  opts: { throwOnError?: boolean } = {}
+): void {
+  const dir = safeDossierPath(CACHE_DIR, dossierName);
+  try {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(dir, `${version}.ds.md`), content, 'utf8');
+    fs.writeFileSync(
+      path.join(dir, `${version}.meta.json`),
+      JSON.stringify(
+        {
+          cached_at: new Date().toISOString(),
+          version,
+          source_registry: sourceRegistry,
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+  } catch (err) {
+    if (opts.throwOnError) throw err;
+    // best-effort: swallow (matches prior create.ts / install-skill.ts behaviour)
+  }
+}
+
+/**
+ * Parse a `--max-age <seconds>` CLI option into a number, or return undefined
+ * when unset. Throws when the value is provided but not a valid number.
+ * Used by run/create/install-skill which all expose the same flag.
+ */
+export function parseMaxAgeOption(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (Number.isNaN(n)) {
+    throw new Error(`--max-age must be a number (got "${raw}")`);
+  }
+  return n;
+}

--- a/cli/src/commands/cache.ts
+++ b/cli/src/commands/cache.ts
@@ -3,10 +3,95 @@ import os from 'node:os';
 import path from 'node:path';
 import readline from 'node:readline';
 import type { Command } from 'commander';
+import { DEFAULT_RESOLUTION_TTL_SECONDS, listResolutions } from '../cache-resolver';
+import { getConfig } from '../config';
 import { safeDossierPath } from '../helpers';
+
+function formatAge(ageMs: number): string {
+  const seconds = Math.round(ageMs / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.round(hours / 24);
+  return `${days}d`;
+}
 
 export function registerCacheCommand(program: Command): void {
   const cacheCmd = program.command('cache').description('Manage local dossier cache');
+
+  // cache resolutions
+  cacheCmd
+    .command('resolutions')
+    .description('Show cached versionless → version resolutions (with age and TTL status)')
+    .option('--json', 'Output as JSON')
+    .action((options: { json?: boolean }) => {
+      const entries = listResolutions();
+
+      // Effective TTL from config (same precedence cache-resolver uses)
+      const configuredTtl = getConfig('cache.resolutionTtlSeconds');
+      const ttlSeconds =
+        typeof configuredTtl === 'number' && Number.isFinite(configuredTtl) && configuredTtl >= 0
+          ? configuredTtl
+          : DEFAULT_RESOLUTION_TTL_SECONDS;
+
+      const now = Date.now();
+      const enriched = entries.map((e) => {
+        const resolvedAtMs = new Date(e.record.resolved_at).getTime();
+        const ageMs = Number.isFinite(resolvedAtMs) ? now - resolvedAtMs : null;
+        const expired = ageMs !== null && ttlSeconds > 0 ? ageMs >= ttlSeconds * 1000 : false;
+        return { ...e, ageMs, expired };
+      });
+
+      if (options.json) {
+        console.log(
+          JSON.stringify(
+            {
+              ttl_seconds: ttlSeconds,
+              entries: enriched.map((e) => ({
+                name: e.name,
+                resolved_version: e.record.resolved_version,
+                resolved_at: e.record.resolved_at,
+                source_registry: e.record.source_registry,
+                age_seconds: e.ageMs !== null ? Math.round(e.ageMs / 1000) : null,
+                expired: e.expired,
+              })),
+            },
+            null,
+            2
+          )
+        );
+        process.exit(0);
+      }
+
+      if (entries.length === 0) {
+        console.log('\nNo version resolutions cached.');
+        console.log(`(TTL: ${ttlSeconds}s — set via cache.resolutionTtlSeconds or --max-age)\n`);
+        process.exit(0);
+      }
+
+      console.log(`\n🔖 Cached resolutions (${entries.length}), TTL: ${ttlSeconds}s:\n`);
+      console.log(
+        `  ${'NAME'.padEnd(40)} ${'VERSION'.padEnd(10)} ${'REGISTRY'.padEnd(10)} ${'AGE'.padEnd(8)} STATUS`
+      );
+      console.log(
+        `  ${'─'.repeat(40)} ${'─'.repeat(10)} ${'─'.repeat(10)} ${'─'.repeat(8)} ${'─'.repeat(8)}`
+      );
+      for (const e of enriched) {
+        const registry = e.record.source_registry || '-';
+        const age = e.ageMs !== null ? formatAge(e.ageMs) : '?';
+        const status = e.ageMs === null ? 'invalid' : e.expired ? 'EXPIRED' : 'fresh';
+        console.log(
+          `  ${e.name.padEnd(40)} ${e.record.resolved_version.padEnd(10)} ${registry.padEnd(10)} ${age.padEnd(8)} ${status}`
+        );
+      }
+      console.log('');
+      console.log(
+        '  Tip: EXPIRED entries are re-resolved on next run. Use --max-age 0 or --fresh to force a recheck.\n'
+      );
+      process.exit(0);
+    });
 
   // cache list
   cacheCmd

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -3,9 +3,15 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { Command } from 'commander';
+import {
+  parseMaxAgeOption,
+  readCachedContent,
+  resolveCachedVersion,
+  writeCachedContent,
+} from '../cache-resolver';
 import * as config from '../config';
 import { detectLlm, printRegistryErrors } from '../helpers';
-import { multiRegistryGetContent, multiRegistryGetDossier } from '../multi-registry';
+import { multiRegistryGetContent } from '../multi-registry';
 import { parseNameVersion } from '../registry-client';
 
 const DEFAULT_CREATE_TEMPLATE = 'imboard-ai/meta/create-dossier-and-skill';
@@ -22,6 +28,11 @@ export function registerCreateCommand(program: Command): void {
     .option('--category <category>', 'Category (devops, data-science, development, etc.)')
     .option('--tags <tags>', 'Comma-separated tags')
     .option('--llm <name>', 'LLM to use (claude-code, auto)', 'auto')
+    .option(
+      '--max-age <seconds>',
+      'Max age of cached version resolution before re-checking the registry (default: 300, 0 = always check)'
+    )
+    .option('--fresh', 'Skip cache, fetch fresh from registry')
     .action(
       async (
         file: string | undefined,
@@ -33,6 +44,8 @@ export function registerCreateCommand(program: Command): void {
           category?: string;
           tags?: string;
           llm?: string;
+          maxAge?: string;
+          fresh?: boolean;
         }
       ) => {
         try {
@@ -50,39 +63,40 @@ export function registerCreateCommand(program: Command): void {
             process.exit(2);
           }
 
-          // Fetch template from registry
-          const [dossierName, version] = parseNameVersion(options.template);
-          let metaDossierContent = '';
+          // Fetch template from registry (with TTL'd version resolution for versionless names)
+          const [dossierName, pinnedVersion] = parseNameVersion(options.template);
 
-          // Check cache first
-          const cacheDir = path.join(os.homedir(), '.dossier', 'cache');
-          const dossierCacheDir = path.join(cacheDir, ...dossierName.split('/'));
-          let cached = false;
-
-          if (fs.existsSync(dossierCacheDir)) {
-            const metaFiles = fs
-              .readdirSync(dossierCacheDir)
-              .filter((f: string) => f.endsWith('.meta.json'));
-            for (const mf of metaFiles) {
-              const ver = mf.replace('.meta.json', '');
-              if (version && ver !== version) continue;
-              const contentFile = path.join(dossierCacheDir, `${ver}.ds.md`);
-              if (fs.existsSync(contentFile)) {
-                metaDossierContent = fs.readFileSync(contentFile, 'utf8');
-                cached = true;
-                console.log(`📦 Using cached template: ${dossierName}@${ver}\n`);
-                break;
-              }
+          let resolvedVersion = pinnedVersion;
+          if (!pinnedVersion) {
+            let maxAgeSeconds: number | undefined;
+            try {
+              maxAgeSeconds = parseMaxAgeOption(options.maxAge);
+            } catch (err: unknown) {
+              console.error(`\n❌ ${(err as Error).message}\n`);
+              process.exit(2);
+            }
+            try {
+              const resolved = await resolveCachedVersion(dossierName, {
+                fresh: options.fresh,
+                maxAgeSeconds,
+              });
+              resolvedVersion = resolved.version;
+            } catch (err: unknown) {
+              console.error(`\n❌ ${(err as Error).message}\n`);
+              process.exit(2);
             }
           }
 
-          if (!cached) {
+          let metaDossierContent = '';
+          const cachedContent = !options.fresh
+            ? readCachedContent(dossierName, resolvedVersion as string)
+            : null;
+
+          if (cachedContent !== null) {
+            metaDossierContent = cachedContent;
+            console.log(`📦 Using cached template: ${dossierName}@${resolvedVersion}\n`);
+          } else {
             try {
-              let resolvedVersion = version;
-              if (!resolvedVersion) {
-                const { result: meta } = await multiRegistryGetDossier(dossierName);
-                resolvedVersion = meta?.version || 'latest';
-              }
               const { result, errors: contentErrors } = await multiRegistryGetContent(
                 dossierName,
                 resolvedVersion
@@ -97,6 +111,14 @@ export function registerCreateCommand(program: Command): void {
                 process.exit(2);
               }
               metaDossierContent = result.content;
+              if (!options.fresh) {
+                writeCachedContent(
+                  dossierName,
+                  resolvedVersion as string,
+                  result.content,
+                  result._registry
+                );
+              }
               console.log(`📥 Fetched template: ${dossierName}@${resolvedVersion}\n`);
             } catch (err: unknown) {
               const e = err as { statusCode?: number; message: string };

--- a/cli/src/commands/install-skill.ts
+++ b/cli/src/commands/install-skill.ts
@@ -3,19 +3,14 @@ import os from 'node:os';
 import path from 'node:path';
 import { parseDossierContent } from '@ai-dossier/core';
 import type { Command } from 'commander';
-import { safeDossierPath } from '../helpers';
-import { multiRegistryGetContent, multiRegistryGetDossier } from '../multi-registry';
+import {
+  parseMaxAgeOption,
+  readCachedContent,
+  resolveCachedVersion,
+  writeCachedContent,
+} from '../cache-resolver';
+import { multiRegistryGetContent } from '../multi-registry';
 import { parseNameVersion } from '../registry-client';
-
-function compareSemver(a: string, b: string): number {
-  const pa = a.split('.').map(Number);
-  const pb = b.split('.').map(Number);
-  for (let i = 0; i < 3; i++) {
-    const diff = (pa[i] || 0) - (pb[i] || 0);
-    if (diff !== 0) return diff;
-  }
-  return 0;
-}
 
 export function registerInstallSkillCommand(program: Command): void {
   program
@@ -23,7 +18,11 @@ export function registerInstallSkillCommand(program: Command): void {
     .description('Install a registry dossier as a Claude Code skill')
     .argument('[name]', 'Dossier name to install (use name@version for specific version)')
     .option('--force', 'Overwrite if skill already exists')
-    .option('--fresh', 'Bypass cache and fetch from registry')
+    .option('--fresh', 'Skip cache, fetch fresh from registry')
+    .option(
+      '--max-age <seconds>',
+      'Max age of cached version resolution before re-checking the registry (default: 300, 0 = always check)'
+    )
     .option('--list', 'List currently installed skills')
     .option('--remove <skill>', 'Remove an installed skill')
     .option('--json', 'Output as JSON')
@@ -33,6 +32,7 @@ export function registerInstallSkillCommand(program: Command): void {
         options: {
           force?: boolean;
           fresh?: boolean;
+          maxAge?: string;
           list?: boolean;
           remove?: string;
           json?: boolean;
@@ -109,52 +109,30 @@ export function registerInstallSkillCommand(program: Command): void {
         }
 
         try {
-          const cacheDir = path.join(os.homedir(), '.dossier', 'cache');
-          let content: string | null = null;
           let resolvedVersion = version;
+
+          // For versionless installs: resolve which version to use via the TTL'd resolver.
+          if (!version) {
+            const maxAgeSeconds = parseMaxAgeOption(options.maxAge);
+            const resolved = await resolveCachedVersion(dossierName, {
+              fresh: options.fresh,
+              maxAgeSeconds,
+            });
+            resolvedVersion = resolved.version;
+          }
+
+          let content: string | null = null;
           let fromCache = false;
 
           if (!options.fresh) {
-            if (!version) {
-              const dossierCacheDir = safeDossierPath(cacheDir, dossierName);
-              if (fs.existsSync(dossierCacheDir)) {
-                const metaFiles = fs
-                  .readdirSync(dossierCacheDir)
-                  .filter((f) => f.endsWith('.meta.json'));
-                if (metaFiles.length > 0) {
-                  const versions = metaFiles
-                    .map((f) => f.replace('.meta.json', ''))
-                    .sort(compareSemver);
-                  const ver = versions[versions.length - 1];
-                  const contentFile = path.join(dossierCacheDir, `${ver}.ds.md`);
-                  if (fs.existsSync(contentFile)) {
-                    content = fs.readFileSync(contentFile, 'utf8');
-                    resolvedVersion = ver;
-                    fromCache = true;
-                  }
-                }
-              }
-            } else {
-              const contentFile = path.join(
-                safeDossierPath(cacheDir, dossierName),
-                `${version}.ds.md`
-              );
-              if (fs.existsSync(contentFile)) {
-                content = fs.readFileSync(contentFile, 'utf8');
-                resolvedVersion = version;
-                fromCache = true;
-              }
+            const cached = readCachedContent(dossierName, resolvedVersion as string);
+            if (cached !== null) {
+              content = cached;
+              fromCache = true;
             }
           }
 
           if (!content) {
-            if (!resolvedVersion) {
-              const { result: meta } = await multiRegistryGetDossier(dossierName);
-              if (!meta) {
-                throw { statusCode: 404, message: `Not found: ${dossierName}` };
-              }
-              resolvedVersion = meta.version || 'latest';
-            }
             const { result: fetchedContent } = await multiRegistryGetContent(
               dossierName,
               resolvedVersion
@@ -163,6 +141,15 @@ export function registerInstallSkillCommand(program: Command): void {
               throw { statusCode: 404, message: `Not found: ${dossierName}` };
             }
             content = fetchedContent.content;
+            // Write to cache so future installs hit it.
+            if (!options.fresh) {
+              writeCachedContent(
+                dossierName,
+                resolvedVersion as string,
+                content,
+                fetchedContent._registry
+              );
+            }
           }
 
           fs.mkdirSync(skillDir, { recursive: true });

--- a/cli/src/commands/pull.ts
+++ b/cli/src/commands/pull.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { sha256Hex } from '@ai-dossier/core';
 import type { Command } from 'commander';
+import { cachedContentPath, writeCachedContent } from '../cache-resolver';
 import { printRegistryErrors, safeDossierPath } from '../helpers';
 import { multiRegistryGetContent, multiRegistryGetDossier } from '../multi-registry';
 import { parseNameVersion } from '../registry-client';
@@ -36,7 +37,7 @@ export function registerPullCommand(program: Command): void {
           }
 
           const dossierDir = safeDossierPath(cacheDir, dossierName);
-          const contentFile = path.join(dossierDir, `${version}.ds.md`);
+          const contentFile = cachedContentPath(dossierName, version);
           const metaFile = path.join(dossierDir, `${version}.meta.json`);
 
           if (!options.force && fs.existsSync(contentFile) && fs.existsSync(metaFile)) {
@@ -68,21 +69,9 @@ export function registerPullCommand(program: Command): void {
           }
 
           try {
-            fs.mkdirSync(dossierDir, { recursive: true, mode: 0o700 });
-            fs.writeFileSync(contentFile, content, 'utf8');
-            fs.writeFileSync(
-              metaFile,
-              JSON.stringify(
-                {
-                  cached_at: new Date().toISOString(),
-                  version,
-                  source_registry: result._registry,
-                },
-                null,
-                2
-              ),
-              'utf8'
-            );
+            writeCachedContent(dossierName, version, content, result._registry, {
+              throwOnError: true,
+            });
           } catch (writeErr: unknown) {
             console.error(
               `❌ ${dossierName}@${version}: failed to write cache files to '${dossierDir}': ${(writeErr as Error).message}`

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -4,34 +4,24 @@ import os from 'node:os';
 import path from 'node:path';
 import { type DossierFrontmatter, parseDossierContent } from '@ai-dossier/core';
 import type { Command } from 'commander';
+import {
+  cachedContentPath,
+  parseMaxAgeOption,
+  type ResolutionSource,
+  resolveCachedVersion,
+  writeCachedContent,
+} from '../cache-resolver';
 import * as config from '../config';
 import {
   buildLlmCommand,
   detectLlm,
   downloadUrlToTempFile,
-  printRegistryErrors,
   printRegistryNotFoundError,
   runVerification,
-  safeDossierPath,
 } from '../helpers';
-import { multiRegistryGetContent, multiRegistryGetDossier } from '../multi-registry';
+import { multiRegistryGetContent } from '../multi-registry';
 import { parseNameVersion } from '../registry-client';
 import { appendRunLog } from '../run-log';
-
-/**
- * Check if a newer version exists in the registry.
- * Returns the latest version string, or null if no update / error / timeout.
- */
-async function checkForUpdate(dossierName: string, cachedVersion: string): Promise<string | null> {
-  const timeout = new Promise<null>((resolve) => setTimeout(() => resolve(null), 3000));
-  const check = multiRegistryGetDossier(dossierName).then(({ result }) => {
-    if (result?.version && result.version !== cachedVersion) {
-      return result.version;
-    }
-    return null;
-  });
-  return Promise.race([check, timeout]);
-}
 
 export function registerRunCommand(program: Command): void {
   program
@@ -47,6 +37,10 @@ export function registerRunCommand(program: Command): void {
     .option('--no-prompt', "Don't ask for confirmation")
     .option('--fresh', 'Skip cache, fetch fresh from registry')
     .option('--pull', 'Update cache before running')
+    .option(
+      '--max-age <seconds>',
+      'Max age of cached version resolution before re-checking the registry (default: 300, 0 = always check)'
+    )
     .option('--skip-checksum', 'Skip checksum verification (DANGEROUS)')
     .option('--skip-all-checks', 'Skip ALL verifications (VERY DANGEROUS)')
     .action(
@@ -60,6 +54,7 @@ export function registerRunCommand(program: Command): void {
           noPrompt?: boolean;
           fresh?: boolean;
           pull?: boolean;
+          maxAge?: string;
           skipChecksum?: boolean;
           skipAllChecks?: boolean;
         }
@@ -77,86 +72,75 @@ export function registerRunCommand(program: Command): void {
           resolvedVersion: 'unknown',
           source: 'local' as 'cache' | 'registry' | 'local' | 'url',
           registry: undefined as string | undefined,
-          updateAvailable: undefined as string | undefined,
+          resolutionSource: undefined as
+            | 'cache'
+            | 'registry'
+            | 'stale-cache'
+            | 'pinned'
+            | undefined,
         };
-
-        let updateCheckPromise: Promise<string | null> | null = null;
 
         // If not a URL or local file, treat as a registry name
         if (!isUrl && !isLocalFile) {
-          const [dossierName, version] = parseNameVersion(file);
+          const [dossierName, pinnedVersion] = parseNameVersion(file);
 
-          const cacheDir = path.join(os.homedir(), '.dossier', 'cache');
-          let cached = false;
+          // resolvedVersion starts as pinnedVersion (string | null); when null, the
+          // resolver below populates it. After that block it's guaranteed non-null.
+          let resolvedVersion: string | null = pinnedVersion;
+          let resolvedRegistry: string | undefined;
+          // `'pinned'` is added locally for name@version requests that bypass the resolver.
+          let resolutionSource: ResolutionSource | 'pinned' = 'pinned';
 
-          if (!options.fresh) {
-            const dossierCacheDir = safeDossierPath(cacheDir, dossierName);
-            if (fs.existsSync(dossierCacheDir)) {
-              const metaFiles = fs
-                .readdirSync(dossierCacheDir)
-                .filter((f: string) => f.endsWith('.meta.json'));
-              for (const mf of metaFiles) {
-                const ver = mf.replace('.meta.json', '');
-                if (version && ver !== version) continue;
-                const contentFile = path.join(dossierCacheDir, `${ver}.ds.md`);
-                if (fs.existsSync(contentFile)) {
-                  if (!options.pull) {
-                    resolvedFile = contentFile;
-                    cached = true;
-                    runContext.source = 'cache';
-                    runContext.resolvedVersion = ver;
-
-                    // Check meta for previously-detected update
-                    const metaPath = path.join(dossierCacheDir, mf);
-                    try {
-                      const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
-                      if (meta.latest_known_version && meta.latest_known_version !== ver) {
-                        runContext.updateAvailable = meta.latest_known_version;
-                      }
-                      const checkedAt = meta.latest_checked_at
-                        ? new Date(meta.latest_checked_at).getTime()
-                        : 0;
-                      const oneHourAgo = Date.now() - 3600000;
-                      if (checkedAt < oneHourAgo) {
-                        updateCheckPromise = checkForUpdate(dossierName, ver)
-                          .then((latestVer) => {
-                            try {
-                              meta.latest_known_version = latestVer || ver;
-                              meta.latest_checked_at = new Date().toISOString();
-                              fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), 'utf8');
-                            } catch {
-                              /* ignore meta write errors */
-                            }
-                            if (latestVer) runContext.updateAvailable = latestVer;
-                            return latestVer;
-                          })
-                          .catch(() => null);
-                      }
-                    } catch {
-                      // Meta read failed — start a fresh check
-                      updateCheckPromise = checkForUpdate(dossierName, ver).catch(() => null);
-                    }
-
-                    log(`📦 Using cached: ${dossierName}@${ver}\n`);
-                    break;
-                  }
-                }
-              }
+          // For versionless requests: resolve which version to use via the TTL'd resolver.
+          // Pinned versions skip resolution — they're content-addressable.
+          if (!pinnedVersion) {
+            let maxAgeSeconds: number | undefined;
+            try {
+              maxAgeSeconds = parseMaxAgeOption(options.maxAge);
+            } catch (err: unknown) {
+              console.error(`\n❌ ${(err as Error).message}\n`);
+              process.exit(1);
+            }
+            try {
+              const resolved = await resolveCachedVersion(dossierName, {
+                fresh: options.fresh || options.pull,
+                maxAgeSeconds,
+              });
+              resolvedVersion = resolved.version;
+              resolvedRegistry = resolved.registry;
+              resolutionSource = resolved.source;
+            } catch (err: unknown) {
+              console.error(`\n❌ ${(err as Error).message}\n`);
+              process.exit(1);
             }
           }
 
-          if (!cached) {
+          const contentFile = cachedContentPath(dossierName, resolvedVersion as string);
+          const haveCachedContent = !options.fresh && !options.pull && fs.existsSync(contentFile);
+
+          runContext.resolutionSource = resolutionSource;
+
+          if (haveCachedContent) {
+            resolvedFile = contentFile;
+            runContext.source = 'cache';
+            runContext.resolvedVersion = resolvedVersion as string;
+            runContext.registry = resolvedRegistry;
+            // Make the resolution path explicit so users can tell:
+            //   - "cache hit, fresh resolution" (resolver hit registry, content already on disk)
+            //   - "cache hit, TTL'd resolution" (resolver served from resolution cache)
+            //   - "cache hit, STALE resolution" (registry was unreachable; resolver fell back)
+            //   - "pinned version" (no resolution involved)
+            let suffix = '';
+            if (resolutionSource === 'stale-cache') {
+              suffix = ' (version resolution is STALE — registry was unreachable)';
+            } else if (resolutionSource === 'cache') {
+              suffix = ' (version resolution from TTL cache; pass --max-age 0 to recheck)';
+            } else if (resolutionSource === 'registry') {
+              suffix = ' (version freshly resolved from registry)';
+            }
+            log(`📦 Using cached: ${dossierName}@${resolvedVersion}${suffix}\n`);
+          } else {
             try {
-              let resolvedVersion = version;
-              if (!resolvedVersion) {
-                const { result: meta, errors: metaErrors } =
-                  await multiRegistryGetDossier(dossierName);
-                if (!meta) {
-                  printRegistryNotFoundError(file, metaErrors);
-                  process.exit(1);
-                }
-                resolvedVersion = meta.version || 'latest';
-              }
               const { result, errors: contentErrors } = await multiRegistryGetContent(
                 dossierName,
                 resolvedVersion
@@ -167,37 +151,32 @@ export function registerRunCommand(program: Command): void {
               }
 
               if (!options.fresh) {
-                const dossierCacheDir = safeDossierPath(cacheDir, dossierName);
-                fs.mkdirSync(dossierCacheDir, { recursive: true, mode: 0o700 });
-                const contentFile = path.join(dossierCacheDir, `${resolvedVersion}.ds.md`);
-                fs.writeFileSync(contentFile, result.content, 'utf8');
-                fs.writeFileSync(
-                  path.join(dossierCacheDir, `${resolvedVersion}.meta.json`),
-                  JSON.stringify(
-                    {
-                      cached_at: new Date().toISOString(),
-                      version: resolvedVersion,
-                      source_registry: result._registry,
-                    },
-                    null,
-                    2
-                  ),
-                  'utf8'
+                writeCachedContent(
+                  dossierName,
+                  resolvedVersion as string,
+                  result.content,
+                  result._registry,
+                  { throwOnError: true }
                 );
                 resolvedFile = contentFile;
-                runContext.source = 'registry';
-                runContext.resolvedVersion = resolvedVersion || 'unknown';
-                runContext.registry = result._registry;
-                log(`📥 Fetched: ${dossierName}@${resolvedVersion}\n`);
+                // "Refreshed" earlier was misleading: resolver served from cache, but the *content*
+                // was newly downloaded. Be explicit about both axes.
+                if (resolutionSource === 'cache') {
+                  log(
+                    `📥 Fetched content for ${dossierName}@${resolvedVersion} (version resolution from TTL cache)\n`
+                  );
+                } else {
+                  log(`📥 Fetched: ${dossierName}@${resolvedVersion}\n`);
+                }
               } else {
                 const tmpFile = path.join(os.tmpdir(), `dossier-${Date.now()}.ds.md`);
                 fs.writeFileSync(tmpFile, result.content, 'utf8');
                 resolvedFile = tmpFile;
-                runContext.source = 'registry';
-                runContext.resolvedVersion = resolvedVersion || 'unknown';
-                runContext.registry = result._registry;
                 log(`📥 Fetched: ${dossierName}@${resolvedVersion} (not cached)\n`);
               }
+              runContext.source = 'registry';
+              runContext.resolvedVersion = resolvedVersion as string;
+              runContext.registry = result._registry;
             } catch (err: unknown) {
               const e = err as { statusCode?: number; message: string };
               if (e.statusCode === 404) {
@@ -271,17 +250,6 @@ export function registerRunCommand(program: Command): void {
 
         // Nested session detection
         if (process.env.CLAUDE_CODE === '1' || process.env.CLAUDECODE === '1') {
-          // Wait for update check before showing warning
-          if (updateCheckPromise) {
-            await updateCheckPromise.catch(() => null);
-          }
-          if (runContext.updateAvailable) {
-            console.error(
-              `\n⚠️  Update available: ${file}@${runContext.updateAvailable} (cached: ${runContext.resolvedVersion})`
-            );
-            console.error('   Run with --pull to update\n');
-          }
-
           console.error('ℹ️  Running inside Claude Code — outputting dossier content\n');
 
           const llmOption =
@@ -292,29 +260,18 @@ export function registerRunCommand(program: Command): void {
             resolved_version: runContext.resolvedVersion,
             source: runContext.source,
             registry: runContext.registry,
+            resolution_source: runContext.resolutionSource,
             verification: 'nested-skip',
             llm: llmOption,
             user: `${process.env.USER || 'unknown'}@${os.hostname()}`,
             cwd: process.cwd(),
             nested: true,
-            update_available: runContext.updateAvailable,
           });
 
           process.stdout.write(dossierContent);
           fs.unlinkSync(secureTmpFile);
           fs.rmdirSync(secureTmpDir);
           process.exit(0);
-        }
-
-        // Wait for update check before verification
-        if (updateCheckPromise) {
-          await updateCheckPromise.catch(() => null);
-        }
-        if (runContext.updateAvailable) {
-          console.log(
-            `\n⚠️  Update available: ${file}@${runContext.updateAvailable} (cached: ${runContext.resolvedVersion})`
-          );
-          console.log('   Run with --pull to update\n');
         }
 
         const result = await runVerification(resolvedFile, options);
@@ -330,12 +287,12 @@ export function registerRunCommand(program: Command): void {
             resolved_version: runContext.resolvedVersion,
             source: runContext.source,
             registry: runContext.registry,
+            resolution_source: runContext.resolutionSource,
             verification: 'failed',
             llm: llmOption,
             user: `${process.env.USER || 'unknown'}@${os.hostname()}`,
             cwd: process.cwd(),
             nested: false,
-            update_available: runContext.updateAvailable,
           });
           fs.unlinkSync(secureTmpFile);
           fs.rmdirSync(secureTmpDir);
@@ -348,12 +305,12 @@ export function registerRunCommand(program: Command): void {
           resolved_version: runContext.resolvedVersion,
           source: runContext.source,
           registry: runContext.registry,
+          resolution_source: runContext.resolutionSource,
           verification: options.skipAllChecks ? 'skipped' : 'passed',
           llm: llmOption,
           user: `${process.env.USER || 'unknown'}@${os.hostname()}`,
           cwd: process.cwd(),
           nested: false,
-          update_available: runContext.updateAvailable,
         });
 
         console.log('📝 Audit Log:');

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -49,6 +49,7 @@ const DEFAULT_CONFIG: DossierConfig = {
   defaultLlm: 'auto',
   theme: 'auto',
   auditLog: true,
+  'cache.resolutionTtlSeconds': 300,
 };
 
 /**

--- a/cli/src/run-log.ts
+++ b/cli/src/run-log.ts
@@ -13,11 +13,26 @@ export interface RunLogEntry {
   resolved_version: string;
   source: 'cache' | 'registry' | 'local' | 'url';
   registry?: string;
+  /**
+   * How the version was resolved (only meaningful for registry sources):
+   *   - 'pinned'      — caller passed name@version explicitly
+   *   - 'registry'    — resolver called the registry and got a fresh version
+   *   - 'cache'       — resolver served from TTL'd resolution cache (no registry call)
+   *   - 'stale-cache' — registry was unreachable; fell back to highest cached semver
+   * Useful for postmortems answering "did this run hit a stale resolution that
+   * masked a registry outage?". Absent for local files and URLs.
+   */
+  resolution_source?: 'pinned' | 'registry' | 'cache' | 'stale-cache';
   verification: 'passed' | 'failed' | 'skipped' | 'nested-skip';
   llm: string;
   user: string;
   cwd: string;
   nested: boolean;
+  /**
+   * Deprecated: written by the pre-#401 update-check machinery. Retained on the
+   * interface so `dossier history` can still display this field when reading
+   * older runs.jsonl entries. Not written by new runs.
+   */
   update_available?: string;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,10 +27,10 @@
     },
     "cli": {
       "name": "@ai-dossier/cli",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@ai-dossier/core": "^1.3.3",
+        "@ai-dossier/core": "^1.3.4",
         "commander": "^12.1.0"
       },
       "bin": {
@@ -48,7 +48,7 @@
     },
     "mcp-server": {
       "name": "@ai-dossier/mcp-server",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ai-dossier/core": "^1.2.0",
@@ -6611,7 +6611,7 @@
     },
     "packages/core": {
       "name": "@ai-dossier/core",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.927.0",


### PR DESCRIPTION
## Summary

- New `cli/src/cache-resolver.ts` puts a TTL on **version resolution** (the only thing that ages) instead of on content bytes. Default 300s, overridable via `cache.resolutionTtlSeconds` config and per-call `--max-age <seconds>`.
- Pinned `name@1.2.3` skips the resolver entirely — content is immutable and content-addressable.
- Registry unreachable falls back to highest-cached semver with a loud stderr warning naming the underlying error and three concrete remediations (no more silent staleness).
- Rewires `run`, `create`, `install-skill` through the resolver and shares extracted helpers (`writeCachedContent`, `cachedContentPath`, `readCachedContent`, `parseMaxAgeOption`) with `pull`.
- New `ai-dossier cache resolutions` subcommand shows age / TTL status. `DOSSIER_DEBUG=1` traces every resolver decision. `RunLogEntry.resolution_source` recorded for postmortems.
- Hardening: intermediate org-scoped dirs in `~/.dossier/cache/.resolution/` chmod'd to `0o700`; `lstat`+`unlink` defends against local symlink swap on resolution-file writes.
- Removes the cosmetic post-run "Update available: run --pull" warning — proactive resolution replaces it.

Closes #401

## Test plan

- [x] New `cache-resolver.test.ts` covers fresh / cached / past-TTL / fresh flag / max-age=0 / registry-unreachable fallback / hard-fail-no-cache / pinned paths.
- [x] Existing `run.test.ts` updated with a regression test: cache has v1.0.0, registry returns v1.1.0, versionless run executes v1.1.0 (would have failed before this PR).
- [x] `make test` — all 471 CLI tests + 189 registry tests + others pass across 89 test files.
- [x] `npx biome check .` clean on changed files (pre-existing mcp-server warnings unchanged).
- [x] `make build-all` succeeds.
- [ ] Manual E2E: publish a dossier from machine A, `ai-dossier run <name>` on machine B → caches v1; bump version on A and republish; rerun on B within 5min → still v1; pass `--max-age 0` or wait 5min → resolves to v2 automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)