### PR TITLE
fix(cli): checksum --update no longer claims 'unchanged' on frontmatter-only edits

### DIFF
--- a/cli/src/__tests__/commands/checksum.test.ts
+++ b/cli/src/__tests__/commands/checksum.test.ts
@@ -11,6 +11,9 @@ const mockedFs = vi.mocked(fs);
 describe('checksum command', () => {
   beforeEach(() => {
     // Mocks are reset by global afterEach (setup.ts)
+    mockedFs.existsSync.mockReset();
+    mockedFs.readFileSync.mockReset();
+    mockedFs.writeFileSync.mockReset();
   });
 
   it('should exit 1 when file not found', async () => {
@@ -113,5 +116,92 @@ describe('checksum command', () => {
 
     expect(mockedFs.writeFileSync).toHaveBeenCalled();
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Checksum added'));
+  });
+
+  it('should report "Checksum updated" when body changed with --update', async () => {
+    const body = '\n\n# Test Dossier\n\nBody content here.\n';
+    const staleHash = crypto.createHash('sha256').update('different body', 'utf8').digest('hex');
+    const frontmatter = {
+      dossier_schema_version: '1.0',
+      title: 'Test Dossier',
+      version: '1.0.0',
+      objective: 'Test objective',
+      risk_level: 'low',
+      status: 'Draft',
+      category: ['testing'],
+      checksum: { algorithm: 'sha256', hash: staleHash },
+    };
+    const content = `---dossier\n${JSON.stringify(frontmatter, null, 2)}\n---\n${body}`;
+
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(content);
+    const program = createTestProgram();
+    registerChecksumCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'dossier', 'checksum', 'test.ds.md', '--update'])
+    ).rejects.toThrow();
+
+    expect(mockedFs.writeFileSync).toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Checksum updated'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining(staleHash));
+  });
+
+  it('should report "Body checksum unchanged" + note when only frontmatter changed with --update', async () => {
+    const body = '\n\n# Test Dossier\n\nBody content here.\n';
+    const hash = crypto.createHash('sha256').update(body, 'utf8').digest('hex');
+    const frontmatter = {
+      dossier_schema_version: '1.0',
+      title: 'Test Dossier',
+      version: '1.0.0',
+      objective: 'Test objective',
+      risk_level: 'low',
+      status: 'Draft',
+      category: ['testing'],
+      name: 'Added Name',
+      checksum: { hash },
+    };
+    const content = `---dossier\n${JSON.stringify(frontmatter, null, 4)}\n---\n${body}`;
+
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(content);
+    const program = createTestProgram();
+    registerChecksumCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'dossier', 'checksum', 'test.ds.md', '--update'])
+    ).rejects.toThrow();
+
+    expect(mockedFs.writeFileSync).toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Body checksum unchanged'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('frontmatter changed'));
+  });
+
+  it('should report "Checksum unchanged" and skip write when nothing changed with --update', async () => {
+    const body = '\n\n# Test Dossier\n\nBody content here.\n';
+    const hash = crypto.createHash('sha256').update(body, 'utf8').digest('hex');
+    const frontmatter = {
+      dossier_schema_version: '1.0',
+      title: 'Test Dossier',
+      version: '1.0.0',
+      objective: 'Test objective',
+      risk_level: 'low',
+      status: 'Draft',
+      category: ['testing'],
+      checksum: { algorithm: 'sha256', hash },
+    };
+    const content = `---dossier\n${JSON.stringify(frontmatter, null, 2)}\n---\n${body}`;
+
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(content);
+    const program = createTestProgram();
+    registerChecksumCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'dossier', 'checksum', 'test.ds.md', '--update'])
+    ).rejects.toThrow();
+
+    expect(mockedFs.writeFileSync).not.toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Checksum unchanged'));
   });
 });

--- a/cli/src/commands/checksum.ts
+++ b/cli/src/commands/checksum.ts
@@ -70,19 +70,30 @@ export function registerChecksumCommand(program: Command): void {
         };
 
         const updatedContent = `---dossier\n${JSON.stringify(frontmatter, null, 2)}\n---\n${body}`;
-        fs.writeFileSync(dossierFile, updatedContent, 'utf8');
+        const fileChanged = updatedContent !== content;
+        if (fileChanged) {
+          fs.writeFileSync(dossierFile, updatedContent, 'utf8');
+        }
 
         if (!options.quiet) {
           if (existingHash === calculatedHash) {
-            console.log('✅ Checksum unchanged');
+            if (fileChanged) {
+              console.log('✅ Body checksum unchanged');
+              console.log(`   SHA256: ${calculatedHash}`);
+              console.log("   Note: frontmatter changed — 'git diff' to see.");
+            } else {
+              console.log('✅ Checksum unchanged');
+              console.log(`   SHA256: ${calculatedHash}`);
+            }
           } else if (existingHash) {
             console.log('✅ Checksum updated');
             console.log(`   Old: ${existingHash}`);
             console.log(`   New: ${calculatedHash}`);
+            console.log(`   SHA256: ${calculatedHash}`);
           } else {
             console.log('✅ Checksum added');
+            console.log(`   SHA256: ${calculatedHash}`);
           }
-          console.log(`   SHA256: ${calculatedHash}`);
         } else {
           console.log(calculatedHash);
         }


### PR DESCRIPTION
## Problem

The dossier checksum is computed over the **body only** (after the `---` frontmatter), so frontmatter mutations are invisible to the hash. `ai-dossier checksum <file> --update` reported `✅ Checksum unchanged` even when it rewrote the file with changed frontmatter, misleading users into thinking the file was byte-identical (issue #398).

## Fix

`--update` now compares the rewritten content to the on-disk content (`updatedContent !== content`) and branches the messaging:

- **Body hash unchanged + file changed (frontmatter edit):**
  ```
  ✅ Body checksum unchanged
     SHA256: <hash>
     Note: frontmatter changed — 'git diff' to see.
  ```
- **Body hash unchanged + file unchanged:** keeps `✅ Checksum unchanged` and **skips the pointless `writeFileSync`** (no empty git diff).
- **Body hash changed:** unchanged `✅ Checksum updated` (with Old/New/SHA256) and `✅ Checksum added` behavior.
- `--quiet` behavior is unchanged (prints just the hash).

### Before / After (frontmatter-only edit)
Before:
```
✅ Checksum unchanged
   SHA256: 69c658...
```
After:
```
✅ Body checksum unchanged
   SHA256: 69c658...
   Note: frontmatter changed — 'git diff' to see.
```

## Tests
Extended `cli/src/__tests__/commands/checksum.test.ts` with three `--update` cases:
- body edit → `Checksum updated` (+ file written)
- frontmatter-only edit (valid checksum, non-canonical frontmatter) → `Body checksum unchanged` + frontmatter note (+ file written)
- no edit at all → `Checksum unchanged` and `writeFileSync` **not** called

Also reset the `node:fs` mocks in the suite's `beforeEach` (following the pattern in other command test files) so `not.toHaveBeenCalled()` assertions are reliable across tests.

## Verification
- `npx biome check --write .` — clean
- `make build-all` — all packages built
- `npx vitest run` in `cli/` — 476 passed (45 files)
- `npx vitest run` in `packages/core/` — 284 passed, 1 skipped (untouched)
- Manual sanity check against a temp dossier file for all four scenarios (unchanged / frontmatter-only / body-changed / `--quiet`)

Closes #398