### PR TITLE
feat(cli): run --headless passthrough for --model/--budget/--permission-mode/--allowed-tools

### DIFF
--- a/cli/src/__tests__/helpers.test.ts
+++ b/cli/src/__tests__/helpers.test.ts
@@ -242,6 +242,80 @@ describe('buildLlmCommand', () => {
     expect((result as NonNullable<typeof result>).stdin).toBe('file content');
   });
 
+  it('should forward passthrough flags in headless mode', () => {
+    mockedFs.readFileSync.mockReturnValue('file content');
+    const result = buildLlmCommand('claude-code', '/path/to/dossier.ds.md', true, {
+      model: 'sonnet',
+      budget: 2,
+      permissionMode: 'bypassPermissions',
+      allowedTools: 'Bash Read Write',
+    });
+    expect(result).not.toBeNull();
+    const r = result as NonNullable<typeof result>;
+    expect(r.cmd).toBe('claude');
+    expect(r.args).toEqual([
+      '-p',
+      '--model',
+      'sonnet',
+      '--max-budget-usd',
+      '2',
+      '--permission-mode',
+      'bypassPermissions',
+      '--allowedTools',
+      'Bash,Read,Write',
+    ]);
+    expect(r.stdin).toBe('file content');
+    expect(r.description).toContain('--model');
+    expect(r.description).toContain('--max-budget-usd');
+    expect(r.description).toContain('--allowedTools');
+  });
+
+  it('should normalize comma- and space-separated allowed tools (dedupe, trim)', () => {
+    mockedFs.readFileSync.mockReturnValue('file content');
+    const result = buildLlmCommand('claude-code', '/path/to/dossier.ds.md', true, {
+      allowedTools: 'Bash  Read, Write ,Bash,',
+    });
+    expect(result).not.toBeNull();
+    const r = result as NonNullable<typeof result>;
+    expect(r.args).toEqual(['-p', '--allowedTools', 'Bash,Read,Write']);
+  });
+
+  it('should forward --model in interactive (non-headless) mode', () => {
+    mockedFs.readFileSync.mockReturnValue('file content');
+    const result = buildLlmCommand('claude-code', '/path/to/dossier.ds.md', false, {
+      model: 'sonnet',
+    });
+    expect(result).not.toBeNull();
+    const r = result as NonNullable<typeof result>;
+    expect(r.args).toEqual(['--model', 'sonnet', '/path/to/dossier.ds.md']);
+    expect(r.stdin).toBeUndefined();
+    expect(r.description).toBe('claude --model sonnet "/path/to/dossier.ds.md"');
+  });
+
+  it('should ignore headless-only flags in interactive mode (model still forwarded)', () => {
+    mockedFs.readFileSync.mockReturnValue('file content');
+    const result = buildLlmCommand('claude-code', '/path/to/dossier.ds.md', false, {
+      model: 'sonnet',
+      budget: 2,
+      permissionMode: 'bypassPermissions',
+      allowedTools: 'Bash Read',
+    });
+    expect(result).not.toBeNull();
+    const r = result as NonNullable<typeof result>;
+    expect(r.args).toEqual(['--model', 'sonnet', '/path/to/dossier.ds.md']);
+    expect(r.stdin).toBeUndefined();
+  });
+
+  it('should handle budget of 0 in headless mode', () => {
+    mockedFs.readFileSync.mockReturnValue('file content');
+    const result = buildLlmCommand('claude-code', '/path/to/dossier.ds.md', true, {
+      budget: 0,
+    });
+    expect(result).not.toBeNull();
+    const r = result as NonNullable<typeof result>;
+    expect(r.args).toEqual(['-p', '--max-budget-usd', '0']);
+  });
+
   it('should return null for unknown LLM', () => {
     expect(buildLlmCommand('unknown-llm', '/file.ds.md')).toBeNull();
   });

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -32,6 +32,20 @@ export function registerRunCommand(program: Command): void {
     .argument('<file>', 'Dossier file, URL, or registry name to run')
     .option('--llm <name>', 'LLM to use (claude-code, auto)')
     .option('--headless', 'Run in headless mode (non-interactive, for CI/CD)')
+    .option('--model <name>', 'Model alias/name (forwarded to claude --model)')
+    .option(
+      '--budget <usd>',
+      'Max USD budget (headless only; forwarded to claude --max-budget-usd)',
+      parseFloat
+    )
+    .option(
+      '--permission-mode <mode>',
+      'Permission mode (headless only; forwarded to claude --permission-mode)'
+    )
+    .option(
+      '--allowed-tools <list>',
+      'Comma- or space-separated allowed tools (headless only; forwarded to claude --allowedTools)'
+    )
     .option('--dry-run', 'Show plan without executing')
     .option('--force', 'Skip risk warnings')
     .option('--no-prompt', "Don't ask for confirmation")
@@ -49,6 +63,10 @@ export function registerRunCommand(program: Command): void {
         options: {
           llm?: string;
           headless?: boolean;
+          model?: string;
+          budget?: number;
+          permissionMode?: string;
+          allowedTools?: string;
           dryRun?: boolean;
           force?: boolean;
           noPrompt?: boolean;
@@ -323,6 +341,15 @@ export function registerRunCommand(program: Command): void {
         console.log('   Status:      VERIFIED');
         console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
 
+        if (
+          !options.headless &&
+          (options.budget != null || options.permissionMode || options.allowedTools)
+        ) {
+          process.stderr.write(
+            'Warning: --budget, --permission-mode, and --allowed-tools require --headless (claude -p) and will be ignored in interactive mode.\n'
+          );
+        }
+
         if (options.dryRun) {
           console.log('🧪 DRY RUN MODE - No execution\n');
           console.log('Would execute:');
@@ -330,8 +357,19 @@ export function registerRunCommand(program: Command): void {
           console.log(`   LLM: ${llmOption}`);
 
           const llmToUse = detectLlm(llmOption as string, true);
+          const passthrough = {
+            model: options.model,
+            budget: options.budget,
+            permissionMode: options.permissionMode,
+            allowedTools: options.allowedTools,
+          };
+          const descriptor = llmToUse
+            ? buildLlmCommand(llmToUse, resolvedFile, options.headless, passthrough)
+            : null;
           console.log(
-            `   Command: ${llmToUse ? `claude "${resolvedFile}"` : 'No LLM detected - would show error'}\n`
+            `   Command: ${
+              descriptor ? descriptor.description : 'No LLM detected - would show error'
+            }\n`
           );
           console.log('✅ All verifications passed - ready to execute');
           fs.unlinkSync(secureTmpFile);
@@ -368,7 +406,12 @@ export function registerRunCommand(program: Command): void {
           process.exit(2);
         }
 
-        const descriptor = buildLlmCommand(llmToUse, resolvedFile, options.headless);
+        const descriptor = buildLlmCommand(llmToUse, resolvedFile, options.headless, {
+          model: options.model,
+          budget: options.budget,
+          permissionMode: options.permissionMode,
+          allowedTools: options.allowedTools,
+        });
         if (!descriptor) {
           console.log(`❌ Unknown LLM: ${llmToUse}\n`);
           console.log('Supported: claude-code, auto\n');

--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -249,6 +249,36 @@ export interface LlmExecDescriptor {
 }
 
 /**
+ * Passthrough options forwarded to the underlying LLM CLI (claude-code).
+ * These map to claude flags; most only apply in headless (`-p`) mode.
+ */
+export interface LlmPassthroughOptions {
+  model?: string;
+  /** USD budget; forwarded as `--max-budget-usd` (headless only). */
+  budget?: number;
+  permissionMode?: string;
+  /** Raw list from the CLI (space- or comma-separated); normalized to commas. */
+  allowedTools?: string;
+}
+
+/**
+ * Normalize a raw allowed-tools list (space- or comma-separated) into the
+ * comma-separated form claude's `--allowedTools` flag expects. Trims empties
+ * and de-dupes while preserving order.
+ */
+function normalizeAllowedTools(raw: string): string | null {
+  const seen = new Set<string>();
+  const parts: string[] = [];
+  for (const piece of raw.split(/[\s,]+/)) {
+    const trimmed = piece.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    parts.push(trimmed);
+  }
+  return parts.length > 0 ? parts.join(',') : null;
+}
+
+/**
  * Download a URL to a local temp file (synchronous).
  * Returns the temp file path.
  */
@@ -286,26 +316,50 @@ export function downloadUrlToTempFile(url: string): string {
 export function buildLlmCommand(
   llm: string,
   file: string,
-  headless = false
+  headless = false,
+  passthrough?: LlmPassthroughOptions
 ): LlmExecDescriptor | null {
-  if (llm === 'claude-code') {
-    if (headless) {
-      const content = fs.readFileSync(file, 'utf8');
-      return {
-        cmd: 'claude',
-        args: ['-p'],
-        stdin: content,
-        description: `cat "${file}" | claude -p`,
-      };
-    } else {
-      return {
-        cmd: 'claude',
-        args: [file],
-        description: `claude "${file}"`,
-      };
-    }
-  } else {
+  if (llm !== 'claude-code') {
     return null;
+  }
+
+  if (headless) {
+    const content = fs.readFileSync(file, 'utf8');
+    const args = ['-p'];
+    if (passthrough?.model) {
+      args.push('--model', passthrough.model);
+    }
+    if (passthrough?.budget != null && !Number.isNaN(passthrough.budget)) {
+      args.push('--max-budget-usd', String(passthrough.budget));
+    }
+    if (passthrough?.permissionMode) {
+      args.push('--permission-mode', passthrough.permissionMode);
+    }
+    const tools = passthrough?.allowedTools
+      ? normalizeAllowedTools(passthrough.allowedTools)
+      : null;
+    if (tools) {
+      args.push('--allowedTools', tools);
+    }
+    const extraFlags = args.length > 1 ? ` ${args.slice(1).join(' ')}` : '';
+    return {
+      cmd: 'claude',
+      args,
+      stdin: content,
+      description: `cat "${file}" | claude -p${extraFlags}`,
+    };
+  } else {
+    const args: string[] = [];
+    if (passthrough?.model) {
+      args.push('--model', passthrough.model);
+    }
+    args.push(file);
+    const flagPrefix = args.length > 1 ? `${args.slice(0, -1).join(' ')} ` : '';
+    return {
+      cmd: 'claude',
+      args,
+      description: `claude ${flagPrefix}"${file}"`,
+    };
   }
 }
 


### PR DESCRIPTION
Closes #382

## Problem
`ai-dossier run --headless` spawned `claude -p` with no options, so cron/CI automation could not control `--model`, `--max-budget-usd`, `--permission-mode`, or `--allowedTools`. Users had to wrap the `claude` CLI manually.

## Solution
Add passthrough CLI options to `ai-dossier run` and forward them to the spawned `claude` process via `buildLlmCommand`.

### New CLI options
| Option | Maps to claude flag | Mode |
|---|---|---|
| `--model <name>` | `--model <name>` | both |
| `--budget <usd>` | `--max-budget-usd <usd>` | headless only |
| `--permission-mode <mode>` | `--permission-mode <mode>` | headless only |
| `--allowed-tools <list>` | `--allowedTools <list>` | headless only |

### Example
```
ai-dossier run scan-tools.ds.md --headless \
  --model sonnet \
  --budget 2 \
  --permission-mode bypassPermissions \
  --allowed-tools "Bash Read Write Edit Glob Grep WebSearch WebFetch Agent"
```
becomes:
```
cat "<file>" | claude -p --model sonnet --max-budget-usd 2 --permission-mode bypassPermissions --allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,Agent
```

## Implementation details
- `buildLlmCommand` gains an optional 4th `passthrough` object parameter (`LlmPassthroughOptions`). The existing 2–3 positional call signature stays backward compatible (existing tests/call sites unchanged).
- `--allowed-tools` raw input (space- or comma-separated) is deduped, trimmed, and joined with commas to match claude's `--allowedTools` format (e.g. `Bash Read` → `Bash,Read`).
- Flag spelling (`--allowedTools`, camelCase) verified against `claude --help`, which documents `--allowedTools, --allowed-tools <tools...>`.
- Dossier content is still piped via stdin in headless mode (`-p`).

## Behavior decisions
**Interactive (non-headless) mode:**
- `--model` is forwarded: `claude --model <m> <file>`.
- `--budget`, `--permission-mode`, `--allowed-tools` are headless/`-p`-oriented (claude's `--max-budget-usd` only works with `--print`) and are **dropped** in interactive mode. A **stderr warning** is emitted when any of them is passed without `--headless`, so the silent drop is surfaced to the user.

**Dry-run (`--dry-run`):** the printed `Command:` preview reflects the forwarded flags (uses the same `buildLlmCommand` descriptor), so users see exactly what would spawn. The interactive-mode warning also fires in dry-run.

## Verification
- `npx biome check --write .` — clean (no fixes on changed files)
- `make build-all` — ✓
- `npx vitest run` in `cli/` — ✓ 45 files, 478 tests pass
- Manual smoke (`--headless --dry-run`): `Command: cat "<file>" | claude -p --model sonnet --max-budget-usd 2 --permission-mode bypassPermissions --allowedTools Bash,Read`
- Manual smoke (interactive `--dry-run`): warning emitted + `Command: claude --model sonnet "<file>"` (budget/allowed-tools dropped)

## Test changes
Extended `cli/src/__tests__/helpers.test.ts` `buildLlmCommand` block with cases for: headless + all passthrough flags; allowed-tools normalization/dedup; interactive `--model` forwarding; interactive dropping of headless-only flags; budget `0` handling. Existing assertions unchanged. `run.test.ts` mock unchanged (4th arg is optional).

## Files changed
- `cli/src/commands/run.ts` — new options, options type, passthrough wiring, interactive-mode warning, dry-run preview via descriptor
- `cli/src/helpers.ts` — `LlmPassthroughOptions` interface, `normalizeAllowedTools` helper, extended `buildLlmCommand`
- `cli/src/__tests__/helpers.test.ts` — new test cases