### PR TITLE
chore: acknowledge failing Vercel previews rather than chasing them

### DIFF
--- a/.github/workflows/vercel-failure-logs.yml
+++ b/.github/workflows/vercel-failure-logs.yml
@@ -151,6 +151,23 @@ jobs:
                 failureSummary = bits.join('\n');
                 core.info(`deployment failure summary:\n${failureSummary}`);
               }
+
+              // KNOWN CONDITION — preview deploys currently fail account-side with
+              // "Resource provisioning failed" while production deploys succeed. It is
+              // not caused by any PR. Commenting it on every pull request is pure noise
+              // and trains people to ignore this bot, so log it and stay quiet.
+              // Delete this block once previews are provisioning again.
+              const knownPreviewFault =
+                /resource provisioning failed/i.test(meta?.errorMessage ?? '') &&
+                (context.payload.deployment?.environment ?? '').toLowerCase() !== 'production';
+              if (knownPreviewFault) {
+                core.notice(
+                  'Preview deployment failed with the known account-level "Resource provisioning failed" ' +
+                  'condition. Production deploys are unaffected. Not commenting — see CONTRIBUTING.md ' +
+                  '("Known infrastructure issues").'
+                );
+                return;
+              }
             } catch (err) {
               core.warning(`Could not resolve deployment metadata: ${err.message}`);
             }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,13 @@ cd "$(git rev-parse --show-toplevel)/../worktrees/<branch-name>"
 
 **Before any work, verify:** `pwd | grep -q "worktree" || echo "STOP: create a worktree first"`
 
+## Known: Vercel preview checks fail
+
+Every PR shows a failing Vercel check. Account-level `Resource provisioning failed`,
+not caused by any branch — production deploys fine, only previews fail. Do not
+investigate or try to fix it in code. `lint` + `test` are the real gates. See
+CONTRIBUTING.md → "Known Infrastructure Issues".
+
 ## Project Quick Reference
 
 | Directory | Purpose |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,6 +204,28 @@ For significant changes to the protocol, specification, or security model, pleas
 - New example dossiers
 - Minor tool improvements
 
+## Known Infrastructure Issues
+
+### Vercel preview deployments fail — expected, not your PR
+
+Every pull request shows a failing **Vercel** check. This is a known account-level
+condition and **nothing in your branch causes it**. Do not spend time bisecting it.
+
+- **Production is unaffected.** Merges to `main` deploy successfully; only PR previews fail.
+- The build itself succeeds (`readyState: READY`). The deployment then fails with
+  `errorCode: BUILD_FAILED`, `errorMessage: Resource provisioning failed` — Vercel's
+  wording for standing up attached resources, not for compiling.
+- Established by a control PR containing a single README comment and no dependency or
+  code changes, which failed identically.
+
+`lint` and `test` are the checks that gate quality. A red Vercel check alongside green
+`lint`/`test` is the current normal state.
+
+The `Surface Vercel Build Failures` workflow deliberately stays silent on this specific
+condition so it does not comment the same message on every PR. It still reports any
+*other* deployment failure. Remove that suppression in
+`.github/workflows/vercel-failure-logs.yml` once previews provision again.
+
 ## Code Review Process
 
 All submissions require review. We use GitHub pull requests for this purpose.


### PR DESCRIPTION
Preview deployments fail account-side; production deploys succeed. The fix is in the Vercel dashboard, not this repo — so this stops the repo from repeatedly raising it.

## Evidence

```
2026-07-28T08:01:32Z   Production   ✅ success
2026-07-28T07:55:41Z   Preview      ❌ failure
…every Preview back through 06:47   ❌ failure
```

The build reports `readyState: READY`; the deployment then fails with `errorCode: BUILD_FAILED`, `errorMessage: Resource provisioning failed`. A control PR (#416) with one README comment and no dependency or code changes failed identically.

## Changes

**Workflow stays silent on this one condition.** Otherwise it comments the same message on every PR — which is how a useful bot becomes one everyone mutes. Any *other* deployment failure is still reported, so the tool keeps its value.

**Documented in two places** — `CONTRIBUTING.md` for humans, `CLAUDE.md` for agents — stating plainly that a red Vercel check beside green `lint`/`test` is the current normal state, and not to bisect it.

Both carry an explicit removal note so the suppression doesn't quietly become permanent.