### PR TITLE
docs(claude-code): document the Trigger-Skill Pattern

### DIFF
--- a/docs/guides/claude-code-integration.md
+++ b/docs/guides/claude-code-integration.md
@@ -193,6 +193,67 @@ Claude can access these resources for context:
 
 ---
 
+## Dossiers as Claude Code Skills
+
+A dossier can be installed as a [Claude Code Skill](https://code.claude.com/docs/en/skills) so it's discovered and invoked automatically by natural language, no MCP prompt required:
+
+```bash
+ai-dossier install-skill imboard-ai/git/full-cycle-issue-skill
+```
+
+This writes the dossier to `~/.claude/skills/<name>/SKILL.md`. From then on, Claude routes to it whenever a request matches its `description`.
+
+### The Trigger-Skill Pattern
+
+A **trigger skill** is a thin `SKILL.md` that exists only for **discovery + routing**. When matched, it hands off to an **executable dossier** — the heavy, versioned procedure — loaded at runtime via `ai-dossier run`. The trigger stays tiny so Claude can hold many of them with minimal context cost.
+
+```
+┌─────────────────────────┐        ai-dossier run        ┌──────────────────────────┐
+│  Trigger skill          │ ───────────────────────────▶ │  Executable dossier      │
+│  ~/.claude/skills/…     │   (loaded only when matched)  │  imboard-ai/…@version    │
+│  • name + description   │                               │  • full procedure        │
+│  • flag parsing         │                               │  • all phases / steps    │
+│  • one `run` call       │                               │  • versioned separately  │
+└─────────────────────────┘                               └──────────────────────────┘
+```
+
+**Why split it — the motivation.** Claude Code loads skills by *progressive disclosure*, in three tiers ([docs](https://code.claude.com/docs/en/skills)):
+
+1. **Discovery (always resident):** only each skill's `name` + `description` stay in context (the combined `description`/`when_to_use` is capped at ~1,536 characters). This is the cost you pay for *every* installed skill, all the time.
+2. **Activation (on trigger):** when a request matches, the **entire** `SKILL.md` body loads as a single message and **stays for the rest of the session** — there is no partial loading of one `SKILL.md`.
+3. **Execution (on demand):** content the body *references* (separate files, or — in our case — a registry dossier fetched with `ai-dossier run`) loads only when actually needed.
+
+So a fat, self-contained skill spends its whole body on tier 2 the moment it fires. A **trigger skill pushes the weight down to tier 3**: the always-resident footprint is just the description, and the heavy procedure only enters context when the work actually starts — and can be versioned, signed, and reused independently of the trigger.
+
+**When to use a trigger skill vs. a whole skill:**
+
+| Use a **trigger skill → executable dossier** when… | Keep it a **whole skill** when… |
+| --- | --- |
+| The procedure is multi-stage or long (Anthropic recommends keeping `SKILL.md` **under ~500 lines**) | It's a short, self-contained procedure |
+| The same procedure is reused by several entry points, or one entry point composes several dossiers | It runs top-to-bottom and a run uses most of the body |
+| The procedure is versioned/shared via the registry and you want the trigger decoupled from its content | There's nothing to reuse or version separately |
+
+A whole skill is *not* a context tax just by existing — its body only loads on trigger. So split for **multi-stage orchestration, reuse, or independent versioning**, not merely for size.
+
+### Anatomy of a trigger skill
+
+The trigger does three things: parse flags, call `ai-dossier run`, and tell Claude to follow the output. Everything substantive lives in the executable dossier. Example — `full-cycle-issue-skill` (≈56 lines) fronting the `imboard-ai/git/full-cycle-issue` dossier:
+
+```markdown
+# Full Cycle Issue
+
+## Flags
+- `--base <branch>`: Override the target branch
+
+## Steps
+1. Extract the issue number from the user's request
+2. Run: `ai-dossier run imboard-ai/git/full-cycle-issue --pull`
+3. If `--base` was provided, pass it as the base_branch parameter
+4. Follow ALL phases in the workflow output. Do not skip any.
+```
+
+The 800+ lines of actual workflow live in the dossier, fetched only when the skill fires. Bump the dossier's version and every trigger pointing at it picks up the change on its next run — no skill reinstall needed.
+
 ## Troubleshooting
 
 ### "Signature verification failed"
@@ -275,6 +336,7 @@ First verify, then execute the dossier at ./my-automation.ds.md
 
 ## Related Documentation
 
+- [Claude Code Skills](https://code.claude.com/docs/en/skills) - Official skill authoring + progressive disclosure
 - [Signing Dossiers](./signing-dossiers.md) - How to sign your own dossiers
 - [MCP Server README](../../mcp-server/README.md) - Full MCP server documentation
 - [Security Architecture](../../security/ARCHITECTURE.md) - Security model details
@@ -283,6 +345,10 @@ First verify, then execute the dossier at ./my-automation.ds.md
 ---
 
 ## Changelog
+
+### 2026-06-04
+- Added "Dossiers as Claude Code Skills" section
+- Documented the **Trigger-Skill Pattern** (thin trigger skill → executable dossier) and its motivation via progressive disclosure
 
 ### 2025-11-28
 - Initial guide created


### PR DESCRIPTION
## What

Adds a **Dossiers as Claude Code Skills** section to `docs/guides/claude-code-integration.md`, documenting `install-skill` and the **Trigger-Skill Pattern**: a thin *trigger skill* (discovery + routing + flag-parse + one `ai-dossier run` call) fronting an *executable dossier* — the heavy, versioned procedure loaded at runtime.

## Why

The skill ↔ dossier packaging pattern was undocumented — the guide only covered MCP execution. This makes the **motivation** explicit by grounding it in Claude Code's progressive-disclosure model:

1. **Discovery** — only `name` + `description` are always resident
2. **Activation** — the *full* `SKILL.md` body loads on trigger and stays for the session (no partial loading)
3. **Execution** — referenced content (incl. `ai-dossier run` dossiers) loads on demand

So a trigger skill pushes the heavy procedure from tier 2 down to tier 3, keeping the always-resident footprint to just the description and letting the procedure be versioned/reused independently.

## Contents

- Pattern + ASCII diagram
- Progressive-disclosure motivation (with links to the official Claude Code skills docs)
- A **when to split vs. keep whole** table (split for multi-stage orchestration / reuse / independent versioning — not merely for size)
- The `full-cycle-issue-skill` anatomy as a worked example
- Cross-link to official skills docs + changelog entry

Docs-only; +66 lines, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)