### PR TITLE
fix(cli): declare yaml as an explicit dependency

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -54,7 +54,8 @@
   },
   "dependencies": {
     "@ai-dossier/core": "^1.4.0",
-    "commander": "^12.1.0"
+    "commander": "^12.1.0",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/node": "^24.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2508,13 +2508,13 @@
       }
     },
     "node_modules/@vercel/build-utils": {
-      "version": "13.35.0",
-      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.35.0.tgz",
-      "integrity": "sha512-UQmy2Ht1S3Evz7V9IfA1MyK452gjfPwZRnjGVRV/iVrB9MSCg4tMKmXTVYIarRMuUPbBmnJpoJ1mXPI/pHkJvg==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-14.0.3.tgz",
+      "integrity": "sha512-yfK9NmS/P9p7Sk5XebxwpIqIUQCj2qRdHMmlZ+r4mp45Xy4jJeLoCN5TsyZc3yUN7wJmJHcRYdTy421pCMA2PQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/python-analysis": "0.11.1",
+        "@vercel/python-analysis": "0.13.1",
         "cjs-module-lexer": "1.2.3",
         "es-module-lexer": "1.5.0"
       }
@@ -2527,9 +2527,9 @@
       "license": "MIT"
     },
     "node_modules/@vercel/error-utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@vercel/error-utils/-/error-utils-2.2.0.tgz",
-      "integrity": "sha512-WFWiRxfPzoYWYifaj4thSKvAaZZwUOqD4k5GINRIgZgCiS2E3iAJbWbIsIZmkQdTecWFHcWGA6q48CjisgpOBA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@vercel/error-utils/-/error-utils-2.2.1.tgz",
+      "integrity": "sha512-9DhP8jP7raLML4hGsBemxX5fXuQnu5xxMV+HjGygGbzEmVK/+KyJ3QP2Cw7PdF0uXdb9N0Qa4c3tRGH34ZX6vw==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -2568,9 +2568,9 @@
       "license": "MIT"
     },
     "node_modules/@vercel/node": {
-      "version": "5.8.27",
-      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.8.27.tgz",
-      "integrity": "sha512-Nsly5g2N70nkBKzXgTLUtjI2wwF0wHSzt6kzFMW2my1ZuYNEexWtIbvS0cV5ykBLSo5XUhhen6EWYM81oRvxdw==",
+      "version": "5.9.7",
+      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.9.7.tgz",
+      "integrity": "sha512-ekJSoPjuoeyCSsFm5Z7LEsFQoBXHCoBT4UMISjWIP5jLNKKTWxTSyTpwceLbPmBbc5q88iwMjhkIRRQWMm8LBQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2578,10 +2578,10 @@
         "@edge-runtime/primitives": "4.1.0",
         "@edge-runtime/vm": "3.2.0",
         "@types/node": "20.11.0",
-        "@vercel/build-utils": "13.35.0",
-        "@vercel/error-utils": "2.2.0",
+        "@vercel/build-utils": "14.0.3",
+        "@vercel/error-utils": "2.2.1",
         "@vercel/nft": "1.10.0",
-        "@vercel/static-config": "3.4.0",
+        "@vercel/static-config": "3.4.1",
         "async-listen": "3.0.0",
         "cjs-module-lexer": "1.2.3",
         "edge-runtime": "2.5.9",
@@ -3137,9 +3137,9 @@
       "license": "MIT"
     },
     "node_modules/@vercel/python-analysis": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@vercel/python-analysis/-/python-analysis-0.11.1.tgz",
-      "integrity": "sha512-EPPLuXJQhIDUx08H9nG76AR2HSgBquwe3OAX5s2w20M923iaWeGGVkhX/4yZ89CJfXEZgE1Aj/mX7lVHOVIcYA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@vercel/python-analysis/-/python-analysis-0.13.1.tgz",
+      "integrity": "sha512-ec4tii9I7i6eHfvsvG/eaNaKh0TxmxBsc904V7yjwZImeyFTEVvDSLQ/+510FB+wBG6gCvpyqBH5aAKP9llqsw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3183,9 +3183,9 @@
       }
     },
     "node_modules/@vercel/static-config": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@vercel/static-config/-/static-config-3.4.0.tgz",
-      "integrity": "sha512-wCq90CMUB//ggnFh77NQO1xaLFsS4LigQIqKrH6ohnr9Br/KI1FhlErx62WfCOuueWaW+LVsbLOqNXIUjK8t6A==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@vercel/static-config/-/static-config-3.4.1.tgz",
+      "integrity": "sha512-kJKTyOg25JDRgDkHEkc+vWlvURxmSQkVKyRPO4EEGD/8HpJT+4u9Z/VGxwnCZ6zZBxYPpma283qBsHwY0gXjfw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3578,9 +3578,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4489,9 +4489,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4812,9 +4812,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -5282,9 +5282,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ai-dossier/core": "^1.4.0",
-        "commander": "^12.1.0"
+        "commander": "^12.1.0",
+        "yaml": "^2.8.3"
       },
       "bin": {
         "ai-dossier": "bin/ai-dossier"
@@ -6664,7 +6665,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"


### PR DESCRIPTION
## Summary
- `cli/src/skill-frontmatter.ts` imports `yaml`, but `cli/package.json` never declared it as a dependency — it only worked in-repo because `yaml` is hoisted to the workspace root from another package.
- This has been silently breaking the `publish-packages.yml` smoke job (`Error: Cannot find module 'yaml'`) on every push to `main` since `c0cb6a2` (2026-07-28), which meant `publish` never ran and several merged CLI fixes — including the `install-skill` dossier-identity collision fix (`cde5c53`) — never actually reached npm, even though `npm view @ai-dossier/cli version` still reported `0.9.0` as current.
- Root cause was found while investigating a user report: `install-skill --for opencode <skill>` blocked with "already installed" even though the fix for that exact bug already landed on `main`.

## Test plan
- [x] `make build-all`
- [x] `make test` (all workspaces, 0 failures)
- [x] Reproduced the CI smoke test locally: `npm pack` for `core`+`cli`, installed into an isolated fixture project, ran `ai-dossier --version` and `install-skill --help` — confirmed `Cannot find module 'yaml'` is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfNrxpiVQEjLtYeAkvZgro