### PR TITLE
feat(cli): cache refresh command + verify highest-semver selection

### DIFF
--- a/cli/src/__tests__/cache-resolver.test.ts
+++ b/cli/src/__tests__/cache-resolver.test.ts
@@ -201,6 +201,19 @@ describe('cache-resolver', () => {
 
       expect(highestCachedSemver('org/x')).toBe('1.0.0');
     });
+
+    // Regression for #407 problem 1: `run` must pick the highest cached version,
+    // not the first readdir entry. A naive `versions[0]` would return 3.1.0 here.
+    it('returns the highest semver, not the first readdir entry (#407)', () => {
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readdirSync.mockReturnValue([
+        '3.1.0.meta.json',
+        '3.2.0.meta.json',
+        '3.3.0.meta.json',
+      ] as any);
+
+      expect(highestCachedSemver('org/x')).toBe('3.3.0');
+    });
   });
 
   describe('listResolutions', () => {

--- a/cli/src/cache-resolver.ts
+++ b/cli/src/cache-resolver.ts
@@ -77,7 +77,7 @@ function readResolution(dossierName: string): ResolutionRecord | null {
   }
 }
 
-function writeResolution(dossierName: string, record: ResolutionRecord): void {
+export function writeResolution(dossierName: string, record: ResolutionRecord): void {
   const file = resolutionFilePath(dossierName);
   const targetDir = path.dirname(file);
   // Node's mkdir({recursive:true,mode}) only applies `mode` to the leaf directory it creates.

--- a/cli/src/commands/cache.ts
+++ b/cli/src/commands/cache.ts
@@ -2,10 +2,18 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import readline from 'node:readline';
+import { sha256Hex } from '@ai-dossier/core';
 import type { Command } from 'commander';
-import { DEFAULT_RESOLUTION_TTL_SECONDS, listResolutions } from '../cache-resolver';
+import {
+  DEFAULT_RESOLUTION_TTL_SECONDS,
+  highestCachedSemver,
+  listResolutions,
+  writeCachedContent,
+  writeResolution,
+} from '../cache-resolver';
 import { getConfig } from '../config';
-import { safeDossierPath } from '../helpers';
+import { printRegistryErrors, safeDossierPath } from '../helpers';
+import { multiRegistryGetContent, multiRegistryGetDossier } from '../multi-registry';
 
 function formatAge(ageMs: number): string {
   const seconds = Math.round(ageMs / 1000);
@@ -16,6 +24,48 @@ function formatAge(ageMs: number): string {
   if (hours < 24) return `${hours}h`;
   const days = Math.round(hours / 24);
   return `${days}d`;
+}
+
+interface CachedDossierEntry {
+  name: string;
+  version: string;
+  size: number;
+  cached_at: string;
+  path: string;
+}
+
+/** Walk ~/.dossier/cache and return one entry per cached (name, version). */
+function walkCachedDossiers(cacheDir: string): CachedDossierEntry[] {
+  const entries: CachedDossierEntry[] = [];
+  function walk(dir: string): void {
+    if (!fs.existsSync(dir)) return;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.name.endsWith('.meta.json')) {
+        try {
+          const meta = JSON.parse(fs.readFileSync(full, 'utf8'));
+          const version = entry.name.replace('.meta.json', '');
+          const contentFile = path.join(dir, `${version}.ds.md`);
+          if (!fs.existsSync(contentFile)) return;
+          const rel = path.relative(cacheDir, dir);
+          const stats = fs.statSync(contentFile);
+          entries.push({
+            name: rel,
+            version,
+            size: stats.size,
+            cached_at: meta.cached_at,
+            path: contentFile,
+          });
+        } catch {
+          // skip invalid entries
+        }
+      }
+    }
+  }
+  walk(cacheDir);
+  return entries;
 }
 
 export function registerCacheCommand(program: Command): void {
@@ -111,42 +161,7 @@ export function registerCacheCommand(program: Command): void {
         process.exit(0);
       }
 
-      const entries: {
-        name: string;
-        version: string;
-        size: number;
-        cached_at: string;
-        path: string;
-      }[] = [];
-      function walk(dir: string): void {
-        if (!fs.existsSync(dir)) return;
-        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-          const full = path.join(dir, entry.name);
-          if (entry.isDirectory()) {
-            walk(full);
-          } else if (entry.name.endsWith('.meta.json')) {
-            try {
-              const meta = JSON.parse(fs.readFileSync(full, 'utf8'));
-              const version = entry.name.replace('.meta.json', '');
-              const contentFile = path.join(dir, `${version}.ds.md`);
-              if (!fs.existsSync(contentFile)) return;
-
-              const rel = path.relative(cacheDir, dir);
-              const stats = fs.statSync(contentFile);
-              entries.push({
-                name: rel,
-                version,
-                size: stats.size,
-                cached_at: meta.cached_at,
-                path: contentFile,
-              });
-            } catch {
-              // skip invalid entries
-            }
-          }
-        }
-      }
-      walk(cacheDir);
+      const entries = walkCachedDossiers(cacheDir);
 
       if (entries.length === 0) {
         if (options.json) {
@@ -191,6 +206,189 @@ export function registerCacheCommand(program: Command): void {
       }
       console.log('');
       process.exit(0);
+    });
+
+  // cache refresh
+  cacheCmd
+    .command('refresh')
+    .description('Re-fetch the latest published version for cached dossiers')
+    .argument('[name...]', 'Specific dossier name(s) to refresh (default: all cached)')
+    .option('--json', 'Output a machine-readable summary')
+    .action(async (names: string[], options: { json?: boolean }) => {
+      const cacheDir = path.join(os.homedir(), '.dossier', 'cache');
+
+      if (!fs.existsSync(cacheDir)) {
+        if (options.json) {
+          console.log(
+            JSON.stringify({ total: 0, refreshed: [], up_to_date: [], failed: [] }, null, 2)
+          );
+        } else {
+          console.log('\nNo cached dossiers to refresh.\n');
+        }
+        return;
+      }
+
+      const entries = walkCachedDossiers(cacheDir);
+
+      // Resolve the target set: explicit names if provided, otherwise every cached name.
+      let targets: string[];
+      if (names.length > 0) {
+        targets = names;
+      } else {
+        targets = [...new Set(entries.map((e) => e.name))].sort();
+        if (targets.length === 0) {
+          if (options.json) {
+            console.log(
+              JSON.stringify({ total: 0, refreshed: [], up_to_date: [], failed: [] }, null, 2)
+            );
+          } else {
+            console.log('\nNo cached dossiers to refresh.\n');
+          }
+          return;
+        }
+      }
+
+      const refreshed: Array<{ name: string; old_version: string; new_version: string }> = [];
+      const upToDate: Array<{ name: string; version: string }> = [];
+      const failed: Array<{ name: string; error: string }> = [];
+
+      for (const name of targets) {
+        // For named refresh, a name that isn't cached is a user error — point at `pull`.
+        if (names.length > 0 && !entries.some((e) => e.name === name)) {
+          const msg = `not cached (use \`dossier pull ${name}\` to fetch it)`;
+          failed.push({ name, error: msg });
+          if (!options.json) {
+            console.error(`❌ ${name}: ${msg}`);
+          }
+          continue;
+        }
+
+        try {
+          const oldVersion = highestCachedSemver(name);
+
+          // Resolve the latest published version directly from the registry.
+          // (Not via resolveCachedVersion — its stale-fallback would mask registry
+          // failures, and refresh must report those as failures.)
+          const { result: meta, errors: metaErrors } = await multiRegistryGetDossier(name);
+          if (!meta || !meta.version) {
+            const msg =
+              metaErrors.length > 0 ? metaErrors.map((e) => e.error).join('; ') : 'not found';
+            failed.push({ name, error: msg });
+            if (!options.json) {
+              console.error(`❌ ${name}: ${msg}`);
+              printRegistryErrors(metaErrors);
+            }
+            continue;
+          }
+
+          const newVersion = meta.version;
+          const registry = meta._registry;
+
+          // Same version already cached — refresh the resolution timestamp and skip the
+          // (byte-identical) content re-download.
+          if (oldVersion && oldVersion === newVersion) {
+            writeResolution(name, {
+              resolved_version: newVersion,
+              resolved_at: new Date().toISOString(),
+              source_registry: registry,
+            });
+            upToDate.push({ name, version: newVersion });
+            if (!options.json) {
+              console.log(`✅ ${name}@${newVersion} (already latest)`);
+            }
+            continue;
+          }
+
+          // Version changed (or content missing) — fetch the new content.
+          const { result, errors: contentErrors } = await multiRegistryGetContent(name, newVersion);
+          if (!result) {
+            const msg =
+              contentErrors.length > 0
+                ? contentErrors.map((e) => e.error).join('; ')
+                : 'content not found';
+            failed.push({ name, error: msg });
+            if (!options.json) {
+              console.error(`❌ ${name}: ${msg}`);
+              printRegistryErrors(contentErrors);
+            }
+            continue;
+          }
+
+          if (result.digest) {
+            const actual = sha256Hex(result.content);
+            // Registry sends the digest with an algorithm prefix (e.g. `sha256:<hex>`);
+            // sha256Hex returns the bare hex. Strip the prefix and compare
+            // case-insensitively so a valid download isn't rejected over the label.
+            const expected = result.digest.replace(/^sha256:/i, '');
+            if (actual.toLowerCase() !== expected.toLowerCase()) {
+              failed.push({ name, error: 'checksum mismatch after refresh' });
+              if (!options.json) {
+                console.error(`❌ ${name}@${newVersion}: checksum mismatch after refresh`);
+              }
+              continue;
+            }
+          }
+
+          try {
+            writeCachedContent(name, newVersion, result.content, registry, {
+              throwOnError: true,
+            });
+          } catch (writeErr: unknown) {
+            const msg = `failed to write cache: ${(writeErr as Error).message}`;
+            failed.push({ name, error: msg });
+            if (!options.json) {
+              console.error(`❌ ${name}@${newVersion}: ${msg}`);
+            }
+            continue;
+          }
+
+          // Content is now cached for the new version — refresh the resolution record.
+          writeResolution(name, {
+            resolved_version: newVersion,
+            resolved_at: new Date().toISOString(),
+            source_registry: registry,
+          });
+
+          refreshed.push({
+            name,
+            old_version: oldVersion ?? '<none>',
+            new_version: newVersion,
+          });
+          if (!options.json) {
+            console.log(`🔄 ${name}: ${oldVersion ?? '<none>'} → ${newVersion}`);
+          }
+        } catch (err: unknown) {
+          const e = err as { statusCode?: number; message: string };
+          const msg = e.statusCode === 404 ? 'not found in registry' : e.message;
+          failed.push({ name, error: msg });
+          if (!options.json) {
+            console.error(`❌ ${name}: ${msg}`);
+          }
+        }
+      }
+
+      if (options.json) {
+        console.log(
+          JSON.stringify(
+            {
+              total: targets.length,
+              refreshed,
+              up_to_date: upToDate,
+              failed,
+            },
+            null,
+            2
+          )
+        );
+      } else {
+        console.log(
+          `\n${refreshed.length} refreshed, ${upToDate.length} up-to-date, ${failed.length} failed.`
+        );
+      }
+
+      if (failed.length === targets.length && targets.length > 0) {
+        process.exit(1);
+      }
     });
 
   // cache clean


### PR DESCRIPTION
## Summary

Adds `ai-dossier cache refresh [name...]` — re-fetches the latest published version for all (or named) cached dossiers, independent of the pull path.

### `cache refresh` subcommand
- No args → refresh every currently cached dossier.
- `cache refresh <name> [<name>...]` → refresh only the named dossiers.
- Per dossier: resolves latest via `multiRegistryGetDossier`, fetches content via `multiRegistryGetContent`, verifies checksum (strips `sha256:` prefix, case-insensitive — mirrors pull.ts), writes to cache via `writeCachedContent`, and refreshes the resolution record via `writeResolution`.
- Output: `🔄 name: oldver → newver` (changed), `✅ name@ver (already latest)` (unchanged), `❌ name: error` (failure).
- `--json` for machine-readable output. Exit 1 only when all targets fail (matches pull.ts).

### Other changes
- Extracts shared `walkCachedDossiers()` from `cache list` (DRY — both list and refresh walk the same cache tree).
- Exports `writeResolution` from `cache-resolver.ts` for the refresh path.
- Adds a regression test: `highestCachedSemver` returns the highest semver, not the first `readdir` entry (with 3.1.0/3.2.0/3.3.0 cached → returns 3.3.0).

## #407 status

| Problem | Status |
|---------|--------|
| 1. `run` picks oldest cached version | **Already fixed** by #402 — `resolveCachedVersion` uses `highestCachedSemver()` with semver sort. Regression test added here. |
| 2. Update check only notifies | **Already fixed** by #402 — TTL resolver re-fetches after expiry; `--pull`/`--fresh` provide explicit opt-in. |
| 3. No bulk refresh | **Fixed by this PR** — `cache refresh` command. |

Closes #407