### PR TITLE
fix(ci): decrypt the Neon project id when reading it from SSM

### DIFF
--- a/.github/workflows/neon-branch-cleanup.yml
+++ b/.github/workflows/neon-branch-cleanup.yml
@@ -76,7 +76,10 @@ jobs:
           set +e
           KEY=$(aws ssm get-parameter --name "$SSM_API_KEY" --with-decryption \
                   --query 'Parameter.Value' --output text 2>/dev/null)
-          PROJ=$(aws ssm get-parameter --name "$SSM_PROJECT_ID" \
+          # chamber stores every value as a SecureString, so this needs decryption too.
+          # Without it SSM returns the KMS ciphertext, which sails through the empty
+          # check and only fails much later as a confusing 404 from the Neon API.
+          PROJ=$(aws ssm get-parameter --name "$SSM_PROJECT_ID" --with-decryption \
                   --query 'Parameter.Value' --output text 2>/dev/null)
           if [ -z "$KEY" ] || [ "$KEY" = "None" ] || [ -z "$PROJ" ] || [ "$PROJ" = "None" ]; then
             echo "::warning::Could not read Neon credentials from SSM — skipping cleanup."
@@ -144,6 +147,15 @@ jobs:
             // confuse. An org id cannot be used as a project id, so resolve it rather
             // than failing with an opaque 404.
             let projectId = project;
+            // A KMS ciphertext is long, base64-ish and starts with AQIC. Catching it
+            // here gives a message that names the cause, instead of a 404 from Neon.
+            if (/^AQIC/.test(project) || project.length > 120) {
+              core.warning(
+                'NEON_PROJECT_ID looks like a KMS ciphertext rather than a project id — ' +
+                'the SSM read is missing --with-decryption.'
+              );
+              return;
+            }
             if (/^org-/i.test(project)) {
               core.info(`"${project}" looks like an org id; resolving its project(s)…`);
               try {


### PR DESCRIPTION
Found by the first dry run of #421 — which is what dry runs are for.

`chamber` stores every value as a SecureString, but only the API key read passed `--with-decryption`. SSM returned the **KMS ciphertext** for the project id, which is a non-empty string and so passed the empty-value check, then failed much later as an opaque Neon 404:

```
GET /projects/AQICAHitdHOPszWxtiUgY/kxryK4yg554Mgmu…/branches → 404 this route does not exist
```

Two changes:

- add `--with-decryption` to the project id read
- fail early with a message naming the cause when a value still looks like ciphertext (`AQIC` prefix or implausible length), so the next occurrence doesn't need tracing back from a 404

Everything upstream of this now works: OIDC assumption, both SSM reads, and the head-ref resolution (`PR #420, head ref: fix/sign-schedule-and-skill-guard [DRY RUN]`). This is the last step before the branch listing.