### PR TITLE
docs: record the infrastructure failures worth not repeating

### DIFF
--- a/.github/workflows/neon-branch-cleanup.yml
+++ b/.github/workflows/neon-branch-cleanup.yml
@@ -36,8 +36,12 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'Pull request number to clean up'
-        required: true
+        description: 'Pull request number to clean up (leave blank if using head_ref)'
+        required: false
+        type: string
+      head_ref:
+        description: 'Git branch name to clean up directly — for branches that never had a PR, which the close event cannot cover'
+        required: false
         type: string
       dry_run:
         description: 'List what would be deleted without deleting'
@@ -96,6 +100,7 @@ jobs:
           NEON_API_KEY: ${{ steps.creds.outputs.key }}
           NEON_PROJECT_ID: ${{ steps.creds.outputs.project }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          INPUT_HEAD_REF: ${{ inputs.head_ref }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           # Arming is explicit. workflow_dispatch honours its dry_run input; the
           # automatic pull_request path only deletes once the repository variable
@@ -117,7 +122,9 @@ jobs:
             const prNumber = process.env.PR_NUMBER;
 
             // On workflow_dispatch there is no event payload, so resolve the head ref.
-            let headRef = process.env.PR_HEAD_REF;
+            // head_ref is also accepted directly: a push to a branch with no PR still
+            // provisions a Neon branch, and no close event will ever fire for it.
+            let headRef = process.env.PR_HEAD_REF || process.env.INPUT_HEAD_REF;
             if (!headRef && prNumber) {
               const { data: pr } = await github.rest.pulls.get({
                 owner: context.repo.owner, repo: context.repo.repo,
@@ -125,7 +132,10 @@ jobs:
               });
               headRef = pr.head.ref;
             }
-            if (!headRef) { core.warning('Could not determine the PR head ref.'); return; }
+            if (!headRef) {
+              core.warning('Provide either pr_number or head_ref — neither was resolvable.');
+              return;
+            }
             core.info(`PR #${prNumber}, head ref: ${headRef}${dryRun ? '  [DRY RUN]' : ''}`);
             if (dryRun && context.eventName !== 'workflow_dispatch') {
               core.notice(

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,15 @@ cd "$(git rev-parse --show-toplevel)/../worktrees/<branch-name>"
 
 **Before any work, verify:** `pwd | grep -q "worktree" || echo "STOP: create a worktree first"`
 
+## Before debugging infrastructure
+
+Read `docs/explanation/infrastructure-lessons.md` first. It records failures that
+already cost significant time here — silent OIDC trust mismatches, SSM ciphertext
+passing as a value, Vercel preview failures that are actually a Neon branch quota,
+stale CLI versions producing wrong signatures. Several present with symptoms far from
+their cause, and at least three were made worse by reasoning about how something
+"should" work instead of printing the actual value.
+
 ## Project Quick Reference
 
 | Directory | Purpose |

--- a/docs/explanation/README.md
+++ b/docs/explanation/README.md
@@ -42,3 +42,4 @@ Dossier takes a skill and adds what makes it safe to share:
 - [Protocol Reference](../reference/protocol.md) - Technical details
 - [Architecture Overview](../architecture/README.md) - System design
 - [Security Documentation](../../security/) - In-depth security analysis
+- [Infrastructure Lessons](infrastructure-lessons.md) — diagnosed failures worth not repeating: OIDC claims, SSM decryption, Neon quotas, publishing pitfalls

--- a/docs/explanation/infrastructure-lessons.md
+++ b/docs/explanation/infrastructure-lessons.md
@@ -1,0 +1,187 @@
+# Infrastructure Lessons
+
+Findings that cost real time to diagnose, written down so they cost it once.
+
+Each entry follows the same shape: the symptom you will actually see, what it turned
+out to be, and how to check quickly. They are grouped by the thing that misled us,
+because the symptom is rarely near the cause.
+
+---
+
+## Silent failure is the recurring theme
+
+Four separate security mechanisms in this project stopped working without anything
+turning red:
+
+| Mechanism | Broke when | Undetected for |
+|---|---|---|
+| Ed25519 key format | the signer moved from minisign to Node crypto and started emitting SPKI PEM, while the trusted-key list stored raw base64 | ~8 months |
+| Signature coverage | signatures only ever covered the body, leaving `risk_level` and `requires_approval` — the fields gating execution — unauthenticated | since inception |
+| KMS OIDC trust | the repo was renamed `imboard-ai/dossier` → `imboard-ai/ai-dossier` and the IAM trust policy still named the old one | 9 months |
+| Frontmatter mutation | `toSkillFrontmatter` mutated a parse result that is shared for identical input, leaking fields between calls | until a test called it twice |
+
+None of them had a test or a scheduled job that exercised them. `sign.yml` in
+particular was `workflow_dispatch`-only, so its breakage waited nine months for
+somebody to sign something by hand.
+
+**The rule:** a security mechanism that only runs when a human remembers is a
+mechanism you should assume is broken. `sign.yml` now runs weekly for exactly this
+reason — it signs a throwaway artifact and costs nothing, but converts a silent
+credential failure into a red check within days.
+
+---
+
+## GitHub OIDC: print the claim, never infer it
+
+A mismatched IAM trust policy fails with:
+
+```
+Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity
+```
+
+That message names nothing — not the claim presented, not the expected value, not the
+role. We guessed wrong three times against it.
+
+**The subject varies by trigger, in non-obvious ways:**
+
+| Trigger | Subject |
+|---|---|
+| `workflow_dispatch` (from default branch) | `repo:OWNER/REPO:ref:refs/heads/main` |
+| `pull_request` | `repo:OWNER/REPO:pull_request` |
+| `deployment_status` | `repo:OWNER/REPO:ref:` — **note the empty ref** |
+
+The `deployment_status` case is the trap. There is nothing after `ref:`, so no branch
+pattern like `ref:refs/heads/*` can ever match it. It is also identical for every
+deployment in the repo, **including fork pull requests** — so a role trusting that
+claim is reachable from a fork. That is why the Vercel log workflow has its own
+minimal role rather than reusing the one holding the KMS signing key.
+
+**How to check:** run the `Print OIDC Claim` workflow (Actions → Print OIDC Claim). It
+assumes no role and prints `sub`/`aud`/`ref`/`event_name`. Write the trust policy to
+match what it prints.
+
+Two more gotchas:
+
+- `StringEquals` takes one value per key. Multiple allowed subjects need `StringLike`
+  with a list, even when no wildcards are involved.
+- A workflow needs to be on the **default branch** before `workflow_dispatch` will
+  register it. You cannot dry-run a workflow before merging it — which is why anything
+  destructive should ship with an explicit arming flag (see below).
+
+---
+
+## SSM via chamber: everything is a SecureString
+
+`chamber write` stores values encrypted. Reading without `--with-decryption` returns
+the **KMS ciphertext**, not the value:
+
+```bash
+aws ssm get-parameter --name /dossier/thing --with-decryption --query 'Parameter.Value' --output text
+```
+
+The failure mode is nasty because a ciphertext is a perfectly good non-empty string.
+It passes any "did we get a value?" check and fails much later, far from the cause —
+in our case as an opaque `404` from a third-party API several steps downstream.
+
+**Guard for it:** a KMS ciphertext starts with `AQIC` and is long. Checking that at the
+point of use turns a distant 404 into a message naming the real problem.
+
+---
+
+## Neon
+
+### Three identifiers that look alike
+
+The console surfaces an **org id** (`org-…`), a **project name** (`neon-gray-nest`) and
+a **project id** (`hidden-heart-08015346`). Only the project id works against
+`/projects/{id}/branches`; anything else returns a bare `404 project not found` that
+does not say which of the three it wanted.
+
+The cleanup workflow now lists projects and resolves id → name → org id, so any of the
+three works. If you are calling the API by hand, get the project id from Neon Console →
+project → Settings → General.
+
+### Preview deployments failing is usually the branch quota
+
+**Symptom:** every Vercel *preview* deployment fails with
+`errorCode: BUILD_FAILED`, `errorMessage: Resource provisioning failed`, while
+**production deploys succeed**.
+
+That asymmetry is the tell. Production uses the primary branch and provisions nothing;
+each preview tries to create a *new* Neon branch. On the free tier's 10-branch cap,
+once you are at 10/10 every preview fails.
+
+Note the build itself reports `readyState: READY` — nothing is wrong with your code,
+and the `BUILD_FAILED` error code is misleading. Check Neon → Branches before
+suspecting anything in the repo.
+
+### Overriding `DATABASE_URL` does not stop branch creation
+
+Tempting theory: point Preview's `DATABASE_URL` at a shared branch and the integration
+stops provisioning per-PR branches. **Measured, and it does not.**
+
+A preview deployment created a branch anyway — the Neon branch count went 1 → 2 across
+a single comment-only push. Overriding the variable changes what the application
+*connects to*, not what the integration *provisions*.
+
+So the override buys **isolation** (previews not pointed at per-PR databases). It does
+not buy **suppression**, and the cleanup automation remains necessary.
+
+### Branches leak without cleanup
+
+`.github/workflows/neon-branch-cleanup.yml` deletes a PR's branch when the PR closes.
+It is gated on the repository variable `NEON_CLEANUP_ARMED=true`; without it every
+automatic run is a dry run.
+
+Branches created by pushes with **no** open PR are not covered by the close event and
+must be reclaimed with a manual dispatch.
+
+---
+
+## Publishing dossiers
+
+### Use a CLI built from current `main`
+
+`node_modules/.bin/ai-dossier` in a checkout can be an old published version. Signing
+or linting with a pre-0.9.0 CLI silently produces the wrong result: it emits the legacy
+signature format and rejects correctly-signed dossiers against the old schema. An entire
+batch of 14 publishes failed this way before anyone noticed the version.
+
+Check `ai-dossier --version` against `packages/core/package.json` before a bulk
+operation.
+
+### `lint` exit codes
+
+`ai-dossier lint` exits non-zero for **warnings** as well as errors, and a fully clean
+file prints `no issues found` with no error-count line at all. Any script gating on
+lint must handle both output shapes, or it will reject files that are fine.
+
+### The registry index is cached
+
+After `publish` or `remove`, `ai-dossier list` can lag by a few minutes — the index is
+served through a CDN. `ai-dossier info <name>` queries the API directly and is
+authoritative. To force it:
+
+```bash
+curl -s https://purge.jsdelivr.net/gh/imboard-ai/dossier-content@main/index.json
+```
+
+---
+
+## Destructive automation: arm it explicitly
+
+Anything that deletes should ship inert and be armed as a separate, deliberate step.
+
+The Neon cleanup workflow deletes databases, and `workflow_dispatch` does not register
+until a workflow is on the default branch — so it could not be tested before merging.
+Merging an untested deleter is a bad trade; not merging means never testing it. The
+resolution is a repository variable (`NEON_CLEANUP_ARMED`) that gates deletion, so the
+sequence becomes: merge inert → dry-run → read the log → arm.
+
+That gate proved itself immediately: merging the PR closed the PR, which fired the
+workflow on its first real trigger. It deleted nothing.
+
+Alongside that, selection for a destructive operation should be conservative by
+construction — exclude primary/protected items structurally, keep an explicit deny
+list, require a positive match against the specific thing being cleaned up, and log
+anything unclassifiable instead of acting on it.


### PR DESCRIPTION
Several problems in this repo cost hours and would have cost minutes with a note. They share a shape: **the symptom appears far from the cause, and the error message names nothing useful.**

`docs/explanation/infrastructure-lessons.md` records them as symptom → cause → how to check.

## What's in it

**Silent failure is the theme.** Four security mechanisms broke without anything turning red — Ed25519 key format (~8 months), signature coverage (since inception), KMS OIDC trust after the repo rename (9 months), and a frontmatter mutation bug. None had a test or scheduled run exercising them. `sign.yml` now runs weekly for exactly that reason.

**OIDC: print the claim, never infer it.** The subject varies by trigger, and `deployment_status` emits an **empty ref** (`repo:owner/name:ref:`) that no branch pattern can match — and which is identical for fork PRs, so a role trusting it is fork-reachable. We guessed wrong three times against an error naming nothing. `Print OIDC Claim` exists to end that.

**SSM/chamber:** everything is a SecureString. Without `--with-decryption` you get a ciphertext, which passes every non-empty check and fails far downstream.

**Neon:** three lookalike identifiers (org id / project name / project id) behind one unhelpful 404; preview-only failures are a branch quota, not your code; and — **measured, contradicting what I'd assumed and repeated** — overriding Preview `DATABASE_URL` does *not* stop branch provisioning. Branch count went 1 → 2 across a single comment-only push. The cleanup workflow is necessary, not a workaround.

**Publishing:** a stale `node_modules` CLI signs with the legacy format and rejects valid dossiers; `lint` exits non-zero on warnings and prints two different clean-output shapes; the registry index is CDN-cached, so `info` is authoritative, not `list`.

**Destructive automation should ship inert and be armed separately** — with the reasoning, since `workflow_dispatch` won't register until a workflow is on the default branch, making "test before merge" impossible.

## Also in this PR

A `head_ref` input for the Neon cleanup workflow. A push to a branch with **no PR** still provisions a Neon branch, and no close event ever fires for it — those orphans had no reclaim path. Found while cleaning up the probe branch from the provisioning test.

`CLAUDE.md` points at the doc, since agents read it first and were among those repeating the mistakes.