### PR TITLE
feat(cli): opencode integration for install-skill (0.8.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Bump `hono` (4.12.18 → 4.12.30), `js-yaml` (3.14.2 → 3.15.0), and `qs` (2.0.2 → 2.0.4) to close pre-existing advisories flagged by `npm audit --audit-level=high`. Within-semver, no API changes.
+
 ### Added
 - **opencode integration for `install-skill`**: when `~/.config/opencode/` exists, dossier skills now dual-write a YAML-frontmatter wrapper to `~/.config/opencode/skills/<name>/SKILL.md` so [opencode](https://opencode.ai) can discover and trigger them. The signed source in `~/.claude/skills/` is never modified. Wrappers of delegating skills (body invokes `ai-dossier run`) include `allowedTools: [Bash(ai-dossier run *)]` so opencode auto-approves the delegation. Override with `--for claude|opencode|both`.
 - New `ai-dossier sync-skills` command — retroactively generates opencode wrappers for skills already installed in `~/.claude/skills/` and prunes orphaned wrappers. Idempotent. Supports `--dry-run`, `--no-prune`, and `--json`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **opencode integration for `install-skill`**: when `~/.config/opencode/` exists, dossier skills now dual-write a YAML-frontmatter wrapper to `~/.config/opencode/skills/<name>/SKILL.md` so [opencode](https://opencode.ai) can discover and trigger them. The signed source in `~/.claude/skills/` is never modified. Wrappers of delegating skills (body invokes `ai-dossier run`) include `allowedTools: [Bash(ai-dossier run *)]` so opencode auto-approves the delegation. Override with `--for claude|opencode|both`.
+- New `ai-dossier sync-skills` command — retroactively generates opencode wrappers for skills already installed in `~/.claude/skills/` and prunes orphaned wrappers. Idempotent. Supports `--dry-run`, `--no-prune`, and `--json`.
+- `install-skill --list` now badges each skill with the tools it's installed in (`[claude, opencode]` or `[claude]`); `install-skill --remove` cleans both locations.
 - TTL-based version resolution for versionless dossier references (`run`, `create`, `install-skill`): stale versionless requests auto-update silently within a configurable window (default 300s). Resolution metadata lives under `~/.dossier/cache/.resolution/<name>.json`.
 - New `--max-age <seconds>` flag on `run`, `create`, and `install-skill` (default 300, `0` = always re-check the registry).
 - `--fresh` flag on `create` (already supported on `run` and `install-skill`) to bypass the resolution cache for one call.

--- a/cli/README.md
+++ b/cli/README.md
@@ -266,6 +266,30 @@ ai-dossier install-skill --remove my-skill
 
 Restart Claude Code (or start a new session) to pick up a newly installed skill. At run time the skill calls `ai-dossier run <registry-path>`, which fetches and verifies the dossier on demand — so you don't need to install the dossier separately.
 
+**opencode support (auto-detect)**: When `~/.config/opencode/` exists, `install-skill` also writes a YAML-frontmatter wrapper to `~/.config/opencode/skills/<name>/SKILL.md`. opencode's parser only accepts standard YAML frontmatter (`---`), so dossier skills that use `---dossier` (JSON) frontmatter would otherwise be invisible. The wrapper carries the same `name`, `description`, and body; the signed source in `~/.claude/skills/` is never modified. Delegating skills (body contains `ai-dossier run`) also get an `allowedTools: [Bash(ai-dossier run *)]` line so opencode auto-approves the delegation.
+
+Override with `--for claude|opencode|both`:
+
+```bash
+ai-dossier install-skill org/skills/my-skill --for claude   # skip opencode wrapper
+ai-dossier install-skill org/skills/my-skill --for both     # force opencode even if dir absent
+```
+
+`--remove` cleans both locations. `--list` badges each skill with the tools it's installed in (`[claude, opencode]` or `[claude]`).
+
+### `sync-skills` — regenerate opencode wrappers for existing installs
+
+Use after installing opencode on a machine that already has dossier skills, or after any manual change to `~/.claude/skills/`:
+
+```bash
+ai-dossier sync-skills                # write missing wrappers, prune orphans
+ai-dossier sync-skills --dry-run      # show what would change without writing
+ai-dossier sync-skills --no-prune     # keep wrappers even if the source is gone
+ai-dossier sync-skills --json         # machine-readable output
+```
+
+Idempotent — re-running is safe and reports `unchanged` for wrappers already in sync.
+
 ### `skill-export` — local skill → registry dossier
 
 Publish a locally installed skill to the registry as a versioned, signed dossier so others can `install-skill` it:

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-dossier/cli",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Create, verify, sign, publish, and run dossiers — portable, signed, versioned skills for any LLM tool. The dossier ⇄ Claude Code skill bridge (install-skill / skill-export).",
   "main": "dist/cli.js",
   "bin": {

--- a/cli/src/__tests__/commands/install-skill.test.ts
+++ b/cli/src/__tests__/commands/install-skill.test.ts
@@ -1,7 +1,9 @@
 import fs from 'node:fs';
+import path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { registerInstallSkillCommand } from '../../commands/install-skill';
 import * as multiRegistry from '../../multi-registry';
+import { OPENCODE_CONFIG_DIR, OPENCODE_SKILLS_DIR } from '../../opencode-sync';
 import * as registryClient from '../../registry-client';
 import { createTestProgram, parseNameVersionImpl } from '../helpers/test-utils';
 
@@ -11,8 +13,26 @@ vi.mock('../../registry-client');
 
 const mockedFs = vi.mocked(fs);
 
+/** Compact dossier content used by install tests — has both name & description. */
+const DOSSIER_CONTENT = [
+  '---dossier',
+  '{',
+  '  "dossier_schema_version": "1.0.0",',
+  '  "name": "my-skill",',
+  '  "description": "A skill",',
+  '  "objective": "Do the thing"',
+  '}',
+  '---',
+  '',
+  '# Body',
+  '',
+  'Run: ai-dossier run org/my-skill --pull',
+  '',
+].join('\n');
+
 describe('install-skill command', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.mocked(registryClient.parseNameVersion).mockImplementation(parseNameVersionImpl);
   });
 
@@ -46,6 +66,26 @@ describe('install-skill command', () => {
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('No installed skills'));
   });
 
+  it('--list badges skills also present in opencode', async () => {
+    // claude skill dir + opencode wrapper dir both exist; both contain 'my-skill'.
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readdirSync.mockImplementation(((p: any) => {
+      // Called for the claude skills dir and for the opencode skills dir.
+      return [{ name: 'my-skill', isDirectory: () => true }] as any;
+    }) as any);
+    mockedFs.readFileSync.mockReturnValue('---\ndescription: A skill\n---\nContent');
+
+    const program = createTestProgram();
+    registerInstallSkillCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'dossier', 'install-skill', '--list'])
+    ).rejects.toThrow();
+
+    // Badge appears next to the name.
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('[claude, opencode]'));
+  });
+
   it('should remove a skill with --remove', async () => {
     mockedFs.existsSync.mockReturnValue(true);
 
@@ -58,6 +98,21 @@ describe('install-skill command', () => {
 
     expect(mockedFs.rmSync).toHaveBeenCalled();
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Removed skill'));
+  });
+
+  it('--remove cleans both claude and opencode', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+
+    const program = createTestProgram();
+    registerInstallSkillCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'dossier', 'install-skill', '--remove', 'old-skill'])
+    ).rejects.toThrow();
+
+    // Two rmSync calls — one per location.
+    expect(mockedFs.rmSync).toHaveBeenCalledTimes(2);
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('claude, opencode'));
   });
 
   it('should exit 1 when removing non-existent skill', async () => {
@@ -114,5 +169,113 @@ describe('install-skill command', () => {
     ).rejects.toThrow();
 
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('already installed'));
+  });
+
+  it('auto-writes opencode wrapper when ~/.config/opencode exists', async () => {
+    // existsSync returns true only for OPENCODE_CONFIG_DIR (auto-detect) — nothing
+    // else exists, so install proceeds and wrapper writes go through.
+    mockedFs.existsSync.mockImplementation(((p: any) => {
+      const s = String(p);
+      return s === OPENCODE_CONFIG_DIR;
+    }) as any);
+    vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
+      result: { content: DOSSIER_CONTENT, _registry: 'public' },
+      errors: [],
+    } as any);
+
+    const program = createTestProgram();
+    registerInstallSkillCommand(program);
+    await program.parseAsync(['node', 'dossier', 'install-skill', 'org/my-skill']);
+
+    // Wrapper was written under OPENCODE_SKILLS_DIR.
+    const writes = mockedFs.writeFileSync.mock.calls.map((c) => String(c[0]));
+    expect(writes.some((p) => p.startsWith(OPENCODE_SKILLS_DIR))).toBe(true);
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `opencode: created at ${path.join(OPENCODE_SKILLS_DIR, 'my-skill', 'SKILL.md')}`
+      )
+    );
+  });
+
+  it('does NOT auto-write opencode wrapper when ~/.config/opencode is absent', async () => {
+    mockedFs.existsSync.mockReturnValue(false);
+    vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
+      result: { content: DOSSIER_CONTENT, _registry: 'public' },
+      errors: [],
+    } as any);
+
+    const program = createTestProgram();
+    registerInstallSkillCommand(program);
+    await program.parseAsync(['node', 'dossier', 'install-skill', 'org/my-skill']);
+
+    const writes = mockedFs.writeFileSync.mock.calls.map((c) => String(c[0]));
+    expect(writes.some((p) => p.startsWith(OPENCODE_SKILLS_DIR))).toBe(false);
+  });
+
+  it('--for claude skips opencode wrapper even when opencode dir exists', async () => {
+    mockedFs.existsSync.mockImplementation(((p: any) => String(p) === OPENCODE_CONFIG_DIR) as any);
+    vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
+      result: { content: DOSSIER_CONTENT, _registry: 'public' },
+      errors: [],
+    } as any);
+
+    const program = createTestProgram();
+    registerInstallSkillCommand(program);
+    await program.parseAsync([
+      'node',
+      'dossier',
+      'install-skill',
+      '--for',
+      'claude',
+      'org/my-skill',
+    ]);
+
+    const writes = mockedFs.writeFileSync.mock.calls.map((c) => String(c[0]));
+    expect(writes.some((p) => p.startsWith(OPENCODE_SKILLS_DIR))).toBe(false);
+  });
+
+  it('--for both forces opencode wrapper even when opencode dir is absent', async () => {
+    mockedFs.existsSync.mockReturnValue(false);
+    vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
+      result: { content: DOSSIER_CONTENT, _registry: 'public' },
+      errors: [],
+    } as any);
+
+    const program = createTestProgram();
+    registerInstallSkillCommand(program);
+    await program.parseAsync(['node', 'dossier', 'install-skill', '--for', 'both', 'org/my-skill']);
+
+    const writes = mockedFs.writeFileSync.mock.calls.map((c) => String(c[0]));
+    expect(writes.some((p) => p.startsWith(OPENCODE_SKILLS_DIR))).toBe(true);
+  });
+
+  it('rejects invalid --for value', async () => {
+    const program = createTestProgram();
+    registerInstallSkillCommand(program);
+    await expect(
+      program.parseAsync(['node', 'dossier', 'install-skill', '--for', 'bogus', 'org/my-skill'])
+    ).rejects.toThrow();
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Invalid --for value'));
+  });
+
+  it('YAML-native source is not wrapped (opencode reads source directly)', async () => {
+    // opencode dir exists → auto-detect fires. But the source is YAML, so wrapper
+    // generation returns 'skipped' and no file is written under OPENCODE_SKILLS_DIR.
+    mockedFs.existsSync.mockImplementation(((p: any) => String(p) === OPENCODE_CONFIG_DIR) as any);
+    vi.mocked(multiRegistry.multiRegistryGetContent).mockResolvedValue({
+      result: {
+        content: '---\nname: my-skill\ndescription: A skill\n---\n\n# Body\n',
+        _registry: 'public',
+      },
+      errors: [],
+    } as any);
+
+    const program = createTestProgram();
+    registerInstallSkillCommand(program);
+    await program.parseAsync(['node', 'dossier', 'install-skill', 'org/my-skill']);
+
+    const writes = mockedFs.writeFileSync.mock.calls.map((c) => String(c[0]));
+    expect(writes.some((p) => p.startsWith(OPENCODE_SKILLS_DIR))).toBe(false);
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('opencode: source is YAML'));
   });
 });

--- a/cli/src/__tests__/commands/sync-skills.test.ts
+++ b/cli/src/__tests__/commands/sync-skills.test.ts
@@ -1,0 +1,221 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { registerSyncSkillsCommand } from '../../commands/sync-skills';
+import { CLAUDE_SKILLS_DIR, OPENCODE_CONFIG_DIR, OPENCODE_SKILLS_DIR } from '../../opencode-sync';
+import { createTestProgram } from '../helpers/test-utils';
+
+vi.mock('node:fs');
+const mockedFs = vi.mocked(fs);
+
+const DOSSIER_SRC = [
+  '---dossier',
+  '{',
+  '  "dossier_schema_version": "1.0.0",',
+  '  "name": "my-skill",',
+  '  "description": "A skill"',
+  '}',
+  '---',
+  '',
+  '# Body',
+  '',
+  'Run: ai-dossier run org/my-skill --pull',
+  '',
+].join('\n');
+
+const YAML_SRC = '---\nname: yaml-skill\ndescription: A yaml skill\n---\n\n# Body\n';
+
+/** Build an existsSync predicate given a set of paths that should return true. */
+function existsIn(paths: Set<string>) {
+  return (p: any) => paths.has(String(p));
+}
+
+describe('sync-skills command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exits 1 when opencode is not installed', async () => {
+    mockedFs.existsSync.mockReturnValue(false);
+
+    const program = createTestProgram();
+    registerSyncSkillsCommand(program);
+
+    await expect(program.parseAsync(['node', 'dossier', 'sync-skills'])).rejects.toThrow();
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('opencode not found'));
+  });
+
+  it('reports empty state when opencode present but no claude skills', async () => {
+    // Opencode dir exists, claude skills dir does not.
+    mockedFs.existsSync.mockImplementation(existsIn(new Set([OPENCODE_CONFIG_DIR])) as any);
+
+    const program = createTestProgram();
+    registerSyncSkillsCommand(program);
+
+    await expect(program.parseAsync(['node', 'dossier', 'sync-skills'])).rejects.toThrow(/exit/i);
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('No claude skills to sync'));
+  });
+
+  it('creates wrappers for dossier-frontmatter sources', async () => {
+    const skillSource = path.join(CLAUDE_SKILLS_DIR, 'my-skill', 'SKILL.md');
+    // Everything the walk needs exists; wrapper target does not (→ create).
+    mockedFs.existsSync.mockImplementation(((p: any) => {
+      const s = String(p);
+      if (s === OPENCODE_CONFIG_DIR) return true;
+      if (s === CLAUDE_SKILLS_DIR) return true;
+      if (s === skillSource) return true;
+      if (s === OPENCODE_SKILLS_DIR) return false; // for prune walk
+      return false;
+    }) as any);
+    mockedFs.readdirSync.mockImplementation(((p: any) => {
+      const s = String(p);
+      if (s === CLAUDE_SKILLS_DIR) {
+        return [{ name: 'my-skill', isDirectory: () => true }] as any;
+      }
+      return [] as any;
+    }) as any);
+    mockedFs.readFileSync.mockReturnValue(DOSSIER_SRC);
+
+    const program = createTestProgram();
+    registerSyncSkillsCommand(program);
+    await expect(program.parseAsync(['node', 'dossier', 'sync-skills'])).rejects.toThrow();
+
+    // Wrapper was written under OPENCODE_SKILLS_DIR/my-skill/SKILL.md.
+    const writes = mockedFs.writeFileSync.mock.calls.map((c) => String(c[0]));
+    expect(writes.some((p) => p === path.join(OPENCODE_SKILLS_DIR, 'my-skill', 'SKILL.md'))).toBe(
+      true
+    );
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('created:   1'));
+  });
+
+  it('skips YAML-native sources', async () => {
+    const skillSource = path.join(CLAUDE_SKILLS_DIR, 'yaml-skill', 'SKILL.md');
+    mockedFs.existsSync.mockImplementation(((p: any) => {
+      const s = String(p);
+      return s === OPENCODE_CONFIG_DIR || s === CLAUDE_SKILLS_DIR || s === skillSource;
+    }) as any);
+    mockedFs.readdirSync.mockImplementation(((p: any) => {
+      if (String(p) === CLAUDE_SKILLS_DIR) {
+        return [{ name: 'yaml-skill', isDirectory: () => true }] as any;
+      }
+      return [] as any;
+    }) as any);
+    mockedFs.readFileSync.mockReturnValue(YAML_SRC);
+
+    const program = createTestProgram();
+    registerSyncSkillsCommand(program);
+    await expect(program.parseAsync(['node', 'dossier', 'sync-skills'])).rejects.toThrow();
+
+    const writes = mockedFs.writeFileSync.mock.calls.map((c) => String(c[0]));
+    expect(writes.some((p) => p.startsWith(OPENCODE_SKILLS_DIR))).toBe(false);
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('skipped:   1'));
+  });
+
+  it('prunes wrappers whose claude source is gone by default', async () => {
+    const orphanWrapper = path.join(OPENCODE_SKILLS_DIR, 'gone-skill', 'SKILL.md');
+    mockedFs.existsSync.mockImplementation(((p: any) => {
+      const s = String(p);
+      // opencode dir exists, claude skills dir exists (empty), opencode skills dir exists,
+      // orphan wrapper file exists.
+      return (
+        s === OPENCODE_CONFIG_DIR ||
+        s === CLAUDE_SKILLS_DIR ||
+        s === OPENCODE_SKILLS_DIR ||
+        s === orphanWrapper ||
+        s === path.join(OPENCODE_SKILLS_DIR, 'gone-skill')
+      );
+    }) as any);
+    mockedFs.readdirSync.mockImplementation(((p: any) => {
+      const s = String(p);
+      if (s === CLAUDE_SKILLS_DIR) return [] as any;
+      if (s === OPENCODE_SKILLS_DIR) {
+        return [{ name: 'gone-skill', isDirectory: () => true }] as any;
+      }
+      return [] as any;
+    }) as any);
+
+    const program = createTestProgram();
+    registerSyncSkillsCommand(program);
+    await expect(program.parseAsync(['node', 'dossier', 'sync-skills'])).rejects.toThrow();
+
+    expect(mockedFs.rmSync).toHaveBeenCalledWith(path.join(OPENCODE_SKILLS_DIR, 'gone-skill'), {
+      recursive: true,
+      force: true,
+    });
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('removed:   1'));
+  });
+
+  it('--no-prune keeps orphaned wrappers', async () => {
+    mockedFs.existsSync.mockImplementation(((p: any) => {
+      const s = String(p);
+      return (
+        s === OPENCODE_CONFIG_DIR ||
+        s === CLAUDE_SKILLS_DIR ||
+        s === OPENCODE_SKILLS_DIR ||
+        s === path.join(OPENCODE_SKILLS_DIR, 'gone-skill')
+      );
+    }) as any);
+    mockedFs.readdirSync.mockImplementation(((p: any) => {
+      const s = String(p);
+      if (s === CLAUDE_SKILLS_DIR) return [] as any;
+      if (s === OPENCODE_SKILLS_DIR) {
+        return [{ name: 'gone-skill', isDirectory: () => true }] as any;
+      }
+      return [] as any;
+    }) as any);
+
+    const program = createTestProgram();
+    registerSyncSkillsCommand(program);
+    await expect(
+      program.parseAsync(['node', 'dossier', 'sync-skills', '--no-prune'])
+    ).rejects.toThrow();
+
+    expect(mockedFs.rmSync).not.toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('prune disabled'));
+  });
+
+  it('--dry-run reports actions but writes nothing', async () => {
+    const skillSource = path.join(CLAUDE_SKILLS_DIR, 'my-skill', 'SKILL.md');
+    mockedFs.existsSync.mockImplementation(((p: any) => {
+      const s = String(p);
+      return s === OPENCODE_CONFIG_DIR || s === CLAUDE_SKILLS_DIR || s === skillSource;
+    }) as any);
+    mockedFs.readdirSync.mockImplementation(((p: any) => {
+      if (String(p) === CLAUDE_SKILLS_DIR) {
+        return [{ name: 'my-skill', isDirectory: () => true }] as any;
+      }
+      return [] as any;
+    }) as any);
+    mockedFs.readFileSync.mockReturnValue(DOSSIER_SRC);
+
+    const program = createTestProgram();
+    registerSyncSkillsCommand(program);
+    await expect(
+      program.parseAsync(['node', 'dossier', 'sync-skills', '--dry-run'])
+    ).rejects.toThrow();
+
+    expect(mockedFs.writeFileSync).not.toHaveBeenCalled();
+    expect(mockedFs.rmSync).not.toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Dry run'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('created:   1'));
+  });
+
+  it('--json emits structured output', async () => {
+    mockedFs.existsSync.mockImplementation(existsIn(new Set([OPENCODE_CONFIG_DIR])) as any);
+
+    const program = createTestProgram();
+    registerSyncSkillsCommand(program);
+    await expect(
+      program.parseAsync(['node', 'dossier', 'sync-skills', '--json'])
+    ).rejects.toThrow();
+
+    // At least one console.log call should contain valid JSON with success:true or the
+    // empty-state envelope.
+    const jsonCalls = (console.log as any).mock.calls
+      .map((c: any[]) => String(c[0]))
+      .filter((s: string) => s.trim().startsWith('{'));
+    expect(jsonCalls.length).toBeGreaterThan(0);
+    const parsed = JSON.parse(jsonCalls[0]);
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/cli/src/__tests__/opencode-sync.test.ts
+++ b/cli/src/__tests__/opencode-sync.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Unit tests for opencode-sync helpers.
+ *
+ * `vi.mock('node:fs')` is hoisted, so every fs call inside opencode-sync goes
+ * through the mock. The pure helpers (buildOpencodeWrapper, isDossierFrontmatter)
+ * don't touch fs, so the mock is inert for those cases.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildOpencodeWrapper,
+  isDossierFrontmatter,
+  listOpencodeSkills,
+  OPENCODE_CONFIG_DIR,
+  OPENCODE_SKILLS_DIR,
+  opencodeConfigExists,
+  removeOpencodeWrapper,
+  resolveTargets,
+  writeOpencodeWrapper,
+} from '../opencode-sync';
+
+vi.mock('node:fs');
+const mockedFs = vi.mocked(fs);
+
+describe('opencode-sync pure logic', () => {
+  const dossierSrc = [
+    '---dossier',
+    '{',
+    '  "dossier_schema_version": "1.0.0",',
+    '  "name": "full-cycle-issue-skill",',
+    '  "description": "Full autopilot: use when user says \'full cycle issue\'"',
+    '}',
+    '---',
+    '',
+    '# Full Cycle Issue',
+    '',
+    'Run: ai-dossier run imboard-ai/git/full-cycle-issue --pull',
+    '',
+  ].join('\n');
+
+  const yamlSrc = ['---', 'name: my-skill', 'description: A skill', '---', '', '# Body', ''].join(
+    '\n'
+  );
+
+  it('detects dossier-frontmatter sources', () => {
+    expect(isDossierFrontmatter(dossierSrc)).toBe(true);
+    expect(isDossierFrontmatter(yamlSrc)).toBe(false);
+    expect(isDossierFrontmatter('')).toBe(false);
+  });
+
+  it('builds a YAML wrapper preserving name and description', () => {
+    const wrapper = buildOpencodeWrapper(dossierSrc, 'full-cycle-issue-skill');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper).toContain('---\nname: full-cycle-issue-skill');
+    // Single-quoted string; apostrophes doubled up.
+    expect(wrapper).toContain(
+      "description: 'Full autopilot: use when user says ''full cycle issue'''"
+    );
+    // Body is preserved verbatim after the closing fence.
+    expect(wrapper).toContain('Run: ai-dossier run imboard-ai/git/full-cycle-issue --pull');
+  });
+
+  it('emits allowedTools only when the body delegates to ai-dossier run', () => {
+    const wrapper = buildOpencodeWrapper(dossierSrc, 'full-cycle-issue-skill');
+    expect(wrapper).toContain('allowedTools:\n  - Bash(ai-dossier run *)');
+
+    // Self-contained skill — no delegation, no allowedTools.
+    const selfContained = dossierSrc.replace(
+      'Run: ai-dossier run imboard-ai/git/full-cycle-issue --pull',
+      'Follow these steps: 1. Read the file. 2. Report.'
+    );
+    const wrapper2 = buildOpencodeWrapper(selfContained, 'pr-security-review');
+    expect(wrapper2).not.toContain('allowedTools');
+  });
+
+  it('falls back to the directory name when JSON has no name field', () => {
+    const noName = [
+      '---dossier',
+      '{',
+      '  "dossier_schema_version": "1.0.0",',
+      '  "title": "Scaffold Project",',
+      '  "version": "1.0.0"',
+      '}',
+      '---',
+      '',
+      '# Scaffold',
+      '',
+    ].join('\n');
+    const wrapper = buildOpencodeWrapper(noName, 'scaffold-project');
+    expect(wrapper).toContain('name: scaffold-project');
+  });
+
+  it('returns null for YAML-native sources (opencode reads them directly)', () => {
+    expect(buildOpencodeWrapper(yamlSrc, 'my-skill')).toBeNull();
+  });
+
+  it('returns null for unparseable sources rather than throwing', () => {
+    // Malformed JSON inside the dossier fence.
+    const bad = '---dossier\n{ not valid json\n---\n\n# Body\n';
+    expect(buildOpencodeWrapper(bad, 'broken')).toBeNull();
+  });
+
+  it('uses objective as a description fallback when description is absent', () => {
+    const noDesc = [
+      '---dossier',
+      '{',
+      '  "dossier_schema_version": "1.0.0",',
+      '  "name": "s",',
+      '  "objective": "Do the thing"',
+      '}',
+      '---',
+      '',
+      '# S',
+      '',
+    ].join('\n');
+    const wrapper = buildOpencodeWrapper(noDesc, 's');
+    expect(wrapper).toContain("description: 'Do the thing'");
+  });
+});
+
+describe('opencode-sync fs helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opencodeConfigExists reflects existsSync on the config dir', () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    expect(opencodeConfigExists()).toBe(true);
+    expect(mockedFs.existsSync).toHaveBeenCalledWith(OPENCODE_CONFIG_DIR);
+
+    mockedFs.existsSync.mockReturnValue(false);
+    expect(opencodeConfigExists()).toBe(false);
+  });
+
+  it('resolveTargets defaults to claude + auto-detect opencode', () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    expect(resolveTargets(undefined)).toEqual({ writeClaude: true, writeOpencode: true });
+
+    mockedFs.existsSync.mockReturnValue(false);
+    expect(resolveTargets(undefined)).toEqual({ writeClaude: true, writeOpencode: false });
+  });
+
+  it('resolveTargets --for claude skips opencode even when present', () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    expect(resolveTargets('claude')).toEqual({ writeClaude: true, writeOpencode: false });
+  });
+
+  it('resolveTargets --for both forces opencode regardless of dir', () => {
+    mockedFs.existsSync.mockReturnValue(false);
+    expect(resolveTargets('both')).toEqual({ writeClaude: true, writeOpencode: true });
+  });
+
+  it('writeOpencodeWrapper creates when target missing', () => {
+    mockedFs.existsSync.mockReturnValue(false);
+    const src = '---dossier\n{"name":"s","description":"d"}\n---\n\nBody\n';
+    const result = writeOpencodeWrapper('s', src);
+    expect(result).toBe('created');
+    expect(mockedFs.mkdirSync).toHaveBeenCalledWith(path.join(OPENCODE_SKILLS_DIR, 's'), {
+      recursive: true,
+    });
+    expect(mockedFs.writeFileSync).toHaveBeenCalled();
+  });
+
+  it('writeOpencodeWrapper reports unchanged when content matches', () => {
+    const src = '---dossier\n{"name":"s","description":"d"}\n---\n\nBody\n';
+    const expected = buildOpencodeWrapper(src, 's');
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(expected as string);
+
+    const result = writeOpencodeWrapper('s', src);
+    expect(result).toBe('unchanged');
+    expect(mockedFs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('writeOpencodeWrapper updates when existing content differs', () => {
+    const src = '---dossier\n{"name":"s","description":"d"}\n---\n\nBody\n';
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue('---\nname: s\ndescription: old\n---\n\nOld body\n');
+
+    const result = writeOpencodeWrapper('s', src);
+    expect(result).toBe('updated');
+    expect(mockedFs.writeFileSync).toHaveBeenCalled();
+  });
+
+  it('writeOpencodeWrapper skips YAML-native sources', () => {
+    const yamlSrc = '---\nname: s\ndescription: d\n---\n\nBody\n';
+    const result = writeOpencodeWrapper('s', yamlSrc);
+    expect(result).toBe('skipped');
+    expect(mockedFs.mkdirSync).not.toHaveBeenCalled();
+    expect(mockedFs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('removeOpencodeWrapper is a no-op when nothing present', () => {
+    mockedFs.existsSync.mockReturnValue(false);
+    expect(removeOpencodeWrapper('missing')).toBe(false);
+    expect(mockedFs.rmSync).not.toHaveBeenCalled();
+  });
+
+  it('removeOpencodeWrapper removes present wrapper', () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    expect(removeOpencodeWrapper('present')).toBe(true);
+    expect(mockedFs.rmSync).toHaveBeenCalledWith(path.join(OPENCODE_SKILLS_DIR, 'present'), {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  it('listOpencodeSkills returns [] when dir missing', () => {
+    mockedFs.existsSync.mockReturnValue(false);
+    expect(listOpencodeSkills()).toEqual([]);
+  });
+
+  it('listOpencodeSkills returns directory names with SKILL.md', () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readdirSync.mockReturnValue([
+      { name: 'a', isDirectory: () => true },
+      { name: 'b', isDirectory: () => true },
+      { name: 'file.txt', isDirectory: () => false },
+    ] as any);
+    expect(listOpencodeSkills()).toEqual(['a', 'b']);
+  });
+});

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -36,6 +36,7 @@ import { registerRunCommand } from './commands/run';
 import { registerSearchCommand } from './commands/search';
 import { registerSignCommand } from './commands/sign';
 import { registerSkillExportCommand } from './commands/skill-export';
+import { registerSyncSkillsCommand } from './commands/sync-skills';
 import { registerTracesCommand } from './commands/traces';
 import { registerValidateCommand } from './commands/validate';
 import { registerVerifyCommand } from './commands/verify';
@@ -92,6 +93,7 @@ registerRemoveCommand(program);
 // Skills
 registerInstallSkillCommand(program);
 registerSkillExportCommand(program);
+registerSyncSkillsCommand(program);
 
 // Security
 registerSignCommand(program);

--- a/cli/src/commands/install-skill.ts
+++ b/cli/src/commands/install-skill.ts
@@ -10,7 +10,19 @@ import {
   writeCachedContent,
 } from '../cache-resolver';
 import { multiRegistryGetContent } from '../multi-registry';
+import {
+  isDossierFrontmatter,
+  listOpencodeSkills,
+  OPENCODE_SKILLS_DIR,
+  removeOpencodeWrapper,
+  resolveTargets,
+  type SyncTarget,
+  writeOpencodeWrapper,
+} from '../opencode-sync';
 import { parseNameVersion } from '../registry-client';
+
+/** Valid values for --for. Anything else is rejected up front. */
+const VALID_TARGETS = new Set<SyncTarget>(['claude', 'opencode', 'both']);
 
 export function registerInstallSkillCommand(program: Command): void {
   program
@@ -25,6 +37,10 @@ export function registerInstallSkillCommand(program: Command): void {
     )
     .option('--list', 'List currently installed skills')
     .option('--remove <skill>', 'Remove an installed skill')
+    .option(
+      '--for <target>',
+      'Install targets: claude | opencode | both (default: claude + auto-detect opencode)'
+    )
     .option('--json', 'Output as JSON')
     .action(
       async (
@@ -35,10 +51,20 @@ export function registerInstallSkillCommand(program: Command): void {
           maxAge?: string;
           list?: boolean;
           remove?: string;
+          for?: string;
           json?: boolean;
         }
       ) => {
         const skillsDir = path.join(os.homedir(), '.claude', 'skills');
+
+        // Validate --for early — surfaces typos before any I/O.
+        if (options.for && !VALID_TARGETS.has(options.for as SyncTarget)) {
+          console.error(
+            `\n❌ Invalid --for value: ${options.for}. Must be one of: claude, opencode, both\n`
+          );
+          process.exit(1);
+        }
+        const targets = resolveTargets(options.for as SyncTarget | undefined);
 
         if (options.list) {
           if (!fs.existsSync(skillsDir)) {
@@ -56,6 +82,9 @@ export function registerInstallSkillCommand(program: Command): void {
             process.exit(0);
           }
 
+          // Cross-reference opencode installs so we can badge dual-installed skills.
+          const opencodeInstalled = new Set(listOpencodeSkills());
+
           console.log(`\n📋 Installed skills (${entries.length}):\n`);
           for (const e of entries) {
             const skillFile = path.join(skillsDir, e.name, 'SKILL.md');
@@ -68,7 +97,8 @@ export function registerInstallSkillCommand(program: Command): void {
               if (descMatch) description = descMatch[1].trim();
             }
 
-            console.log(`  ${e.name}`);
+            const badge = opencodeInstalled.has(e.name) ? ' [claude, opencode]' : ' [claude]';
+            console.log(`  ${e.name}${badge}`);
             if (description) {
               const snippet =
                 description.length > 80 ? `${description.slice(0, 80)}...` : description;
@@ -81,12 +111,23 @@ export function registerInstallSkillCommand(program: Command): void {
 
         if (options.remove) {
           const skillDir = path.join(skillsDir, options.remove);
-          if (!fs.existsSync(skillDir)) {
+          const claudePresent = fs.existsSync(skillDir);
+          const opencodePresent = fs.existsSync(path.join(OPENCODE_SKILLS_DIR, options.remove));
+
+          if (!claudePresent && !opencodePresent) {
             console.error(`\n❌ Skill not found: ${options.remove}\n`);
             process.exit(1);
           }
-          fs.rmSync(skillDir, { recursive: true, force: true });
-          console.log(`\n✅ Removed skill: ${options.remove}\n`);
+
+          if (claudePresent) {
+            fs.rmSync(skillDir, { recursive: true, force: true });
+          }
+          const removedWrapper = removeOpencodeWrapper(options.remove);
+
+          const parts: string[] = [];
+          if (claudePresent) parts.push('claude');
+          if (removedWrapper) parts.push('opencode');
+          console.log(`\n✅ Removed skill: ${options.remove} (${parts.join(', ')})\n`);
           process.exit(0);
         }
 
@@ -152,8 +193,19 @@ export function registerInstallSkillCommand(program: Command): void {
             }
           }
 
-          fs.mkdirSync(skillDir, { recursive: true });
-          fs.writeFileSync(skillFile, content, 'utf8');
+          // Write the primary claude skill. Always true today; the flag exists so
+          // future flows (e.g. opencode-only refreshes via sync-skills) can opt out.
+          if (targets.writeClaude) {
+            fs.mkdirSync(skillDir, { recursive: true });
+            fs.writeFileSync(skillFile, content, 'utf8');
+          }
+
+          // Dual-write the opencode wrapper when requested. YAML-native sources are
+          // skipped because opencode reads them directly from ~/.claude/skills/.
+          let opencodeResult: 'created' | 'updated' | 'unchanged' | 'skipped' | 'off' = 'off';
+          if (targets.writeOpencode) {
+            opencodeResult = writeOpencodeWrapper(skillName, content);
+          }
 
           const fileSize = Buffer.byteLength(content, 'utf8');
           let summary = '';
@@ -181,6 +233,11 @@ export function registerInstallSkillCommand(program: Command): void {
                   fileSize,
                   summary: summary || null,
                   cached: fromCache,
+                  opencode: opencodeResult,
+                  opencodeLocation:
+                    opencodeResult !== 'off' && opencodeResult !== 'skipped'
+                      ? path.join(OPENCODE_SKILLS_DIR, skillName, 'SKILL.md')
+                      : null,
                 },
                 null,
                 2
@@ -196,6 +253,16 @@ export function registerInstallSkillCommand(program: Command): void {
             if (summary) {
               const snippet = summary.length > 80 ? `${summary.slice(0, 80)}...` : summary;
               console.log(`   Summary: ${snippet}`);
+            }
+            if (opencodeResult === 'created' || opencodeResult === 'updated') {
+              console.log(
+                `   opencode: ${opencodeResult} at ${path.join(OPENCODE_SKILLS_DIR, skillName, 'SKILL.md')}`
+              );
+            } else if (opencodeResult === 'unchanged') {
+              console.log('   opencode: unchanged (already in sync)');
+            } else if (opencodeResult === 'skipped') {
+              // Source was YAML-native — opencode reads the claude copy directly.
+              console.log('   opencode: source is YAML — no wrapper needed');
             }
             console.log('');
           }
@@ -223,3 +290,6 @@ export function registerInstallSkillCommand(program: Command): void {
       }
     );
 }
+
+// Re-export for tests / external tools that want the isDossierFrontmatter check.
+export { isDossierFrontmatter };

--- a/cli/src/commands/sync-skills.ts
+++ b/cli/src/commands/sync-skills.ts
@@ -1,0 +1,163 @@
+/**
+ * `ai-dossier sync-skills` — retroactively generate opencode wrappers for
+ * already-installed dossier skills, and prune wrappers whose source is gone.
+ *
+ * Complements install-skill's auto-sync: use this after installing opencode on
+ * a machine that already has dossier skills, or after any manual change to
+ * ~/.claude/skills/.
+ *
+ * Idempotent by design. All writes go through writeOpencodeWrapper, which
+ * no-ops when content matches. See opencode-sync.ts for the wrapper policy.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Command } from 'commander';
+import {
+  CLAUDE_SKILLS_DIR,
+  isDossierFrontmatter,
+  listOpencodeSkills,
+  OPENCODE_CONFIG_DIR,
+  OPENCODE_SKILLS_DIR,
+  opencodeConfigExists,
+  removeOpencodeWrapper,
+  writeOpencodeWrapper,
+} from '../opencode-sync';
+
+interface SyncCounts {
+  created: number;
+  updated: number;
+  unchanged: number;
+  skippedYaml: number;
+  skippedInvalid: number;
+  removed: number;
+}
+
+export function registerSyncSkillsCommand(program: Command): void {
+  program
+    .command('sync-skills')
+    .description('Regenerate opencode YAML wrappers for installed dossier skills (idempotent)')
+    .option('--dry-run', 'Show what would change without writing anything')
+    .option('--no-prune', 'Keep opencode wrappers whose source is gone (default: prune them)')
+    .option('--json', 'Output as JSON')
+    .action(async (options: { dryRun?: boolean; prune?: boolean; json?: boolean }) => {
+      // Default: prune is on. Commander maps --no-prune → prune: false.
+      const prune = options.prune !== false;
+      const dryRun = options.dryRun === true;
+
+      // Refuse to run if opencode isn't installed — sync-skills exists only to
+      // populate ~/.config/opencode/skills/. Fail loud with a fixable message.
+      if (!opencodeConfigExists()) {
+        const msg = `opencode not found (expected ${OPENCODE_CONFIG_DIR}). Install opencode or create the directory first.`;
+        if (options.json) {
+          console.log(JSON.stringify({ success: false, error: 'opencode_missing', message: msg }));
+        } else {
+          console.error(`\n❌ ${msg}\n`);
+        }
+        process.exit(1);
+      }
+
+      if (!fs.existsSync(CLAUDE_SKILLS_DIR)) {
+        const msg = `No claude skills to sync (${CLAUDE_SKILLS_DIR} does not exist).`;
+        if (options.json) {
+          console.log(JSON.stringify({ success: true, message: msg, counts: emptyCounts() }));
+        } else {
+          console.log(`\nℹ️  ${msg}\n`);
+        }
+        process.exit(0);
+      }
+
+      const claudeEntries = fs
+        .readdirSync(CLAUDE_SKILLS_DIR, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .filter((e) => fs.existsSync(path.join(CLAUDE_SKILLS_DIR, e.name, 'SKILL.md')))
+        .map((e) => e.name);
+
+      const counts = emptyCounts();
+      const details: Array<{ skill: string; action: string }> = [];
+      const claudeSet = new Set(claudeEntries);
+
+      // Sync each claude skill forward into opencode.
+      for (const skillName of claudeEntries) {
+        const sourceFile = path.join(CLAUDE_SKILLS_DIR, skillName, 'SKILL.md');
+        let raw: string;
+        try {
+          raw = fs.readFileSync(sourceFile, 'utf8');
+        } catch {
+          counts.skippedInvalid += 1;
+          details.push({ skill: skillName, action: 'skipped-read-error' });
+          continue;
+        }
+
+        if (!isDossierFrontmatter(raw)) {
+          // YAML-native — opencode already reads it directly from ~/.claude/skills/.
+          counts.skippedYaml += 1;
+          details.push({ skill: skillName, action: 'skipped-yaml' });
+          continue;
+        }
+
+        if (dryRun) {
+          // Simulate: compare against existing wrapper if present.
+          const targetFile = path.join(OPENCODE_SKILLS_DIR, skillName, 'SKILL.md');
+          const exists = fs.existsSync(targetFile);
+          details.push({ skill: skillName, action: exists ? 'would-update' : 'would-create' });
+          if (exists) counts.updated += 1;
+          else counts.created += 1;
+          continue;
+        }
+
+        const result = writeOpencodeWrapper(skillName, raw);
+        if (result === 'created') counts.created += 1;
+        else if (result === 'updated') counts.updated += 1;
+        else if (result === 'unchanged') counts.unchanged += 1;
+        else if (result === 'skipped') counts.skippedYaml += 1;
+        details.push({ skill: skillName, action: result });
+      }
+
+      // Prune wrappers whose claude-side source is gone. Users who want to
+      // keep hand-written opencode-only skills should pass --no-prune.
+      if (prune) {
+        const opencodeSkills = listOpencodeSkills();
+        for (const skillName of opencodeSkills) {
+          if (!claudeSet.has(skillName)) {
+            if (dryRun) {
+              details.push({ skill: skillName, action: 'would-remove' });
+              counts.removed += 1;
+            } else if (removeOpencodeWrapper(skillName)) {
+              counts.removed += 1;
+              details.push({ skill: skillName, action: 'removed' });
+            }
+          }
+        }
+      }
+
+      if (options.json) {
+        console.log(JSON.stringify({ success: true, dryRun, prune, counts, details }, null, 2));
+        process.exit(0);
+      }
+
+      const prefix = dryRun ? '🔍 Dry run — no changes written' : '✅ Sync complete';
+      console.log(`\n${prefix}\n`);
+      console.log(`  created:   ${counts.created}`);
+      console.log(`  updated:   ${counts.updated}`);
+      console.log(`  unchanged: ${counts.unchanged}`);
+      console.log(`  skipped:   ${counts.skippedYaml} (YAML source, no wrapper needed)`);
+      if (counts.skippedInvalid > 0) {
+        console.log(`  errors:    ${counts.skippedInvalid} (read failed)`);
+      }
+      console.log(`  removed:   ${counts.removed}${prune ? '' : ' (prune disabled)'}`);
+      console.log('');
+      process.exit(0);
+    });
+}
+
+function emptyCounts(): SyncCounts {
+  return {
+    created: 0,
+    updated: 0,
+    unchanged: 0,
+    skippedYaml: 0,
+    skippedInvalid: 0,
+    removed: 0,
+  };
+}

--- a/cli/src/help.ts
+++ b/cli/src/help.ts
@@ -12,7 +12,7 @@ const CATEGORIES: Array<{ name: string; commands: string[] }> = [
     name: 'Registry',
     commands: ['search', 'list', 'info', 'get', 'pull', 'export', 'publish', 'remove'],
   },
-  { name: 'Skills', commands: ['install-skill', 'skill-export'] },
+  { name: 'Skills', commands: ['install-skill', 'skill-export', 'sync-skills'] },
   { name: 'Security', commands: ['sign', 'checksum', 'keys'] },
   { name: 'Auth & Config', commands: ['login', 'logout', 'whoami', 'config', 'cache', 'doctor'] },
 ];

--- a/cli/src/opencode-sync.ts
+++ b/cli/src/opencode-sync.ts
@@ -1,0 +1,177 @@
+/**
+ * opencode wrapper generation for dossier skills.
+ *
+ * Background: opencode (https://opencode.ai) reads `~/.claude/skills/` but its
+ * frontmatter parser only accepts standard YAML (`---`). Dossier skills use
+ * `---dossier` (JSON) frontmatter for signature + checksum coverage, so opencode
+ * silently skips them. We solve this by writing a slim YAML wrapper to
+ * `~/.config/opencode/skills/<name>/SKILL.md` — same `name`, same body, opencode-native
+ * frontmatter. The signed source in `~/.claude/skills/` is never touched.
+ *
+ * This module owns:
+ *   - target resolution from the `--for` flag (claude / opencode / both)
+ *   - detecting when a source is already YAML (already loadable, no wrapper needed)
+ *   - wrapper generation (with `allowedTools` for delegating skills)
+ *   - idempotent write / remove of wrappers
+ *
+ * See install-skill.ts and sync-skills.ts for the two callers.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { parseDossierContent } from '@ai-dossier/core';
+
+export type SyncTarget = 'claude' | 'opencode' | 'both';
+
+export interface ResolvedTargets {
+  writeClaude: boolean;
+  writeOpencode: boolean;
+}
+
+/** ~/.claude/skills — the primary install location, read by both Claude Code and opencode. */
+export const CLAUDE_SKILLS_DIR = path.join(os.homedir(), '.claude', 'skills');
+
+/** ~/.config/opencode — opencode's config root. Its existence gates auto-wrapping. */
+export const OPENCODE_CONFIG_DIR = path.join(os.homedir(), '.config', 'opencode');
+
+/** ~/.config/opencode/skills — where we write generated YAML wrappers. */
+export const OPENCODE_SKILLS_DIR = path.join(OPENCODE_CONFIG_DIR, 'skills');
+
+/** True when opencode appears installed on this machine (auto-detect trigger). */
+export function opencodeConfigExists(): boolean {
+  return fs.existsSync(OPENCODE_CONFIG_DIR);
+}
+
+/**
+ * Resolve --for flag to concrete write targets.
+ *
+ * - undefined  → claude + auto-detect opencode
+ * - 'claude'   → claude only (even if opencode is present)
+ * - 'opencode' → opencode only (rare; still installs to claude for the source)
+ * - 'both'     → both, regardless of opencode-dir presence
+ */
+export function resolveTargets(forOpt: SyncTarget | undefined): ResolvedTargets {
+  if (forOpt === 'claude') return { writeClaude: true, writeOpencode: false };
+  if (forOpt === 'both') return { writeClaude: true, writeOpencode: true };
+  if (forOpt === 'opencode') return { writeClaude: true, writeOpencode: true };
+  return { writeClaude: true, writeOpencode: opencodeConfigExists() };
+}
+
+/** True if the raw content starts with `---dossier` (needs wrapping for opencode). */
+export function isDossierFrontmatter(content: string): boolean {
+  return content.startsWith('---dossier');
+}
+
+/**
+ * Escape a YAML single-quoted string per YAML 1.2: single quotes double up,
+ * everything else is literal. Descriptions can contain apostrophes and commas.
+ */
+function yamlSingleQuote(s: string): string {
+  return `'${s.replace(/'/g, "''")}'`;
+}
+
+/**
+ * Detect delegating skills — their body invokes `ai-dossier run <name>`.
+ * We emit an `allowedTools` entry so opencode auto-approves that command.
+ */
+function isDelegatingSkill(body: string): boolean {
+  return /\bai-dossier run\s+\S/.test(body);
+}
+
+/**
+ * Build a YAML-wrapped SKILL.md string from a dossier-frontmatter source.
+ *
+ * Returns null if the source is already YAML (opencode reads it fine, no wrapper needed)
+ * or if parsing fails (best-effort, no throw).
+ *
+ * `skillName` is the filesystem directory name — used as a fallback when the JSON
+ * has no `name` field (edge case: scaffold-project).
+ */
+export function buildOpencodeWrapper(rawContent: string, skillName: string): string | null {
+  if (!isDossierFrontmatter(rawContent)) {
+    return null;
+  }
+
+  let parsed: ReturnType<typeof parseDossierContent>;
+  try {
+    parsed = parseDossierContent(rawContent);
+  } catch {
+    return null;
+  }
+
+  const fm = parsed.frontmatter as Record<string, unknown>;
+  const name = (typeof fm.name === 'string' && fm.name) || skillName;
+  const description =
+    (typeof fm.description === 'string' && fm.description) ||
+    (typeof fm.objective === 'string' && fm.objective) ||
+    '';
+
+  const lines: string[] = ['---', `name: ${name}`];
+  if (description) {
+    lines.push(`description: ${yamlSingleQuote(description)}`);
+  }
+  if (isDelegatingSkill(parsed.body)) {
+    lines.push('allowedTools:');
+    lines.push('  - Bash(ai-dossier run *)');
+  }
+  lines.push('---');
+
+  // Ensure exactly one blank line between frontmatter and body, then the body verbatim.
+  const body = parsed.body.replace(/^\s*\n/, '');
+  return `${lines.join('\n')}\n\n${body}`;
+}
+
+/**
+ * Write an opencode wrapper for a skill. Idempotent: no-op when content matches.
+ *
+ * Returns:
+ *   'created'  — new file written
+ *   'updated'  — existing file overwritten with new content
+ *   'unchanged' — file already matched, no write
+ *   'skipped'  — source is YAML-native, opencode reads it directly (no wrapper needed)
+ */
+export type WriteResult = 'created' | 'updated' | 'unchanged' | 'skipped';
+
+export function writeOpencodeWrapper(skillName: string, rawContent: string): WriteResult {
+  const wrapper = buildOpencodeWrapper(rawContent, skillName);
+  if (wrapper === null) return 'skipped';
+
+  const targetDir = path.join(OPENCODE_SKILLS_DIR, skillName);
+  const targetFile = path.join(targetDir, 'SKILL.md');
+
+  if (fs.existsSync(targetFile)) {
+    const current = fs.readFileSync(targetFile, 'utf8');
+    if (current === wrapper) return 'unchanged';
+    fs.writeFileSync(targetFile, wrapper, 'utf8');
+    return 'updated';
+  }
+
+  fs.mkdirSync(targetDir, { recursive: true });
+  fs.writeFileSync(targetFile, wrapper, 'utf8');
+  return 'created';
+}
+
+/**
+ * Remove a skill's opencode wrapper if present. Best-effort: no error when missing.
+ * Returns true if a wrapper was removed.
+ */
+export function removeOpencodeWrapper(skillName: string): boolean {
+  const targetDir = path.join(OPENCODE_SKILLS_DIR, skillName);
+  if (!fs.existsSync(targetDir)) return false;
+  fs.rmSync(targetDir, { recursive: true, force: true });
+  return true;
+}
+
+/**
+ * List skill names currently present in the opencode skills dir.
+ * Used by --list to show a dual-install badge and by sync-skills to prune.
+ */
+export function listOpencodeSkills(): string[] {
+  if (!fs.existsSync(OPENCODE_SKILLS_DIR)) return [];
+  return fs
+    .readdirSync(OPENCODE_SKILLS_DIR, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .filter((e) => fs.existsSync(path.join(OPENCODE_SKILLS_DIR, e.name, 'SKILL.md')))
+    .map((e) => e.name);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3596,6 +3596,8 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3607,6 +3609,8 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3823,6 +3827,8 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3925,6 +3931,8 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3932,6 +3940,8 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3943,7 +3953,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4340,6 +4352,8 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4358,6 +4372,8 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4380,6 +4396,8 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -4483,6 +4501,8 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4521,6 +4541,8 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4530,7 +4552,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4540,9 +4564,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.30",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -4768,7 +4792,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -5054,6 +5080,8 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5340,6 +5368,8 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5568,10 +5598,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -5894,12 +5927,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -5911,11 +5946,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5926,6 +5963,8 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5942,6 +5981,8 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,10 +27,10 @@
     },
     "cli": {
       "name": "@ai-dossier/cli",
-      "version": "0.8.5",
+      "version": "0.8.7",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@ai-dossier/core": "^1.3.5",
+        "@ai-dossier/core": "^1.3.6",
         "commander": "^12.1.0"
       },
       "bin": {
@@ -48,7 +48,7 @@
     },
     "mcp-server": {
       "name": "@ai-dossier/mcp-server",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ai-dossier/core": "^1.2.0",
@@ -6611,7 +6611,7 @@
     },
     "packages/core": {
       "name": "@ai-dossier/core",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.927.0",


### PR DESCRIPTION
## Summary

Makes dossier skills discoverable and triggerable in [opencode](https://opencode.ai), the same way they already work in Claude Code — one command, no manual sync step.

## The problem

opencode reads `~/.claude/skills/` but its frontmatter parser only accepts standard YAML (`---`). Dossier skills use `---dossier` (JSON) frontmatter to carry the checksum and ed25519 signature — so opencode silently skips every dossier-installed skill. Users saying *"full cycle issue 42"* in opencode get nothing.

## The fix

`install-skill` now auto-detects `~/.config/opencode/` and dual-writes a slim YAML wrapper to `~/.config/opencode/skills/<name>/SKILL.md` alongside the primary install. The signed source is **never modified** — the wrapper is a generated artifact.

**Wrapper contents:**
- `name` (from JSON, falling back to directory name — covers `scaffold-project`)
- `description` (single-quoted YAML with proper apostrophe escaping)
- `allowedTools: [Bash(ai-dossier run *)]` only for delegating skills (body invokes `ai-dossier run`) — opencode auto-approves the delegation
- Body copied verbatim

**Skip conditions:**
- YAML-native sources (opencode reads them directly from `~/.claude/skills/`, no wrapper needed) — covers `ccusage`, `sentry-audit`, `latest-screenshot`
- Unparseable sources (best-effort, no throw)

## User-visible changes

| Surface | Change |
|---|---|
| `install-skill` | Adds `--for claude\|opencode\|both` override; auto-writes opencode wrapper when config dir exists |
| `install-skill --list` | Badges each skill with `[claude, opencode]` or `[claude]` |
| `install-skill --remove` | Cleans both locations |
| `sync-skills` (new) | Retroactively regenerates wrappers for existing installs; prunes orphans. `--dry-run`, `--no-prune`, `--json` |

## Tests

- 19 new tests in `opencode-sync.test.ts` (pure logic + fs helpers)
- 8 new tests in `sync-skills.test.ts` (all command paths)
- 8 new cases in `install-skill.test.ts` (auto-detect, `--for` variants, YAML-native skip, dual-remove)
- All 508 CLI tests + 189 monorepo tests pass

## Zero impact on Claude Code

The change is additive. `~/.claude/skills/` is untouched; ed25519 signatures and checksums remain valid; existing Claude Code behavior is unchanged.

## Design notes

Considered a standalone `~/bin/opencode-sync-dossier-skills` script but rejected it for three reasons: (a) users forget manual steps → drift, (b) `--remove` couldn't clean the wrapper, (c) no CI coverage. Keeping the logic inside ai-dossier means one command owns the full skill lifecycle.

The `--for opencode` variant currently still installs to claude too, since installing to opencode without the claude source would break the delegation runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)