### PR TITLE
fix(cli): strip sha256: prefix before comparing pull digest (#406)

### DIFF
--- a/cli/src/__tests__/commands/pull.test.ts
+++ b/cli/src/__tests__/commands/pull.test.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { sha256Hex } from '@ai-dossier/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { registerPullCommand } from '../../commands/pull';
 import * as multiRegistry from '../../multi-registry';
@@ -141,6 +142,51 @@ describe('pull command', () => {
 
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('downloaded'));
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('not found'));
+  });
+
+  it('should accept a digest carrying the `sha256:` algorithm prefix', async () => {
+    // The registry sends `X-Dossier-Digest: sha256:<hex>`, while sha256Hex
+    // returns the bare hex. A valid download must not be rejected purely over
+    // the prefix label (regression for the "checksum mismatch after download" bug).
+    const content = '# Dossier body';
+    vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
+      result: { version: '1.0.0', _registry: 'public' },
+      errors: [],
+    } as any);
+    vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
+      result: { content, digest: `sha256:${sha256Hex(content)}`, _registry: 'public' },
+      errors: [],
+    });
+    mockedFs.existsSync.mockReturnValue(false);
+
+    const program = createTestProgram();
+    registerPullCommand(program);
+
+    await program.parseAsync(['node', 'dossier', 'pull', 'org/my-dossier']);
+
+    expect(console.error).not.toHaveBeenCalledWith(expect.stringContaining('checksum mismatch'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('downloaded'));
+  });
+
+  it('should still reject a genuinely mismatched digest', async () => {
+    vi.mocked(multiRegistry.multiRegistryGetDossier).mockResolvedValue({
+      result: { version: '1.0.0', _registry: 'public' },
+      errors: [],
+    } as any);
+    vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
+      result: { content: '# Dossier body', digest: 'sha256:deadbeef', _registry: 'public' },
+      errors: [],
+    });
+    mockedFs.existsSync.mockReturnValue(false);
+
+    const program = createTestProgram();
+    registerPullCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'dossier', 'pull', 'org/my-dossier'])
+    ).rejects.toThrow();
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('checksum mismatch'));
   });
 
   it('should pull specific version', async () => {

--- a/cli/src/commands/pull.ts
+++ b/cli/src/commands/pull.ts
@@ -61,7 +61,12 @@ export function registerPullCommand(program: Command): void {
 
           if (digest) {
             const actual = sha256Hex(content);
-            if (actual !== digest) {
+            // The registry sends the digest with an algorithm prefix (e.g.
+            // `sha256:<hex>`); sha256Hex returns the bare hex. Strip the prefix
+            // and compare case-insensitively so a valid download is not rejected
+            // purely because of the `sha256:` label.
+            const expected = digest.replace(/^sha256:/i, '');
+            if (actual.toLowerCase() !== expected.toLowerCase()) {
               console.error(`❌ ${dossierName}@${version}: checksum mismatch after download`);
               failures++;
               continue;


### PR DESCRIPTION
## Problem

`ai-dossier pull` and `run --pull` reject every freshly-pulled dossier with `❌ checksum mismatch after download`, even though the content is valid and `run --fresh` / `checksum --verify` accept the same file. This breaks the documented cache-refresh path (e.g. `fleet-cycle.ds.md` calls `run … --pull`). Fixes #406.

## Root cause

The registry returns the content digest **with an algorithm label**:

```
X-Dossier-Digest: sha256:7db0733f…
```

`pull.ts` compared that raw against `sha256Hex(content)`, which returns **bare hex** (`7db0733f…`):

```ts
const actual = sha256Hex(content);
if (actual !== digest) { /* "7db0733f…" !== "sha256:7db0733f…" → always true */ }
```

The hash value was always correct — the comparison failed purely on the `sha256:` prefix, so a valid download was treated as corrupt.

## Fix

Strip a leading `sha256:` from the registry digest and compare case-insensitively. Genuinely mismatched digests are still rejected.

## Tests

- New: accepts a `sha256:`-prefixed digest whose hash matches the content (regression for this bug).
- New: still rejects a genuinely wrong digest.
- Full CLI suite: **473 passed**, biome clean.

## End-to-end verification

Built the branch and ran the local binary against the live public registry — previously failing, now succeeds:

```
$ node cli/bin/ai-dossier pull imboard-ai/git/ship-issue --force
✅ imboard-ai/git/ship-issue@1.3.0 (updated) [public]
```

## Note on #407

The related cache-staleness issue (#407 — `run` selecting the oldest cached version, no auto-refresh) is **already fixed on `main`** by the TTL resolver in `d639cee` (#401), but that landed *after* the `0.8.4` npm release, so the published CLI still has the old behavior. This PR + that fix want to ship together in the next release (a version bump + `npm publish`); reinstalling `@ai-dossier/cli@latest` on each machine is what makes both effective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)